### PR TITLE
Fix Voxtral-TTS & colab-mcp startup, mark Voxtral verified on A100

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -5,6 +5,8 @@
       "args": [
         "--python",
         "3.13",
+        "--with",
+        "fakeredis==2.34.1",
         "git+https://github.com/googlecolab/colab-mcp"
       ],
       "timeout": 30000

--- a/README.ja.md
+++ b/README.ja.md
@@ -15,7 +15,7 @@ Google Colab 上で選択したローカル TTS を一時的に OpenAI 互換 `/
 | Qwen3-TTS | 動作OK (GPU必須) | 日本語 / 英語 / 中国語 他 10言語 |
 | VoxCPM2 | 動作OK (GPU必須) | 日本語 / 英語 / 中国語 他 30言語 |
 | TinyTTS | 動作OK | 英語 |
-| Voxtral-TTS | 未確認 (GPU必須・VRAM 16GB+) | 英語 / フランス語 / スペイン語 他 9言語 |
+| Voxtral-TTS | 動作OK (GPU必須・VRAM 16GB+) | 英語 / フランス語 / スペイン語 他 9言語 |
 | F5-TTS | 動作OK (GPU必須) | 英語 / 中国語（日本語は別モデル） |
 | Fish-Speech | 動作不可 | 日本語 / 英語 / 中国語 他 80言語以上 |
 | MeloTTS | 動作不可 | - |
@@ -277,7 +277,7 @@ main()
 
 ### Voxtral-TTS
 
-[mistralai/Voxtral-4B-TTS-2603](https://huggingface.co/mistralai/Voxtral-4B-TTS-2603) を使った多言語 TTS です。4B パラメータのモデルで、英語・フランス語・スペイン語・ドイツ語・イタリア語・ポルトガル語・オランダ語・アラビア語・ヒンディー語の 9 言語に対応しています。20 種類のプリセットボイスを内蔵し、wav / mp3 / flac / aac / opus など複数フォーマットに対応しています。バックエンドに vLLM + vllm-omni を使用します。GPU ランタイム（VRAM 16GB 以上）が必要で、Colab 無料枠の T4（15GB）では動作しない可能性があります。ライセンス: CC BY-NC 4.0（非商用のみ）。
+[mistralai/Voxtral-4B-TTS-2603](https://huggingface.co/mistralai/Voxtral-4B-TTS-2603) を使った多言語 TTS です。4B パラメータのモデルで、英語・フランス語・スペイン語・ドイツ語・イタリア語・ポルトガル語・オランダ語・アラビア語・ヒンディー語の 9 言語に対応しています。20 種類のプリセットボイスを内蔵し、wav / mp3 / flac / aac / opus など複数フォーマットに対応しています。バックエンドに vLLM + vllm-omni を使用します。GPU ランタイム（VRAM 16GB 以上）が必要です。Colab A100（VRAM 40GB）で動作確認済みですが、無料枠の T4（15GB）では VRAM 不足のため動作しない可能性があります。ライセンス: CC BY-NC 4.0（非商用のみ）。
 
 ### F5-TTS
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Supported engines:
 | Qwen3-TTS | Works (GPU required) | Japanese / English / Chinese and 10 languages |
 | VoxCPM2 | Works (GPU required) | Japanese / English / Chinese and 30 languages |
 | TinyTTS | Works | English |
-| Voxtral-TTS | Unverified (GPU required, VRAM 16GB+) | English / French / Spanish and 9 languages |
+| Voxtral-TTS | Works (GPU required, VRAM 16GB+) | English / French / Spanish and 9 languages |
 | F5-TTS | Works (GPU required) | English / Chinese (Japanese via separate model) |
 | Fish-Speech | Not working | Japanese / English / Chinese and 80+ languages |
 | MeloTTS | Not working | - |
@@ -277,7 +277,7 @@ An ultra-lightweight English TTS using [ecyht2/tiny-tts](https://github.com/ecyh
 
 ### Voxtral-TTS
 
-A multilingual TTS using [mistralai/Voxtral-4B-TTS-2603](https://huggingface.co/mistralai/Voxtral-4B-TTS-2603). A 4B-parameter model supporting 9 languages: English, French, Spanish, German, Italian, Portuguese, Dutch, Arabic, and Hindi. It includes 20 preset voices and supports multiple formats such as wav / mp3 / flac / aac / opus. The backend uses vLLM + vllm-omni. A GPU runtime (VRAM 16GB or more) is required, and it may not work on Colab's free-tier T4 (15GB). License: CC BY-NC 4.0 (non-commercial only).
+A multilingual TTS using [mistralai/Voxtral-4B-TTS-2603](https://huggingface.co/mistralai/Voxtral-4B-TTS-2603). A 4B-parameter model supporting 9 languages: English, French, Spanish, German, Italian, Portuguese, Dutch, Arabic, and Hindi. It includes 20 preset voices and supports multiple formats such as wav / mp3 / flac / aac / opus. The backend uses vLLM + vllm-omni. A GPU runtime (VRAM 16GB or more) is required. Verified working on Colab A100 (40GB VRAM); may not work on the free-tier T4 (15GB) due to VRAM requirements. License: CC BY-NC 4.0 (non-commercial only).
 
 ### F5-TTS
 

--- a/src/installers/voxtral.py
+++ b/src/installers/voxtral.py
@@ -41,7 +41,7 @@ def install(settings: Settings) -> dict:
     uv_pip_install(
         python_bin,
         [
-            "vllm-omni @ git+https://github.com/vllm-project/vllm-omni.git",
+            "vllm-omni @ git+https://github.com/vllm-project/vllm-omni.git@4c031580cffa99ac8b96ba14055ba78678362436",
         ],
     )
     # Find the stage config YAML path inside vllm_omni package


### PR DESCRIPTION
## Summary

- Pin `vllm-omni` to a vllm 0.18.0 compatible commit so the Voxtral-TTS installer stops crashing on `ImportError: cannot import name 'TokensInput' from 'vllm.inputs'`.
- Pin `fakeredis==2.34.1` in `.mcp.json` so `colab-mcp` (used to verify engines on Colab from Claude Code) can start up again; see [googlecolab/colab-mcp#73](https://github.com/googlecolab/colab-mcp/issues/73).
- Mark `Voxtral-TTS` as verified working on Colab A100 (40GB VRAM) in both the English and Japanese READMEs.

## Background

### Voxtral-TTS installer

`vllm-omni` main was rebased to `vllm 0.19.0` on 2026-04-04 (commit `2804a85e`), which introduced an import of `TokensInput` from `vllm.inputs`. That symbol does not exist in the pinned `vllm==0.18.0`, so the installer failed before the vLLM backend could start. This PR pins `vllm-omni` to `4c031580c` — the last commit before the 0.19.0 rebase — to keep the installer compatible with the pinned vllm version. A longer-term fix is to upgrade vllm itself to 0.19.0 and track vllm-omni main again.

### colab-mcp

`fastmcp 2.14.5` (via `docket`) imports `FakeConnection` from `fakeredis.aioredis`, but newer `fakeredis` releases renamed it to `FakeRedisConnection`. Pinning `fakeredis==2.34.1` (the last version that still exposes the old name) lets the MCP server start up on a fresh install.

## Test plan

- [x] On a Colab A100 runtime (40GB VRAM), run the bootstrap cell with `ENGINE = "Voxtral-TTS"` end-to-end and confirm:
  - vLLM backend starts and serves `/v1/models`
  - OpenAI-compatible proxy starts on the app port
  - `/v1/models`, `/v1/voices` respond
  - Test WAV is generated via `/v1/audio/speech`
  - trycloudflare public URL is printed
- [x] `colab-mcp` starts from the project `.mcp.json` without the `ImportError` and tools become available.
- [ ] (Out of scope) Re-verify on a non-A100 GPU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)