### PR TITLE
Add Irodori-TTS V2 model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ OPENAI_MODEL_ID = ""  #@param {type:"string"}
 
 #@markdown ---
 #@markdown Irodori-TTS
-IRODORI_HF_CHECKPOINT = "Aratako/Irodori-TTS-500M"  #@param {type:"string"}
+# V1を利用する場合: checkpoint="Aratako/Irodori-TTS-500M", codec_repo="facebook/dacvae-watermarked"
+IRODORI_HF_CHECKPOINT = "Aratako/Irodori-TTS-500M-v2"  #@param {type:"string"}
+IRODORI_CODEC_REPO = "Aratako/Semantic-DACVAE-Japanese-32dim"  #@param {type:"string"}
 IRODORI_MODEL_PRECISION = "fp32"  #@param ["fp32", "bf16", "fp16"]
 IRODORI_CODEC_PRECISION = "fp32"  #@param ["fp32", "bf16", "fp16"]
 
@@ -241,7 +243,7 @@ main()
 
 ### Irodori-TTS
 
-[Aratako/Irodori-TTS](https://github.com/Aratako/Irodori-TTS) を使った日本語 TTS です。デフォルトで Hugging Face の `Aratako/Irodori-TTS-500M` モデルを使用します。出力は 48kHz で高音質ですが、voice の切り替え機能はありません。
+[Aratako/Irodori-TTS](https://github.com/Aratako/Irodori-TTS) を使った日本語 TTS です。デフォルトで Hugging Face の `Aratako/Irodori-TTS-500M-v2` モデルを使用します（V1 を利用する場合は `Aratako/Irodori-TTS-500M` に変更してください）。出力は 48kHz で高音質ですが、voice の切り替え機能はありません。
 
 ### Piper
 

--- a/colab/bootstrap.py
+++ b/colab/bootstrap.py
@@ -24,7 +24,10 @@ def parse_args():
     parser.add_argument("--test-speed", type=float, default=1.0)
     parser.add_argument("--test-voice", default="")
     parser.add_argument("--openai-model-id", default="")
-    parser.add_argument("--irodori-hf-checkpoint", default="Aratako/Irodori-TTS-500M")
+    # V1を利用する場合: "Aratako/Irodori-TTS-500M"
+    parser.add_argument("--irodori-hf-checkpoint", default="Aratako/Irodori-TTS-500M-v2")
+    # V1を利用する場合: "facebook/dacvae-watermarked"
+    parser.add_argument("--irodori-codec-repo", default="Aratako/Semantic-DACVAE-Japanese-32dim")
     parser.add_argument("--irodori-model-precision", default="fp32")
     parser.add_argument("--irodori-codec-precision", default="fp32")
     parser.add_argument("--kokoro-default-voice", default="jf_alpha")
@@ -57,6 +60,7 @@ def main():
         test_voice=args.test_voice,
         openai_model_id=args.openai_model_id,
         irodori_hf_checkpoint=args.irodori_hf_checkpoint,
+        irodori_codec_repo=args.irodori_codec_repo,
         irodori_model_precision=args.irodori_model_precision,
         irodori_codec_precision=args.irodori_codec_precision,
         kokoro_default_voice=args.kokoro_default_voice,

--- a/multi_tts_openai_colab.py
+++ b/multi_tts_openai_colab.py
@@ -20,7 +20,9 @@ OPENAI_MODEL_ID = ""  #@param {type:"string"}
 
 #@markdown ---
 #@markdown Irodori-TTS
-IRODORI_HF_CHECKPOINT = "Aratako/Irodori-TTS-500M"  #@param {type:"string"}
+# V1を利用する場合: checkpoint="Aratako/Irodori-TTS-500M", codec_repo="facebook/dacvae-watermarked"
+IRODORI_HF_CHECKPOINT = "Aratako/Irodori-TTS-500M-v2"  #@param {type:"string"}
+IRODORI_CODEC_REPO = "Aratako/Semantic-DACVAE-Japanese-32dim"  #@param {type:"string"}
 IRODORI_MODEL_PRECISION = "fp32"  #@param ["fp32", "bf16", "fp16"]
 IRODORI_CODEC_PRECISION = "fp32"  #@param ["fp32", "bf16", "fp16"]
 
@@ -105,6 +107,8 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         OPENAI_MODEL_ID,
         "--irodori-hf-checkpoint",
         IRODORI_HF_CHECKPOINT,
+        "--irodori-codec-repo",
+        IRODORI_CODEC_REPO,
         "--irodori-model-precision",
         IRODORI_MODEL_PRECISION,
         "--irodori-codec-precision",

--- a/src/apps/irodori_app.py
+++ b/src/apps/irodori_app.py
@@ -22,12 +22,13 @@ from irodori_tts.inference_runtime import (
 
 logger = logging.getLogger("uvicorn.error")
 
-HF_CHECKPOINT = os.environ.get("IRODORI_HF_CHECKPOINT", "Aratako/Irodori-TTS-500M")
+# V1を利用する場合: checkpoint="Aratako/Irodori-TTS-500M", codec_repo="facebook/dacvae-watermarked"
+HF_CHECKPOINT = os.environ.get("IRODORI_HF_CHECKPOINT", "Aratako/Irodori-TTS-500M-v2")
 MODEL_DEVICE = os.environ.get("IRODORI_MODEL_DEVICE", default_runtime_device())
 CODEC_DEVICE = os.environ.get("IRODORI_CODEC_DEVICE", default_runtime_device())
 MODEL_PRECISION = os.environ.get("IRODORI_MODEL_PRECISION", "fp32")
 CODEC_PRECISION = os.environ.get("IRODORI_CODEC_PRECISION", "fp32")
-CODEC_REPO = os.environ.get("IRODORI_CODEC_REPO", "facebook/dacvae-watermarked")
+CODEC_REPO = os.environ.get("IRODORI_CODEC_REPO", "Aratako/Semantic-DACVAE-Japanese-32dim")
 OPENAI_MODEL_ID = os.environ.get("OPENAI_MODEL_ID", HF_CHECKPOINT)
 
 app = FastAPI(title="Irodori OpenAI Compatible TTS")

--- a/src/config.py
+++ b/src/config.py
@@ -43,7 +43,10 @@ class Settings:
     test_speed: float = 1.0
     test_voice: str = ""
     openai_model_id: str = ""
-    irodori_hf_checkpoint: str = "Aratako/Irodori-TTS-500M"
+    # V1を利用する場合: "Aratako/Irodori-TTS-500M"
+    irodori_hf_checkpoint: str = "Aratako/Irodori-TTS-500M-v2"
+    # V1を利用する場合: "facebook/dacvae-watermarked"
+    irodori_codec_repo: str = "Aratako/Semantic-DACVAE-Japanese-32dim"
     irodori_model_precision: str = "fp32"
     irodori_codec_precision: str = "fp32"
     kokoro_default_voice: str = "jf_alpha"

--- a/src/installers/irodori.py
+++ b/src/installers/irodori.py
@@ -26,6 +26,7 @@ def install(settings: Settings) -> dict:
         **os.environ,
         "PYTHONUNBUFFERED": "1",
         "IRODORI_HF_CHECKPOINT": settings.irodori_hf_checkpoint,
+        "IRODORI_CODEC_REPO": settings.irodori_codec_repo,
         "IRODORI_MODEL_PRECISION": settings.irodori_model_precision,
         "IRODORI_CODEC_PRECISION": settings.irodori_codec_precision,
         "OPENAI_MODEL_ID": settings.openai_model_id or settings.irodori_hf_checkpoint,


### PR DESCRIPTION
## Summary
- Change default Irodori-TTS model to V2 (`Aratako/Irodori-TTS-500M-v2`)
- Add `irodori_codec_repo` parameter to specify the codec required by V2 (`Aratako/Semantic-DACVAE-Japanese-32dim`)
- V1 users can switch back by changing the checkpoint and codec_repo values as noted in comments

## Changed files
- `multi_tts_openai_colab.py` — Add `IRODORI_CODEC_REPO` parameter, default to V2
- `src/config.py` — Add `irodori_codec_repo` field
- `colab/bootstrap.py` — Add `--irodori-codec-repo` argument
- `src/installers/irodori.py` — Pass `IRODORI_CODEC_REPO` environment variable
- `src/apps/irodori_app.py` — Update `CODEC_REPO` default to V2 codec
- `README.md` — Update documentation for V2 model and codec

## Test plan
- [x] Launched Irodori-TTS V2 on Google Colab using the feature branch
- [x] `GET /` returns `"model": "Aratako/Irodori-TTS-500M-v2"`
- [x] `GET /v1/models` correctly lists the V2 model
- [x] `POST /v1/audio/speech` returns HTTP 200 with valid WAV (48kHz mono 16bit, ~530KB)
- [x] Verified end-to-end connectivity via cloudflared external URL using local curl

🤖 Generated with [Claude Code](https://claude.com/claude-code)