### PR TITLE
Add VoxCPM2 engine support

### DIFF
--- a/colab/bootstrap.py
+++ b/colab/bootstrap.py
@@ -45,6 +45,9 @@ def parse_args():
     parser.add_argument("--qwen3-hf-model", default="Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice")
     parser.add_argument("--qwen3-language", default="Japanese")
     parser.add_argument("--qwen3-default-speaker", default="ono_anna")
+    parser.add_argument("--voxcpm-hf-model", default="openbmb/VoxCPM2")
+    parser.add_argument("--voxcpm-cfg-value", type=float, default=2.0)
+    parser.add_argument("--voxcpm-inference-timesteps", type=int, default=10)
     parser.add_argument("--voxtral-hf-model", default="mistralai/Voxtral-4B-TTS-2603")
     parser.add_argument("--voxtral-default-voice", default="neutral_female")
     parser.add_argument("--voxtral-backend-port", type=int, default=5001)
@@ -81,6 +84,9 @@ def main():
         qwen3_hf_model=args.qwen3_hf_model,
         qwen3_language=args.qwen3_language,
         qwen3_default_speaker=args.qwen3_default_speaker,
+        voxcpm_hf_model=args.voxcpm_hf_model,
+        voxcpm_cfg_value=args.voxcpm_cfg_value,
+        voxcpm_inference_timesteps=args.voxcpm_inference_timesteps,
         voxtral_hf_model=args.voxtral_hf_model,
         voxtral_default_voice=args.voxtral_default_voice,
         voxtral_backend_port=args.voxtral_backend_port,

--- a/multi_tts_openai_colab.py
+++ b/multi_tts_openai_colab.py
@@ -11,7 +11,7 @@ REPO_URL = "https://github.com/shinshin86/local-tts-on-google-colab.git"  #@para
 REPO_REF = "main"  #@param {type:"string"}
 WORKDIR = "/content/local-tts-on-google-colab"  #@param {type:"string"}
 
-ENGINE = "Kokoro"  #@param ["Irodori-TTS", "Kokoro", "MeloTTS", "Piper", "Piper-Plus", "Qwen3-TTS", "Style-Bert-VITS2"]
+ENGINE = "Kokoro"  #@param ["Irodori-TTS", "Kokoro", "MeloTTS", "Piper", "Piper-Plus", "Qwen3-TTS", "Style-Bert-VITS2", "VoxCPM2", "Voxtral-TTS"]
 EXPOSE_PUBLIC_URL = True  #@param {type:"boolean"}
 TEST_TEXT = "こんにちは。これは OpenAI 互換 TTS の動作確認です。"  #@param {type:"string"}
 TEST_SPEED = 1.0  #@param {type:"number"}
@@ -58,6 +58,12 @@ PIPER_PLUS_MODEL = "tsukuyomi"  #@param {type:"string"}
 QWEN3_HF_MODEL = "Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice"  #@param ["Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice", "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice"]
 QWEN3_LANGUAGE = "Japanese"  #@param ["Chinese", "English", "Japanese", "Korean", "German", "French", "Russian", "Portuguese", "Spanish", "Italian"]
 QWEN3_DEFAULT_SPEAKER = "ono_anna"  #@param ["aiden", "dylan", "eric", "ono_anna", "ryan", "serena", "sohee", "uncle_fu", "vivian"]
+
+#@markdown ---
+#@markdown VoxCPM2 (GPU required)
+VOXCPM_HF_MODEL = "openbmb/VoxCPM2"  #@param {type:"string"}
+VOXCPM_CFG_VALUE = 2.0  #@param {type:"number"}
+VOXCPM_INFERENCE_TIMESTEPS = 10  #@param {type:"integer"}
 
 import shlex
 import subprocess
@@ -143,6 +149,12 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         QWEN3_LANGUAGE,
         "--qwen3-default-speaker",
         QWEN3_DEFAULT_SPEAKER,
+        "--voxcpm-hf-model",
+        VOXCPM_HF_MODEL,
+        "--voxcpm-cfg-value",
+        str(VOXCPM_CFG_VALUE),
+        "--voxcpm-inference-timesteps",
+        str(VOXCPM_INFERENCE_TIMESTEPS),
     ]
     cmd.append("--expose-public-url" if EXPOSE_PUBLIC_URL else "--no-expose-public-url")
     return cmd

