### PR TITLE
Add Voxtral-TTS engine support

### DIFF
--- a/colab/bootstrap.py
+++ b/colab/bootstrap.py
@@ -45,6 +45,9 @@ def parse_args():
     parser.add_argument("--qwen3-hf-model", default="Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice")
     parser.add_argument("--qwen3-language", default="Japanese")
     parser.add_argument("--qwen3-default-speaker", default="ono_anna")
+    parser.add_argument("--voxtral-hf-model", default="mistralai/Voxtral-4B-TTS-2603")
+    parser.add_argument("--voxtral-default-voice", default="jessica")
+    parser.add_argument("--voxtral-backend-port", type=int, default=5001)
     parser.add_argument("--root-dir", default="/content/openai-compatible-local-tts")
     return parser.parse_args()
 
@@ -78,6 +81,9 @@ def main():
         qwen3_hf_model=args.qwen3_hf_model,
         qwen3_language=args.qwen3_language,
         qwen3_default_speaker=args.qwen3_default_speaker,
+        voxtral_hf_model=args.voxtral_hf_model,
+        voxtral_default_voice=args.voxtral_default_voice,
+        voxtral_backend_port=args.voxtral_backend_port,
         root_dir=Path(args.root_dir),
         repo_dir=REPO_DIR,
     )

--- a/colab/bootstrap.py
+++ b/colab/bootstrap.py
@@ -46,7 +46,7 @@ def parse_args():
     parser.add_argument("--qwen3-language", default="Japanese")
     parser.add_argument("--qwen3-default-speaker", default="ono_anna")
     parser.add_argument("--voxtral-hf-model", default="mistralai/Voxtral-4B-TTS-2603")
-    parser.add_argument("--voxtral-default-voice", default="jessica")
+    parser.add_argument("--voxtral-default-voice", default="neutral_female")
     parser.add_argument("--voxtral-backend-port", type=int, default=5001)
     parser.add_argument("--root-dir", default="/content/openai-compatible-local-tts")
     return parser.parse_args()

--- a/src/apps/voxtral_app.py
+++ b/src/apps/voxtral_app.py
@@ -14,13 +14,14 @@ logger = logging.getLogger("uvicorn.error")
 VLLM_BACKEND_URL = os.environ.get("VLLM_BACKEND_URL", "http://127.0.0.1:5001")
 OPENAI_MODEL_ID = os.environ.get("OPENAI_MODEL_ID", "voxtral-tts")
 VOXTRAL_HF_MODEL = os.environ.get("VOXTRAL_HF_MODEL", "mistralai/Voxtral-4B-TTS-2603")
-VOXTRAL_DEFAULT_VOICE = os.environ.get("VOXTRAL_DEFAULT_VOICE", "jessica")
+VOXTRAL_DEFAULT_VOICE = os.environ.get("VOXTRAL_DEFAULT_VOICE", "neutral_female")
 
 VOICES = [
-    "allison", "aoede", "chloe", "coral", "echo",
-    "fable", "jessica", "lucy", "maisie", "nova",
-    "onyx", "orbit", "quinn", "river", "sarah",
-    "shimmer", "stella", "vale", "victoria", "zephyr",
+    "ar_male", "casual_female", "casual_male", "cheerful_female",
+    "de_female", "de_male", "es_female", "es_male",
+    "fr_female", "fr_male", "hi_female", "hi_male",
+    "it_female", "it_male", "neutral_female", "neutral_male",
+    "nl_female", "nl_male", "pt_female", "pt_male",
 ]
 
 SUPPORTED_FORMATS = ["wav", "pcm", "flac", "mp3", "aac", "opus"]

