### PR TITLE
Add NeuTTS engine (CPU-capable, instant voice cloning)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -55,7 +55,7 @@ REPO_URL = "https://github.com/shinshin86/local-tts-on-google-colab.git"  #@para
 REPO_REF = "main"  #@param {type:"string"}
 WORKDIR = "/content/local-tts-on-google-colab"  #@param {type:"string"}
 
-ENGINE = "Kokoro"  #@param ["Irodori-TTS", "Kokoro", "MeloTTS", "MOSS-TTS-Nano", "Piper", "Piper-Plus", "Qwen3-TTS", "Style-Bert-VITS2", "TinyTTS", "Voxtral-TTS"]
+ENGINE = "Kokoro"  #@param ["Irodori-TTS", "Kokoro", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "Piper", "Piper-Plus", "Qwen3-TTS", "Style-Bert-VITS2", "TinyTTS", "Voxtral-TTS"]
 EXPOSE_PUBLIC_URL = True  #@param {type:"boolean"}
 TEST_TEXT = "こんにちは。これは OpenAI 互換 TTS の動作確認です。"  #@param {type:"string"}
 TEST_SPEED = 1.0  #@param {type:"number"}
@@ -276,6 +276,20 @@ main()
 
 [OpenMOSS/MOSS-TTS-Nano](https://github.com/OpenMOSS/MOSS-TTS-Nano) を使った軽量多言語 TTS です。わずか 0.1B（100M）パラメータで、日本語・英語・中国語を含む 20 言語に対応し、GPU 不要・CPU のみで動作します。デフォルトの Hugging Face モデルは `OpenMOSS-Team/MOSS-TTS-Nano-100M`。`continuation` モード（プロンプト音声なしの plain TTS）で起動します。出力は 48 kHz ステレオ。ライセンス: Apache-2.0。注意: 音声自体は正常に生成されますが、現状では入力テキストの長さに関わらず出力が先頭 2 秒程度で切れてしまいます。ラッパーは MOSS-TTS-Nano の `model.inference()` に生成を委譲しているだけなので、修正には上流 `inference()` API 側で生成長パラメータを露出させる必要がありそうです。
 
+### NeuTTS
+
+[neuphonic/neutts](https://github.com/neuphonic/neutts) を使ったオンデバイス TTS です。**インスタント voice cloning** を採用しており、リクエストごとに参照音声の声色で合成します（プリセット話者という概念はありません）。upstream リポジトリに同梱されている 5 つの参照音声を OpenAI 互換 API の `voice` パラメータから指定できます:
+
+| voice | 言語 | 性別 |
+|---|---|---|
+| `dave`     | 英語 | 男性 |
+| `jo`       | 英語 | 女性 |
+| `mateo`    | スペイン語 | 男性 |
+| `greta`    | ドイツ語 | 女性 |
+| `juliette` | フランス語 | 女性 |
+
+デフォルト backbone は `neuphonic/neutts-air`（約 360M パラメータ、英語のみ、Apache 2.0）。他言語には Nano 系の言語別 backbone（`neuphonic/neutts-nano-french` / `-german` / `-spanish`、NeuTTS Open License 1.0）が用意されています。**参照音声の言語と backbone の言語は揃える必要があります** — 揃えないと不自然なアクセントや崩れた音声になります。ラッパーは初回利用時に参照音声を遅延エンコードしてメモリにキャッシュします。日本語は **非対応**。ライセンス: コードは Apache-2.0、モデル重みは backbone により異なります（下記参照）。独自の参照音声を追加することも技術的には可能ですが、必ず権利を持っている音声（本人の同意がある音声）でのみ行ってください。
+
 ### TinyTTS
 
 [ecyht2/tiny-tts](https://github.com/ecyht2/tiny-tts) を使った超軽量の英語 TTS です。モデルはわずか 1.6M パラメータ（約 3.4MB）で、GPU 不要・CPU のみで 53 倍速のリアルタイム合成が可能です。音声は 44.1kHz で出力されます。voice の切り替え機能はありません。ライセンス: Apache 2.0。
@@ -317,6 +331,7 @@ main()
 | Qwen3-TTS | Apache 2.0 | Apache 2.0 | OK | |
 | VoxCPM2 | Apache 2.0 | Apache 2.0 | OK | |
 | MOSS-TTS-Nano | Apache 2.0 | Apache 2.0 | OK | 100M パラメータ、CPU 動作可 |
+| NeuTTS | Apache 2.0 | Apache 2.0 (Air) / NeuTTS Open License 1.0 (Nano) | OK (Air) / 規約要確認 (Nano) | ボイスクローン。英 / 西 / 独 / 仏 |
 | TinyTTS | Apache 2.0 | Apache 2.0 | OK | |
 | Voxtral-TTS | — | CC BY-NC 4.0 | 不可 | vLLM + vllm-omni 経由。音声データセットのライセンス制約により非商用 |
 | F5-TTS | MIT | CC-BY-NC | 不可（モデル） | モデル重みは Emilia データセットの制約により非商用 |
@@ -356,6 +371,8 @@ main()
   https://github.com/ecyht2/tiny-tts
 - MOSS-TTS-Nano
   https://github.com/OpenMOSS/MOSS-TTS-Nano
+- NeuTTS
+  https://github.com/neuphonic/neutts
 - Voxtral-TTS
   https://huggingface.co/mistralai/Voxtral-4B-TTS-2603
 - F5-TTS

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Supported engines:
 | Qwen3-TTS | Works (GPU required) | Japanese / English / Chinese and 10 languages |
 | VoxCPM2 | Works (GPU required) | Japanese / English / Chinese and 30 languages |
 | MOSS-TTS-Nano | Works (output truncated to ~2s) | Japanese / English / Chinese and 20 languages |
+| NeuTTS | Works (CPU OK, voice cloning) | English / Spanish / German / French |
 | TinyTTS | Works | English |
 | Voxtral-TTS | Works (GPU required, VRAM 16GB+) | English / French / Spanish and 9 languages |
 | F5-TTS | Works (GPU required) | English / Chinese (Japanese via separate model) |
@@ -55,7 +56,7 @@ REPO_URL = "https://github.com/shinshin86/local-tts-on-google-colab.git"  #@para
 REPO_REF = "main"  #@param {type:"string"}
 WORKDIR = "/content/local-tts-on-google-colab"  #@param {type:"string"}
 
-ENGINE = "Kokoro"  #@param ["Irodori-TTS", "Kokoro", "MeloTTS", "MOSS-TTS-Nano", "Piper", "Piper-Plus", "Qwen3-TTS", "Style-Bert-VITS2", "TinyTTS", "Voxtral-TTS"]
+ENGINE = "Kokoro"  #@param ["Irodori-TTS", "Kokoro", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "Piper", "Piper-Plus", "Qwen3-TTS", "Style-Bert-VITS2", "TinyTTS", "Voxtral-TTS"]
 EXPOSE_PUBLIC_URL = True  #@param {type:"boolean"}
 TEST_TEXT = "こんにちは。これは OpenAI 互換 TTS の動作確認です。"  #@param {type:"string"}
 TEST_SPEED = 1.0  #@param {type:"number"}
@@ -276,6 +277,20 @@ A high-quality TTS using [OpenBMB/VoxCPM](https://github.com/OpenBMB/VoxCPM). A 
 
 A lightweight multilingual TTS using [OpenMOSS/MOSS-TTS-Nano](https://github.com/OpenMOSS/MOSS-TTS-Nano). Only 0.1B (100M) parameters, supports 20 languages including Japanese / English / Chinese, and runs on CPU without a GPU. Default Hugging Face model: `OpenMOSS-Team/MOSS-TTS-Nano-100M`. Launched in `continuation` mode (plain TTS without a prompt audio). Output is 48 kHz stereo. License: Apache-2.0. Note: audio is generated successfully, but output is currently truncated to roughly the first ~2 seconds regardless of input length. The wrapper delegates generation to MOSS-TTS-Nano's `model.inference()`; exposing a length parameter on the upstream `inference()` API is likely needed to fix this.
 
+### NeuTTS
+
+An on-device TTS using [neuphonic/neutts](https://github.com/neuphonic/neutts). Uses **instant voice cloning** — every request is rendered in the voice of a reference audio file, so there is no preset speaker concept. Five reference voices bundled in the upstream repo are exposed via the OpenAI `voice` parameter:
+
+| voice | language | sex |
+|---|---|---|
+| `dave`     | English | male   |
+| `jo`       | English | female |
+| `mateo`    | Spanish | male   |
+| `greta`    | German  | female |
+| `juliette` | French  | female |
+
+Default backbone: `neuphonic/neutts-air` (~360M params, English only, Apache 2.0). Other languages have separate Nano backbones (`neuphonic/neutts-nano-french` / `-german` / `-spanish`, NeuTTS Open License 1.0). **Use a reference voice whose language matches the backbone** — mixing languages produces accented or garbled output. The wrapper lazy-encodes each reference on first use and caches it in memory. Japanese is **not** supported. License: code Apache-2.0; weights vary per backbone (see Licenses below). Adding your own reference voice is technically possible but should only be done with audio you have rights to (consent of the speaker).
+
 ### TinyTTS
 
 An ultra-lightweight English TTS using [ecyht2/tiny-tts](https://github.com/ecyht2/tiny-tts). The model has only 1.6M parameters (~3.4 MB), no GPU required, and can synthesize speech at 53× real-time on CPU alone. Audio is output at 44.1 kHz. There is no voice switching. License: Apache 2.0.
@@ -317,6 +332,7 @@ The license for each engine is as follows. When using them, always check each pr
 | Qwen3-TTS | Apache 2.0 | Apache 2.0 | OK | |
 | VoxCPM2 | Apache 2.0 | Apache 2.0 | OK | |
 | MOSS-TTS-Nano | Apache 2.0 | Apache 2.0 | OK | 100M params, CPU OK |
+| NeuTTS | Apache 2.0 | Apache 2.0 (Air) / NeuTTS Open License 1.0 (Nano) | OK (Air) / Check terms (Nano) | Voice cloning. EN / ES / DE / FR |
 | TinyTTS | Apache 2.0 | Apache 2.0 | OK | |
 | Voxtral-TTS | — | CC BY-NC 4.0 | Not allowed | Via vLLM + vllm-omni. Non-commercial due to voice dataset license constraints |
 | F5-TTS | MIT | CC-BY-NC | Not allowed (model) | Model weights are non-commercial due to Emilia dataset constraints |
@@ -356,6 +372,8 @@ This repository itself is intended for short-term operational verification and t
   https://github.com/ecyht2/tiny-tts
 - MOSS-TTS-Nano
   https://github.com/OpenMOSS/MOSS-TTS-Nano
+- NeuTTS
+  https://github.com/neuphonic/neutts
 - Voxtral-TTS
   https://huggingface.co/mistralai/Voxtral-4B-TTS-2603
 - F5-TTS

--- a/colab/bootstrap.py
+++ b/colab/bootstrap.py
@@ -51,6 +51,9 @@ def parse_args():
     parser.add_argument("--qwen3-default-speaker", default="ono_anna")
     parser.add_argument("--moss-tts-nano-hf-model", default="OpenMOSS-Team/MOSS-TTS-Nano-100M")
     parser.add_argument("--moss-tts-nano-mode", default="continuation")
+    parser.add_argument("--neutts-backbone-repo", default="neuphonic/neutts-air")
+    parser.add_argument("--neutts-codec-repo", default="neuphonic/neucodec")
+    parser.add_argument("--neutts-default-voice", default="jo")
     parser.add_argument("--voxcpm-hf-model", default="openbmb/VoxCPM2")
     parser.add_argument("--voxcpm-cfg-value", type=float, default=2.0)
     parser.add_argument("--voxcpm-inference-timesteps", type=int, default=10)
@@ -96,6 +99,9 @@ def main():
         qwen3_default_speaker=args.qwen3_default_speaker,
         moss_tts_nano_hf_model=args.moss_tts_nano_hf_model,
         moss_tts_nano_mode=args.moss_tts_nano_mode,
+        neutts_backbone_repo=args.neutts_backbone_repo,
+        neutts_codec_repo=args.neutts_codec_repo,
+        neutts_default_voice=args.neutts_default_voice,
         voxcpm_hf_model=args.voxcpm_hf_model,
         voxcpm_cfg_value=args.voxcpm_cfg_value,
         voxcpm_inference_timesteps=args.voxcpm_inference_timesteps,

--- a/multi_tts_openai_colab.py
+++ b/multi_tts_openai_colab.py
@@ -11,7 +11,7 @@ REPO_URL = "https://github.com/shinshin86/local-tts-on-google-colab.git"  #@para
 REPO_REF = "main"  #@param {type:"string"}
 WORKDIR = "/content/local-tts-on-google-colab"  #@param {type:"string"}
 
-ENGINE = "Kokoro"  #@param ["F5-TTS", "Fish-Speech", "Irodori-TTS", "Kokoro", "MeloTTS", "MOSS-TTS-Nano", "Piper", "Piper-Plus", "Qwen3-TTS", "Style-Bert-VITS2", "TinyTTS", "VoxCPM2", "Voxtral-TTS"]
+ENGINE = "Kokoro"  #@param ["F5-TTS", "Fish-Speech", "Irodori-TTS", "Kokoro", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "Piper", "Piper-Plus", "Qwen3-TTS", "Style-Bert-VITS2", "TinyTTS", "VoxCPM2", "Voxtral-TTS"]
 EXPOSE_PUBLIC_URL = True  #@param {type:"boolean"}
 TEST_TEXT = "こんにちは。これは OpenAI 互換 TTS の動作確認です。"  #@param {type:"string"}
 TEST_SPEED = 1.0  #@param {type:"number"}
@@ -79,6 +79,12 @@ VOXCPM_INFERENCE_TIMESTEPS = 10  #@param {type:"integer"}
 #@markdown MOSS-TTS-Nano (CPU OK)
 MOSS_TTS_NANO_HF_MODEL = "OpenMOSS-Team/MOSS-TTS-Nano-100M"  #@param {type:"string"}
 MOSS_TTS_NANO_MODE = "continuation"  #@param ["continuation", "voice_clone"]
+
+#@markdown ---
+#@markdown NeuTTS (CPU OK, EN/ES/DE/FR, voice cloning)
+NEUTTS_BACKBONE_REPO = "neuphonic/neutts-air"  #@param ["neuphonic/neutts-air", "neuphonic/neutts-nano", "neuphonic/neutts-nano-french", "neuphonic/neutts-nano-german", "neuphonic/neutts-nano-spanish"]
+NEUTTS_CODEC_REPO = "neuphonic/neucodec"  #@param {type:"string"}
+NEUTTS_DEFAULT_VOICE = "jo"  #@param ["dave", "jo", "greta", "juliette", "mateo"]
 
 import shlex
 import subprocess
@@ -182,6 +188,12 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         MOSS_TTS_NANO_HF_MODEL,
         "--moss-tts-nano-mode",
         MOSS_TTS_NANO_MODE,
+        "--neutts-backbone-repo",
+        NEUTTS_BACKBONE_REPO,
+        "--neutts-codec-repo",
+        NEUTTS_CODEC_REPO,
+        "--neutts-default-voice",
+        NEUTTS_DEFAULT_VOICE,
     ]
     cmd.append("--expose-public-url" if EXPOSE_PUBLIC_URL else "--no-expose-public-url")
     return cmd

--- a/src/apps/neutts_app.py
+++ b/src/apps/neutts_app.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import soundfile as sf
+import torch
+from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from neutts import NeuTTS
+from pydantic import BaseModel
+
+logger = logging.getLogger("uvicorn.error")
+
+OPENAI_MODEL_ID = os.environ.get("OPENAI_MODEL_ID", "neutts")
+NEUTTS_BACKBONE_REPO = os.environ.get("NEUTTS_BACKBONE_REPO", "neuphonic/neutts-air")
+NEUTTS_CODEC_REPO = os.environ.get("NEUTTS_CODEC_REPO", "neuphonic/neucodec")
+NEUTTS_DEFAULT_VOICE = os.environ.get("NEUTTS_DEFAULT_VOICE", "jo")
+NEUTTS_SAMPLES_DIR = Path(os.environ.get("NEUTTS_SAMPLES_DIR", "samples"))
+
+# Bundled reference voices shipped in the NeuTTS upstream repo.
+# Each voice is a (display language, wav filename, transcript filename) tuple.
+# The model's language must match the reference audio's language for best results;
+# the default backbone (neutts-air) is English-only, so dave/jo are the safe picks.
+VOICE_PRESETS: dict[str, dict] = {
+    "dave":     {"language": "en", "wav": "dave.wav",     "txt": "dave.txt"},
+    "jo":       {"language": "en", "wav": "jo.wav",       "txt": "jo.txt"},
+    "greta":    {"language": "de", "wav": "greta.wav",    "txt": "greta.txt"},
+    "juliette": {"language": "fr", "wav": "juliette.wav", "txt": "juliette.txt"},
+    "mateo":    {"language": "es", "wav": "mateo.wav",    "txt": "mateo.txt"},
+}
+
+app = FastAPI(title="NeuTTS OpenAI Compatible TTS")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[],
+    allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
+    allow_credentials=False,
+    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_headers=["*"],
+    expose_headers=["x-openai-model", "x-openai-voice"],
+)
+
+
+class AudioSpeechRequest(BaseModel):
+    model: str = OPENAI_MODEL_ID
+    input: str
+    voice: str | None = None
+    response_format: str = "wav"
+    speed: float = 1.0
+
+
+_model: NeuTTS | None = None
+_ref_cache: dict[str, tuple[object, str]] = {}
+
+
+def _device() -> str:
+    return "cuda" if torch.cuda.is_available() else "cpu"
+
+
+def get_model() -> NeuTTS:
+    global _model
+    if _model is None:
+        device = _device()
+        logger.info(
+            "Loading NeuTTS: backbone=%s codec=%s device=%s",
+            NEUTTS_BACKBONE_REPO,
+            NEUTTS_CODEC_REPO,
+            device,
+        )
+        _model = NeuTTS(
+            backbone_repo=NEUTTS_BACKBONE_REPO,
+            backbone_device=device,
+            codec_repo=NEUTTS_CODEC_REPO,
+            codec_device=device,
+        )
+        logger.info("NeuTTS model loaded")
+    return _model
+
+
+def get_reference(voice: str, model: NeuTTS) -> tuple[object, str]:
+    if voice not in _ref_cache:
+        preset = VOICE_PRESETS[voice]
+        wav_path = NEUTTS_SAMPLES_DIR / preset["wav"]
+        txt_path = NEUTTS_SAMPLES_DIR / preset["txt"]
+        if not wav_path.exists() or not txt_path.exists():
+            raise HTTPException(
+                status_code=500,
+                detail=f"Reference files for voice '{voice}' not found under {NEUTTS_SAMPLES_DIR}",
+            )
+        ref_text = txt_path.read_text(encoding="utf-8").strip()
+        logger.info("Encoding reference voice '%s' from %s", voice, wav_path)
+        ref_codes = model.encode_reference(str(wav_path))
+        _ref_cache[voice] = (ref_codes, ref_text)
+    return _ref_cache[voice]
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, exc: Exception):
+    logger.exception("Unhandled exception while serving request")
+    return JSONResponse(
+        status_code=500,
+        content={"error": type(exc).__name__, "detail": str(exc)},
+    )
+
+
+@app.get("/")
+def root():
+    return {
+        "ok": True,
+        "engine": "NeuTTS",
+        "model": OPENAI_MODEL_ID,
+        "backbone": NEUTTS_BACKBONE_REPO,
+        "default_voice": NEUTTS_DEFAULT_VOICE,
+    }
+
+
+@app.get("/v1/models")
+def list_models():
+    return {
+        "object": "list",
+        "data": [{"id": OPENAI_MODEL_ID, "object": "model", "owned_by": "neuphonic"}],
+    }
+
+
+@app.get("/v1/voices")
+def list_voices():
+    return {
+        "object": "list",
+        "data": [
+            {"id": name, "object": "voice", "language": preset["language"]}
+            for name, preset in VOICE_PRESETS.items()
+        ],
+    }
+
+
+@app.post("/v1/audio/speech")
+async def audio_speech(payload: AudioSpeechRequest):
+    if payload.response_format.lower() != "wav":
+        raise HTTPException(status_code=400, detail="This wrapper currently supports only wav.")
+
+    voice = payload.voice or NEUTTS_DEFAULT_VOICE
+    if voice not in VOICE_PRESETS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown voice '{voice}'. Available: {sorted(VOICE_PRESETS.keys())}",
+        )
+
+    model = get_model()
+    ref_codes, ref_text = get_reference(voice, model)
+
+    wav = model.infer(payload.input, ref_codes, ref_text)
+    if wav is None or (hasattr(wav, "__len__") and len(wav) == 0):
+        raise HTTPException(status_code=500, detail="No audio was generated.")
+
+    audio = wav if isinstance(wav, np.ndarray) else np.asarray(wav)
+    sample_rate = 24000
+
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+        tmp_path = tmp.name
+
+    try:
+        sf.write(tmp_path, audio, sample_rate)
+        audio_bytes = Path(tmp_path).read_bytes()
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+
+    return Response(
+        content=audio_bytes,
+        media_type="audio/wav",
+        headers={
+            "Content-Length": str(len(audio_bytes)),
+            "x-openai-model": payload.model,
+            "x-openai-voice": voice,
+        },
+    )

--- a/src/config.py
+++ b/src/config.py
@@ -16,6 +16,8 @@ KOKORO_VOICE_PRESETS = [
     "zf_xiaobei",
 ]
 
+NEUTTS_VOICE_PRESETS = ["dave", "jo", "greta", "juliette", "mateo"]
+
 MELO_VOICE_PRESETS = [
     "JP",
     "EN-Default",
@@ -70,6 +72,9 @@ class Settings:
     qwen3_default_speaker: str = "ono_anna"
     moss_tts_nano_hf_model: str = "OpenMOSS-Team/MOSS-TTS-Nano-100M"
     moss_tts_nano_mode: str = "continuation"
+    neutts_backbone_repo: str = "neuphonic/neutts-air"
+    neutts_codec_repo: str = "neuphonic/neucodec"
+    neutts_default_voice: str = "jo"
     voxcpm_hf_model: str = "openbmb/VoxCPM2"
     voxcpm_cfg_value: float = 2.0
     voxcpm_inference_timesteps: int = 10

--- a/src/installers/__init__.py
+++ b/src/installers/__init__.py
@@ -5,6 +5,7 @@ from .qwen3_tts import install as install_qwen3_tts
 from .kokoro import install as install_kokoro
 from .melo import install as install_melo
 from .moss_tts_nano import install as install_moss_tts_nano
+from .neutts import install as install_neutts
 from .piper import install as install_piper
 from .piper_plus import install as install_piper_plus
 from .style_bert import install as install_style_bert
@@ -20,6 +21,7 @@ INSTALLERS = {
     "Kokoro": install_kokoro,
     "MeloTTS": install_melo,
     "MOSS-TTS-Nano": install_moss_tts_nano,
+    "NeuTTS": install_neutts,
     "Style-Bert-VITS2": install_style_bert,
     "Piper": install_piper,
     "Piper-Plus": install_piper_plus,

--- a/src/installers/neutts.py
+++ b/src/installers/neutts.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import os
+
+from src.config import Settings
+from src.runtime import ensure_git_clone, ensure_venv, popen, uv_pip_install, write_text
+
+
+def install(settings: Settings) -> dict:
+    engine_dir = settings.engines_dir / "neutts"
+    repo_dir = engine_dir / "neutts-repo"
+    engine_dir.mkdir(parents=True, exist_ok=True)
+    # Clone the upstream NeuTTS repo only to obtain the bundled reference samples
+    # (dave/jo: EN, mateo: ES, greta: DE, juliette: FR). The package itself is
+    # installed via pip below.
+    ensure_git_clone("https://github.com/neuphonic/neutts.git", repo_dir)
+
+    python_bin = ensure_venv(engine_dir)
+    uv_pip_install(
+        python_bin,
+        [
+            "fastapi",
+            "uvicorn",
+            "soundfile",
+            "numpy",
+            "neutts",
+        ],
+    )
+
+    write_text(engine_dir / "app.py", settings.read_repo_text("src/apps/neutts_app.py"))
+
+    env = {
+        **os.environ,
+        "PYTHONUNBUFFERED": "1",
+        "OPENAI_MODEL_ID": settings.openai_model_id or "neutts",
+        "NEUTTS_BACKBONE_REPO": settings.neutts_backbone_repo,
+        "NEUTTS_CODEC_REPO": settings.neutts_codec_repo,
+        "NEUTTS_DEFAULT_VOICE": settings.neutts_default_voice,
+        "NEUTTS_SAMPLES_DIR": str(repo_dir / "samples"),
+    }
+    proc = popen(
+        [
+            str(engine_dir / ".venv" / "bin" / "uvicorn"),
+            "app:app",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            str(settings.app_port),
+            "--log-level",
+            "info",
+        ],
+        cwd=str(engine_dir),
+        env=env,
+        log_path=settings.log_dir / "neutts-uvicorn.log",
+    )
+    return {
+        "proc": proc,
+        "app_dir": engine_dir,
+        "log_path": settings.log_dir / "neutts-uvicorn.log",
+    }

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 import time
 
-from src.config import KOKORO_VOICE_PRESETS, MELO_VOICE_PRESETS, Settings
+from src.config import KOKORO_VOICE_PRESETS, MELO_VOICE_PRESETS, NEUTTS_VOICE_PRESETS, Settings
 from src.installers import INSTALLERS
 from src.runtime import (
     ensure_cloudflared,
@@ -28,6 +28,8 @@ def resolve_selected_voice(settings: Settings) -> str:
         return settings.kokoro_default_voice
     if settings.engine == "MeloTTS":
         return settings.melo_default_voice
+    if settings.engine == "NeuTTS":
+        return settings.neutts_default_voice
     return ""
 
 
@@ -80,6 +82,15 @@ def print_engine_voice_hints(settings: Settings):
         print("      it_male, neutral_female, neutral_male, nl_female, nl_male, pt_female, pt_male")
         print("対応言語: en, fr, es, pt, it, nl, de, ar, hi")
         print("注意: A100 GPU 推奨（T4 では VRAM 不足の可能性あり）。ライセンス: CC BY-NC 4.0")
+    elif settings.engine == "NeuTTS":
+        print("NeuTTS は Neuphonic のオンデバイス TTS です（インスタント voice cloning、CPU 動作可）。")
+        print(f"backbone: {settings.neutts_backbone_repo}")
+        print(f"codec   : {settings.neutts_codec_repo}")
+        print(f"デフォルト voice: {settings.neutts_default_voice}")
+        print("候補:", ", ".join(NEUTTS_VOICE_PRESETS), "(dave/jo=英語, mateo=西語, greta=独語, juliette=仏語)")
+        print("対応言語: 英語 / 西語 / 独語 / 仏語（日本語非対応）。")
+        print("注意: 非英語の voice を使う場合は、対応言語の Nano backbone を指定してください。")
+        print("ライセンス: neutts-air=Apache-2.0 / neutts-nano=NeuTTS Open License 1.0")
     elif settings.engine == "MOSS-TTS-Nano":
         print("MOSS-TTS-Nano は OpenMOSS の軽量 TTS です（100M パラメータ、20言語対応、CPU 動作）。")
         print(f"モデル: {settings.moss_tts_nano_hf_model}")


### PR DESCRIPTION
## Summary

- Add **NeuTTS** ([neuphonic/neutts](https://github.com/neuphonic/neutts)) as a new TTS engine. It is an on-device TTS that uses **instant voice cloning** instead of preset speakers — every request is rendered in the voice of a reference audio file.
- The 5 reference voices bundled in the upstream repo are exposed via the OpenAI-compatible `voice` parameter:
  - `dave` (EN, male), `jo` (EN, female, default), `mateo` (ES, male), `greta` (DE, female), `juliette` (FR, female)
- Default backbone: `neuphonic/neutts-air` (~360M params, English only, **Apache 2.0**). Language-specific Nano backbones (`neuphonic/neutts-nano-french` / `-german` / `-spanish`, NeuTTS Open License 1.0) can be selected via `--neutts-backbone-repo`. **Japanese is not supported.**
- Reference audio is lazy-encoded once per voice on first use and cached in memory.

## Why this engine

Fills a gap in the existing lineup: a **CPU-capable, English-focused TTS with voice cloning**. Comparable in slot to `MOSS-TTS-Nano` but with a working voice-cloning UX driven by reference wavs rather than preset speaker IDs.

## Implementation notes

- The OpenAI `voice` parameter is mapped to a static dict of bundled reference samples; the upstream NeuTTS repo is cloned into `engines/neutts/neutts-repo` solely to obtain the `samples/` directory.
- A warning is included that mixing a non-English backbone with an English reference (or vice versa) produces accented / garbled output — this is per the upstream README.

## Test plan

Verified on Colab (GPU runtime) with `REPO_REF=feat/neutts`:

- [x] `pip install neutts` succeeds (resemble-perth 1.0.1 installs cleanly under uv venv — the previously feared dependency conflict did not occur)
- [x] `GET /v1/voices` returns all 5 voices with `language` field
- [x] `POST /v1/audio/speech` with `voice=jo` over localhost — returns 4.30s / 24kHz mono wav (RMS 0.067, voiced 70.7%)
- [x] `POST /v1/audio/speech` with `voice=dave` over the cloudflared public URL — returns 2.80s / 24kHz mono wav (RMS 0.071, voiced 86.4%)
- [x] Audio statistics match real speech (no silence, no all-noise); audio playback confirmed in Colab

🤖 Generated with [Claude Code](https://claude.com/claude-code)