--- a/src/apps/voxcpm_app.py
+++ b/src/apps/voxcpm_app.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import soundfile as sf
+import torch
+from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+from voxcpm import VoxCPM
+
+logger = logging.getLogger("uvicorn.error")
+
+OPENAI_MODEL_ID = os.environ.get("OPENAI_MODEL_ID", "voxcpm2")
+VOXCPM_HF_MODEL = os.environ.get("VOXCPM_HF_MODEL", "openbmb/VoxCPM2")
+VOXCPM_CFG_VALUE = float(os.environ.get("VOXCPM_CFG_VALUE", "2.0"))
+VOXCPM_INFERENCE_TIMESTEPS = int(os.environ.get("VOXCPM_INFERENCE_TIMESTEPS", "10"))
+
+app = FastAPI(title="VoxCPM2 OpenAI Compatible TTS")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[],
+    allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
+    allow_credentials=False,
+    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_headers=["*"],
+    expose_headers=["x-openai-model", "x-openai-voice"],
+)
+
+
+class AudioSpeechRequest(BaseModel):
+    model: str = OPENAI_MODEL_ID
+    input: str
+    voice: str | None = None
+    response_format: str = "wav"
+    speed: float = 1.0
+
+
+_model: VoxCPM | None = None
+
+
+def get_model() -> VoxCPM:
+    global _model
+    if _model is None:
+        logger.info("Loading VoxCPM2 model: %s", VOXCPM_HF_MODEL)
+        _model = VoxCPM.from_pretrained(VOXCPM_HF_MODEL, load_denoiser=False)
+        logger.info("VoxCPM2 model loaded successfully")
+    return _model
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, exc: Exception):
+    logger.exception("Unhandled exception while serving request")
+    return JSONResponse(
+        status_code=500,
+        content={"error": type(exc).__name__, "detail": str(exc)},
+    )
+
+
+@app.get("/")
+def root():
+    return {"ok": True, "engine": "VoxCPM2", "model": OPENAI_MODEL_ID}
+
+
+@app.get("/v1/models")
+def list_models():
+    return {
+        "object": "list",
+        "data": [{"id": OPENAI_MODEL_ID, "object": "model", "owned_by": "openbmb"}],
+    }
+
+
+@app.get("/v1/voices")
+def list_voices():
+    return {
+        "object": "list",
+        "data": [{"id": "default", "object": "voice"}],
+    }
+
+
+@app.post("/v1/audio/speech")
+async def audio_speech(payload: AudioSpeechRequest):
+    if payload.response_format.lower() != "wav":
+        raise HTTPException(status_code=400, detail="This wrapper currently supports only wav.")
+
+    model = get_model()
+    wav = model.generate(
+        text=payload.input,
+        cfg_value=VOXCPM_CFG_VALUE,
+        inference_timesteps=VOXCPM_INFERENCE_TIMESTEPS,
+    )
+
+    if wav is None or (hasattr(wav, "__len__") and len(wav) == 0):
+        raise HTTPException(status_code=500, detail="No audio was generated.")
+
+    audio = wav if isinstance(wav, np.ndarray) else wav.cpu().numpy()
+    sample_rate = model.tts_model.sample_rate
+
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+        tmp_path = tmp.name
+
+    try:
+        sf.write(tmp_path, audio, sample_rate)
+        audio_bytes = Path(tmp_path).read_bytes()
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+
+    voice = payload.voice or "default"
+    return Response(
+        content=audio_bytes,
+        media_type="audio/wav",
+        headers={
+            "Content-Length": str(len(audio_bytes)),
+            "x-openai-model": payload.model,
+            "x-openai-voice": voice,
+        },
+    )

--- a/src/config.py
+++ b/src/config.py
@@ -64,6 +64,9 @@ class Settings:
     qwen3_hf_model: str = "Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice"
     qwen3_language: str = "Japanese"
     qwen3_default_speaker: str = "ono_anna"
+    voxcpm_hf_model: str = "openbmb/VoxCPM2"
+    voxcpm_cfg_value: float = 2.0
+    voxcpm_inference_timesteps: int = 10
     voxtral_hf_model: str = "mistralai/Voxtral-4B-TTS-2603"
     voxtral_default_voice: str = "neutral_female"
     voxtral_backend_port: int = 5001

--- a/src/installers/__init__.py
+++ b/src/installers/__init__.py
@@ -5,6 +5,7 @@ from .melo import install as install_melo
 from .piper import install as install_piper
 from .piper_plus import install as install_piper_plus
 from .style_bert import install as install_style_bert