--- a/src/apps/voxtral_app.py
+++ b/src/apps/voxtral_app.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import logging
+import os
+
+import httpx
+from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+logger = logging.getLogger("uvicorn.error")
+
+VLLM_BACKEND_URL = os.environ.get("VLLM_BACKEND_URL", "http://127.0.0.1:5001")
+OPENAI_MODEL_ID = os.environ.get("OPENAI_MODEL_ID", "voxtral-tts")
+VOXTRAL_HF_MODEL = os.environ.get("VOXTRAL_HF_MODEL", "mistralai/Voxtral-4B-TTS-2603")
+VOXTRAL_DEFAULT_VOICE = os.environ.get("VOXTRAL_DEFAULT_VOICE", "jessica")
+
+VOICES = [
+    "allison", "aoede", "chloe", "coral", "echo",
+    "fable", "jessica", "lucy", "maisie", "nova",
+    "onyx", "orbit", "quinn", "river", "sarah",
+    "shimmer", "stella", "vale", "victoria", "zephyr",
+]
+
+SUPPORTED_FORMATS = ["wav", "pcm", "flac", "mp3", "aac", "opus"]
+
+MEDIA_TYPES = {
+    "wav": "audio/wav",
+    "pcm": "audio/pcm",
+    "flac": "audio/flac",
+    "mp3": "audio/mpeg",
+    "aac": "audio/aac",
+    "opus": "audio/opus",
+}
+
+app = FastAPI(title="Voxtral-TTS OpenAI Compatible TTS")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[],
+    allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
+    allow_credentials=False,
+    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_headers=["*"],
+    expose_headers=["x-openai-model", "x-openai-voice"],
+)
+
+
+class AudioSpeechRequest(BaseModel):
+    model: str = OPENAI_MODEL_ID
+    input: str
+    voice: str | None = None
+    response_format: str = "wav"
+    speed: float = 1.0
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, exc: Exception):
+    logger.exception("Unhandled exception while serving request")
+    return JSONResponse(
+        status_code=500,
+        content={"error": type(exc).__name__, "detail": str(exc)},
+    )
+
+
+@app.get("/")
+def root():
+    return {"ok": True, "engine": "Voxtral-TTS", "model": OPENAI_MODEL_ID, "backend": VLLM_BACKEND_URL}
+
+
+@app.get("/v1/models")
+def list_models():
+    return {
+        "object": "list",
+        "data": [{"id": OPENAI_MODEL_ID, "object": "model", "owned_by": "local"}],
+    }
+
+
+@app.get("/v1/voices")
+def list_voices():
+    return {
+        "object": "list",
+        "data": [{"id": v, "object": "voice"} for v in VOICES],
+    }
+
+
+@app.post("/v1/audio/speech")
+async def audio_speech(payload: AudioSpeechRequest):
+    fmt = payload.response_format.lower()
+    if fmt not in SUPPORTED_FORMATS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported format: {fmt}. Supported: {SUPPORTED_FORMATS}",
+        )
+
+    voice = payload.voice or VOXTRAL_DEFAULT_VOICE
+    if voice not in VOICES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown voice: {voice}. Available: {VOICES}",
+        )
+
+    backend_payload = {
+        "model": VOXTRAL_HF_MODEL,
+        "input": payload.input,
+        "voice": voice,
+        "response_format": fmt,
+        "speed": payload.speed,
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=300) as client:
+            resp = await client.post(
+                f"{VLLM_BACKEND_URL}/v1/audio/speech",
+                json=backend_payload,
+            )
+            resp.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        detail = exc.response.text if exc.response else str(exc)
+        raise HTTPException(status_code=502, detail=f"vLLM backend error: {detail}")
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=f"Failed to reach vLLM backend: {exc}")
+
+    return Response(
+        content=resp.content,
+        media_type=MEDIA_TYPES.get(fmt, "audio/wav"),
+        headers={
+            "Content-Length": str(len(resp.content)),
+            "x-openai-model": payload.model,
+            "x-openai-voice": voice,
+        },
+    )

--- a/src/config.py
+++ b/src/config.py
@@ -65,7 +65,7 @@ class Settings:
     qwen3_language: str = "Japanese"
     qwen3_default_speaker: str = "ono_anna"
     voxtral_hf_model: str = "mistralai/Voxtral-4B-TTS-2603"
-    voxtral_default_voice: str = "jessica"
+    voxtral_default_voice: str = "neutral_female"
     voxtral_backend_port: int = 5001
     root_dir: Path = Path("/content/openai-compatible-local-tts")
     repo_dir: Path = field(default_factory=default_repo_dir)

--- a/src/config.py
+++ b/src/config.py
@@ -64,6 +64,9 @@ class Settings:
     qwen3_hf_model: str = "Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice"
     qwen3_language: str = "Japanese"
     qwen3_default_speaker: str = "ono_anna"
+    voxtral_hf_model: str = "mistralai/Voxtral-4B-TTS-2603"
+    voxtral_default_voice: str = "jessica"
+    voxtral_backend_port: int = 5001
     root_dir: Path = Path("/content/openai-compatible-local-tts")
     repo_dir: Path = field(default_factory=default_repo_dir)
     app_port: int = 8000

--- a/src/installers/__init__.py
+++ b/src/installers/__init__.py
@@ -5,6 +5,7 @@ from .melo import install as install_melo
 from .piper import install as install_piper
 from .piper_plus import install as install_piper_plus
 from .style_bert import install as install_style_bert