+from .voxcpm import install as install_voxcpm
 from .voxtral import install as install_voxtral
 
 
@@ -16,5 +17,6 @@ INSTALLERS = {
     "Piper": install_piper,
     "Piper-Plus": install_piper_plus,
     "Qwen3-TTS": install_qwen3_tts,
+    "VoxCPM2": install_voxcpm,
     "Voxtral-TTS": install_voxtral,
 }

--- a/src/installers/voxcpm.py
+++ b/src/installers/voxcpm.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import os
+
+from src.config import Settings
+from src.runtime import ensure_venv, popen, uv_pip_install, write_text
+
+
+def install(settings: Settings) -> dict:
+    engine_dir = settings.engines_dir / "voxcpm"
+    engine_dir.mkdir(parents=True, exist_ok=True)
+    python_bin = ensure_venv(engine_dir)
+    uv_pip_install(
+        python_bin,
+        [
+            "fastapi",
+            "uvicorn",
+            "voxcpm",
+            "soundfile",
+            "numpy",
+        ],
+    )
+    write_text(engine_dir / "app.py", settings.read_repo_text("src/apps/voxcpm_app.py"))
+    env = {
+        **os.environ,
+        "PYTHONUNBUFFERED": "1",
+        "OPENAI_MODEL_ID": settings.openai_model_id or "voxcpm2",
+        "VOXCPM_HF_MODEL": settings.voxcpm_hf_model,
+        "VOXCPM_CFG_VALUE": str(settings.voxcpm_cfg_value),
+        "VOXCPM_INFERENCE_TIMESTEPS": str(settings.voxcpm_inference_timesteps),
+    }
+    proc = popen(
+        [
+            str(engine_dir / ".venv" / "bin" / "uvicorn"),
+            "app:app",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            str(settings.app_port),
+            "--log-level",
+            "info",
+        ],
+        cwd=str(engine_dir),
+        env=env,
+        log_path=settings.log_dir / "voxcpm-uvicorn.log",
+    )
+    return {"proc": proc, "app_dir": engine_dir, "log_path": settings.log_dir / "voxcpm-uvicorn.log"}

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -54,6 +54,11 @@ def print_engine_voice_hints(settings: Settings):
         print(f"language: {settings.qwen3_language}")
         print(f"デフォルト speaker: {settings.qwen3_default_speaker}")
         print("候補: aiden, dylan, eric, ono_anna, ryan, serena, sohee, uncle_fu, vivian")
+    elif settings.engine == "VoxCPM2":
+        print("VoxCPM2 は OpenBMB の高品質 TTS です（30言語対応、言語自動検出）。")
+        print(f"モデル: {settings.voxcpm_hf_model}")
+        print("voice パラメータは現在 'default' のみ対応です。")
+        print("注意: GPU 推奨（VRAM ~8GB）。ライセンス: Apache-2.0")
     elif settings.engine == "Voxtral-TTS":
         print("Voxtral-TTS は Mistral AI の高品質 TTS です（vLLM バックエンド）。")
         print(f"モデル: {settings.voxtral_hf_model}")


### PR DESCRIPTION
## Summary
- OpenBMB の VoxCPM2 (2B パラメータ、Apache-2.0) を新規 TTS エンジンとして追加
- 30言語対応（日本語含む）、言語自動検出、ゼロショット TTS
- 既存エンジンと同じ Direct Implementation パターン（Qwen3-TTS と同様）で実装

## 変更内容
- `src/apps/voxcpm_app.py` — OpenAI 互換 FastAPI アプリ（`/v1/audio/speech` 等）
- `src/installers/voxcpm.py` — `pip install voxcpm` ベースのインストーラー
- `src/installers/__init__.py`, `src/config.py`, `colab/bootstrap.py`, `src/launcher.py`, `multi_tts_openai_colab.py` — エンジン登録・設定追加

## 動作要件
- GPU 推奨（VRAM ~8GB）
- Colab T4 で動作確認済み（CUDA bfloat16）

## Test plan
- [x] Colab (T4 GPU) でランタイム再起動後に1セルから bootstrap 実行
- [x] ローカル `/v1/audio/speech` で WAV 生成成功
- [x] cloudflared 公開 URL 経由でアクセス可能
- [x] `/v1/models`, `/v1/voices` エンドポイント正常応答

🤖 Generated with [Claude Code](https://claude.com/claude-code)