+from .voxtral import install as install_voxtral
 
 
 INSTALLERS = {
@@ -15,4 +16,5 @@ INSTALLERS = {
     "Piper": install_piper,
     "Piper-Plus": install_piper_plus,
     "Qwen3-TTS": install_qwen3_tts,
+    "Voxtral-TTS": install_voxtral,
 }

--- a/src/installers/voxtral.py
+++ b/src/installers/voxtral.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import os
+
+from src.config import Settings
+from src.runtime import ensure_venv, popen, tail_log, uv_pip_install, wait_http, write_text
+
+
+def install(settings: Settings) -> dict:
+    engine_dir = settings.engines_dir / "voxtral-openai"
+    engine_dir.mkdir(parents=True, exist_ok=True)
+    python_bin = ensure_venv(engine_dir)
+    uv_pip_install(
+        python_bin,
+        [
+            "fastapi",
+            "uvicorn",
+            "httpx",
+            "vllm>=0.18.0",
+            "vllm-omni @ git+https://github.com/vllm-project/vllm-omni.git",
+        ],
+    )
+    # Start vLLM backend server
+    backend_env = {
+        **os.environ,
+        "PYTHONUNBUFFERED": "1",
+    }
+    backend_proc = popen(
+        [
+            str(engine_dir / ".venv" / "bin" / "vllm"),
+            "serve",
+            settings.voxtral_hf_model,
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(settings.voxtral_backend_port),
+        ],
+        cwd=str(engine_dir),
+        env=backend_env,
+        log_path=settings.log_dir / "voxtral-backend.log",
+    )
+    # Wait for vLLM backend to be ready (model loading can take a while)
+    if not wait_http(f"http://127.0.0.1:{settings.voxtral_backend_port}/v1/models", timeout=600):
+        tail_log(settings.log_dir / "voxtral-backend.log")
+        raise RuntimeError("Voxtral vLLM backend did not become ready.")
+    # Deploy OpenAI-compatible proxy
+    write_text(engine_dir / "app.py", settings.read_repo_text("src/apps/voxtral_app.py"))
+    env = {
+        **os.environ,
+        "PYTHONUNBUFFERED": "1",
+        "OPENAI_MODEL_ID": settings.openai_model_id or "voxtral-tts",
+        "VLLM_BACKEND_URL": f"http://127.0.0.1:{settings.voxtral_backend_port}",
+        "VOXTRAL_HF_MODEL": settings.voxtral_hf_model,
+        "VOXTRAL_DEFAULT_VOICE": settings.voxtral_default_voice,
+    }
+    proc = popen(
+        [
+            str(engine_dir / ".venv" / "bin" / "uvicorn"),
+            "app:app",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            str(settings.app_port),
+            "--log-level",
+            "info",
+        ],
+        cwd=str(engine_dir),
+        env=env,
+        log_path=settings.log_dir / "voxtral-proxy-uvicorn.log",
+    )
+    return {
+        "proc": proc,
+        "backend_proc": backend_proc,
+        "app_dir": engine_dir,
+        "log_path": settings.log_dir / "voxtral-proxy-uvicorn.log",
+        "backend_log_path": settings.log_dir / "voxtral-backend.log",
+    }

--- a/src/installers/voxtral.py
+++ b/src/installers/voxtral.py
@@ -82,7 +82,7 @@ def install(settings: Settings) -> dict:
         "OPENAI_MODEL_ID": settings.openai_model_id or "voxtral-tts",
         "VLLM_BACKEND_URL": f"http://127.0.0.1:{settings.voxtral_backend_port}",
         "VOXTRAL_HF_MODEL": settings.voxtral_hf_model,
-        "VOXTRAL_DEFAULT_VOICE": settings.voxtral_default_voice,
+        "VOXTRAL_DEFAULT_VOICE": settings.voxtral_default_voice or "neutral_female",
     }
     proc = popen(
         [

--- a/src/installers/voxtral.py
+++ b/src/installers/voxtral.py
@@ -3,24 +3,50 @@ from __future__ import annotations
 import os
 
 from src.config import Settings
-from src.runtime import ensure_venv, popen, tail_log, uv_pip_install, wait_http, write_text
+from src.runtime import ensure_venv, popen, run, tail_log, uv_pip_install, wait_http, write_text
+
+
+def _find_stage_configs(engine_dir):
+    """Locate voxtral_tts.yaml inside the vllm_omni package."""
+    python_bin = str(engine_dir / ".venv" / "bin" / "python")
+    result = run(
+        [
+            python_bin,
+            "-c",
+            (
+                "import vllm_omni, pathlib; "
+                "p = pathlib.Path(vllm_omni.__path__[0]) / 'model_executor' / 'stage_configs' / 'voxtral_tts.yaml'; "
+                "print(p)"
+            ),
+        ],
+        capture_output=True,
+    )
+    return result.stdout.strip()
 
 
 def install(settings: Settings) -> dict:
     engine_dir = settings.engines_dir / "voxtral-openai"
     engine_dir.mkdir(parents=True, exist_ok=True)
     python_bin = ensure_venv(engine_dir)
+    # Install vllm first, then vllm-omni (which extends/shadows vllm CLI)
     uv_pip_install(
         python_bin,
         [
             "fastapi",
             "uvicorn",
             "httpx",
-            "vllm>=0.18.0",
+            "vllm==0.18.0",
+        ],
+    )
+    uv_pip_install(
+        python_bin,
+        [
             "vllm-omni @ git+https://github.com/vllm-project/vllm-omni.git",
         ],
     )
-    # Start vLLM backend server
+    # Find the stage config YAML path inside vllm_omni package
+    stage_configs_path = _find_stage_configs(engine_dir)
+    # Start vllm-omni backend server with --omni flag
     backend_env = {
         **os.environ,
         "PYTHONUNBUFFERED": "1",
@@ -30,10 +56,15 @@ def install(settings: Settings) -> dict:
             str(engine_dir / ".venv" / "bin" / "vllm"),
             "serve",
             settings.voxtral_hf_model,
+            "--omni",
+            "--stage-configs-path",
+            stage_configs_path,
             "--host",
             "127.0.0.1",
             "--port",
             str(settings.voxtral_backend_port),
+            "--trust-remote-code",
+            "--enforce-eager",
         ],
         cwd=str(engine_dir),
         env=backend_env,

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -58,8 +58,9 @@ def print_engine_voice_hints(settings: Settings):
         print("Voxtral-TTS は Mistral AI の高品質 TTS です（vLLM バックエンド）。")
         print(f"モデル: {settings.voxtral_hf_model}")
         print(f"デフォルト voice: {settings.voxtral_default_voice}")
-        print("候補: allison, aoede, chloe, coral, echo, fable, jessica, lucy, maisie, nova,")
-        print("      onyx, orbit, quinn, river, sarah, shimmer, stella, vale, victoria, zephyr")
+        print("候補: ar_male, casual_female, casual_male, cheerful_female, de_female, de_male,")
+        print("      es_female, es_male, fr_female, fr_male, hi_female, hi_male, it_female,")
+        print("      it_male, neutral_female, neutral_male, nl_female, nl_male, pt_female, pt_male")
         print("対応言語: en, fr, es, pt, it, nl, de, ar, hi")
         print("注意: A100 GPU 推奨（T4 では VRAM 不足の可能性あり）。ライセンス: CC BY-NC 4.0")
     else:

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -54,6 +54,14 @@ def print_engine_voice_hints(settings: Settings):
         print(f"language: {settings.qwen3_language}")
         print(f"デフォルト speaker: {settings.qwen3_default_speaker}")
         print("候補: aiden, dylan, eric, ono_anna, ryan, serena, sohee, uncle_fu, vivian")
+    elif settings.engine == "Voxtral-TTS":
+        print("Voxtral-TTS は Mistral AI の高品質 TTS です（vLLM バックエンド）。")
+        print(f"モデル: {settings.voxtral_hf_model}")
+        print(f"デフォルト voice: {settings.voxtral_default_voice}")
+        print("候補: allison, aoede, chloe, coral, echo, fable, jessica, lucy, maisie, nova,")
+        print("      onyx, orbit, quinn, river, sarah, shimmer, stella, vale, victoria, zephyr")
+        print("対応言語: en, fr, es, pt, it, nl, de, ar, hi")
+        print("注意: A100 GPU 推奨（T4 では VRAM 不足の可能性あり）。ライセンス: CC BY-NC 4.0")
     else:
         print("Irodori-TTS は現状 voice 切り替えを持たない想定です。")
 

--- a/src/runtime.py
+++ b/src/runtime.py
@@ -91,6 +91,7 @@ def kill_old_processes(app_port: int, piper_backend_port: int):
         "uvicorn app:app",
         "uvicorn openai_wrapper_app:app",
         "python -m piper.http_server",
+        "vllm.entrypoints.openai.api_server",
         "cloudflared tunnel",
         "server_fastapi.py",
     ]


### PR DESCRIPTION
## Summary
- Add Mistral AI's Voxtral-4B-TTS-2603 as a new TTS engine
- Uses vllm-omni backend server + FastAPI proxy wrapper (same pattern as Piper)
- 20 preset voices (language/gender-based: neutral_female, casual_male, etc.)
- Supported languages: en, fr, es, pt, it, nl, de, ar, hi
- License: CC BY-NC 4.0 (non-commercial)

## Test plan
- [x] Bootstrap with `--engine Voxtral-TTS` on Google Colab (L4 GPU)
- [x] vllm-omni backend startup and model loading
- [x] Local `/v1/audio/speech` WAV generation (200 OK)
- [x] Public URL access via cloudflared
- [x] All endpoints verified (`/`, `/v1/models`, `/v1/voices`, `/v1/audio/speech`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)