### PR TITLE
Add Sarashina-TTS engine (Japanese-centric, zero-shot voice cloning)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -17,6 +17,7 @@ Google Colab 上で選択したローカル TTS を一時的に OpenAI 互換 `/
 | MOSS-TTS-Nano | 動作（出力が約2秒で切れる） | 日本語 / 英語 / 中国語 他 20言語 |
 | TinyTTS | 動作OK | 英語 |
 | Voxtral-TTS | 動作OK (GPU必須・VRAM 16GB+) | 英語 / フランス語 / スペイン語 他 9言語 |
+| Sarashina-TTS | 動作OK (GPU必須・VRAM ~6GB) | 日本語 / 英語 |
 | F5-TTS | 動作OK (GPU必須) | 英語 / 中国語（日本語は別モデル） |
 | Fish-Speech | 動作不可 | 日本語 / 英語 / 中国語 他 80言語以上 |
 | MeloTTS | 動作不可 | - |
@@ -55,7 +56,7 @@ REPO_URL = "https://github.com/shinshin86/local-tts-on-google-colab.git"  #@para
 REPO_REF = "main"  #@param {type:"string"}
 WORKDIR = "/content/local-tts-on-google-colab"  #@param {type:"string"}
 
-ENGINE = "Kokoro"  #@param ["Irodori-TTS", "Kokoro", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "Piper", "Piper-Plus", "Qwen3-TTS", "Style-Bert-VITS2", "TinyTTS", "Voxtral-TTS"]
+ENGINE = "Kokoro"  #@param ["Irodori-TTS", "Kokoro", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "Piper", "Piper-Plus", "Qwen3-TTS", "Sarashina-TTS", "Style-Bert-VITS2", "TinyTTS", "Voxtral-TTS"]
 EXPOSE_PUBLIC_URL = True  #@param {type:"boolean"}
 TEST_TEXT = "こんにちは。これは OpenAI 互換 TTS の動作確認です。"  #@param {type:"string"}
 TEST_SPEED = 1.0  #@param {type:"number"}
@@ -298,6 +299,19 @@ main()
 
 [mistralai/Voxtral-4B-TTS-2603](https://huggingface.co/mistralai/Voxtral-4B-TTS-2603) を使った多言語 TTS です。4B パラメータのモデルで、英語・フランス語・スペイン語・ドイツ語・イタリア語・ポルトガル語・オランダ語・アラビア語・ヒンディー語の 9 言語に対応しています。20 種類のプリセットボイスを内蔵し、wav / mp3 / flac / aac / opus など複数フォーマットに対応しています。バックエンドに vLLM + vllm-omni を使用します。GPU ランタイム（VRAM 16GB 以上）が必要です。Colab A100（VRAM 40GB）で動作確認済みですが、無料枠の T4（15GB）では VRAM 不足のため動作しない可能性があります。ライセンス: CC BY-NC 4.0（非商用のみ）。
 
+### Sarashina-TTS
+
+SB Intuitions の [sbintuitions/sarashina2.2-tts](https://huggingface.co/sbintuitions/sarashina2.2-tts) を使った日本語中心の TTS です。0.8B パラメータの LLM ベース TTS で、日本語（メイン）と英語に対応し、ゼロショット音声クローン機能を備えています。デフォルトの Hugging Face モデルは `sbintuitions/sarashina2.2-tts`。HuggingFace transformers バックエンドで VRAM ~6GB（Colab T4 で動作可能）、`--sarashina-use-vllm` を有効にすると vLLM バックエンドが使われ、より多くの VRAM を消費する代わりに高速になります。出力は 24kHz で、デフォルトでは SilentCipher の不可聴ウォーターマークが埋め込まれます — 上流モデル規約により除去・無効化は禁止されているのでそのまま利用してください。**ライセンス: Sarashina Model NonCommercial License Agreement（商用利用不可）。**
+
+`voice` パラメータには次の値を指定できます。
+
+| voice | 説明 |
+|---|---|
+| `default` | 参照音声なしの plain TTS（ゼロショットクローンなし） |
+| `clone` | ゼロショット音声クローン。`--sarashina-prompt-wav` と `--sarashina-prompt-text` の両方を指定したときのみ有効。テキストは参照音声の書き起こしを正確に渡してください |
+
+音声クローンを使う場合は、必ず権利を持っている音声（本人の同意がある音声）でのみ行ってください。
+
 ### F5-TTS
 
 [SWivid/F5-TTS](https://github.com/SWivid/F5-TTS) を使ったゼロショット音声クローニング TTS です。参照音声の声質を模倣して音声を生成します。パッケージ同梱のデフォルト参照音声（英語女性）を使用します。日本語モデルを使う場合は `--f5tts-ckpt-file` / `--f5tts-vocab-file` でコミュニティ提供の日本語チェックポイントを指定してください。GPU ランタイム（T4 以上）が必要です。ライセンス: コード MIT / モデル CC-BY-NC。
@@ -334,6 +348,7 @@ main()
 | NeuTTS | Apache 2.0 | Apache 2.0 (Air) / NeuTTS Open License 1.0 (Nano) | OK (Air) / 規約要確認 (Nano) | ボイスクローン。英 / 西 / 独 / 仏 |
 | TinyTTS | Apache 2.0 | Apache 2.0 | OK | |
 | Voxtral-TTS | — | CC BY-NC 4.0 | 不可 | vLLM + vllm-omni 経由。音声データセットのライセンス制約により非商用 |
+| Sarashina-TTS | — | Sarashina Model NonCommercial License | 不可 | 日本語 / 英語。ゼロショット音声クローン対応。出力には SilentCipher のウォーターマークが付与される（除去禁止） |
 | F5-TTS | MIT | CC-BY-NC | 不可（モデル） | モデル重みは Emilia データセットの制約により非商用 |
 | Fish-Speech | Apache 2.0 | Apache 2.0 | OK | A100/L4 GPU 必須（VRAM 24GB+） |
 
@@ -375,6 +390,8 @@ main()
   https://github.com/neuphonic/neutts
 - Voxtral-TTS
   https://huggingface.co/mistralai/Voxtral-4B-TTS-2603
+- Sarashina-TTS
+  https://github.com/sbintuitions/sarashina2.2-tts
 - F5-TTS
   https://github.com/SWivid/F5-TTS
 - Fish Speech

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Supported engines:
 | NeuTTS | Works (CPU OK, voice cloning) | English / Spanish / German / French |
 | TinyTTS | Works | English |
 | Voxtral-TTS | Works (GPU required, VRAM 16GB+) | English / French / Spanish and 9 languages |
+| Sarashina-TTS | Works (GPU required, ~6GB VRAM) | Japanese / English |
 | F5-TTS | Works (GPU required) | English / Chinese (Japanese via separate model) |
 | Fish-Speech | Not working | Japanese / English / Chinese and 80+ languages |
 | MeloTTS | Not working | - |
@@ -56,7 +57,7 @@ REPO_URL = "https://github.com/shinshin86/local-tts-on-google-colab.git"  #@para
 REPO_REF = "main"  #@param {type:"string"}
 WORKDIR = "/content/local-tts-on-google-colab"  #@param {type:"string"}
 
-ENGINE = "Kokoro"  #@param ["Irodori-TTS", "Kokoro", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "Piper", "Piper-Plus", "Qwen3-TTS", "Style-Bert-VITS2", "TinyTTS", "Voxtral-TTS"]
+ENGINE = "Kokoro"  #@param ["Irodori-TTS", "Kokoro", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "Piper", "Piper-Plus", "Qwen3-TTS", "Sarashina-TTS", "Style-Bert-VITS2", "TinyTTS", "Voxtral-TTS"]
 EXPOSE_PUBLIC_URL = True  #@param {type:"boolean"}
 TEST_TEXT = "こんにちは。これは OpenAI 互換 TTS の動作確認です。"  #@param {type:"string"}
 TEST_SPEED = 1.0  #@param {type:"number"}
@@ -299,6 +300,19 @@ An ultra-lightweight English TTS using [ecyht2/tiny-tts](https://github.com/ecyh
 
 A multilingual TTS using [mistralai/Voxtral-4B-TTS-2603](https://huggingface.co/mistralai/Voxtral-4B-TTS-2603). A 4B-parameter model supporting 9 languages: English, French, Spanish, German, Italian, Portuguese, Dutch, Arabic, and Hindi. It includes 20 preset voices and supports multiple formats such as wav / mp3 / flac / aac / opus. The backend uses vLLM + vllm-omni. A GPU runtime (VRAM 16GB or more) is required. Verified working on Colab A100 (40GB VRAM); may not work on the free-tier T4 (15GB) due to VRAM requirements. License: CC BY-NC 4.0 (non-commercial only).
 
+### Sarashina-TTS
+
+A Japanese-centric TTS using [sbintuitions/sarashina2.2-tts](https://huggingface.co/sbintuitions/sarashina2.2-tts) by SB Intuitions. An 0.8B-parameter LLM-based TTS supporting Japanese (primary) and English, with zero-shot voice cloning support. Default Hugging Face model: `sbintuitions/sarashina2.2-tts`. The HuggingFace transformers backend needs ~6GB VRAM (a Colab T4 fits); the optional vLLM backend (`--sarashina-use-vllm`) needs more VRAM but is faster. Generated audio is 24 kHz and contains an inaudible SilentCipher watermark by default — per the upstream model terms, do not remove it. **License: Sarashina Model NonCommercial License Agreement (commercial use prohibited).**
+
+The `voice` parameter exposes:
+
+| voice | description |
+|---|---|
+| `default` | Plain TTS without any reference audio (no zero-shot cloning). |
+| `clone` | Zero-shot voice cloning. Only available when both `--sarashina-prompt-wav` and `--sarashina-prompt-text` are configured. The transcript must match the reference audio. |
+
+For voice cloning, only use reference audio you have rights to (consent of the speaker).
+
 ### F5-TTS
 
 A zero-shot voice cloning TTS using [SWivid/F5-TTS](https://github.com/SWivid/F5-TTS). It mimics the voice quality of a reference audio to generate speech. Uses the default reference audio bundled with the package (English female). To use a Japanese model, specify a community-provided Japanese checkpoint with `--f5tts-ckpt-file` / `--f5tts-vocab-file`. A GPU runtime (T4 or higher) is required. License: code MIT / model CC-BY-NC.
@@ -335,6 +349,7 @@ The license for each engine is as follows. When using them, always check each pr
 | NeuTTS | Apache 2.0 | Apache 2.0 (Air) / NeuTTS Open License 1.0 (Nano) | OK (Air) / Check terms (Nano) | Voice cloning. EN / ES / DE / FR |
 | TinyTTS | Apache 2.0 | Apache 2.0 | OK | |
 | Voxtral-TTS | — | CC BY-NC 4.0 | Not allowed | Via vLLM + vllm-omni. Non-commercial due to voice dataset license constraints |
+| Sarashina-TTS | — | Sarashina Model NonCommercial License | Not allowed | Japanese / English. Zero-shot voice cloning. Output contains a SilentCipher watermark (do not remove) |
 | F5-TTS | MIT | CC-BY-NC | Not allowed (model) | Model weights are non-commercial due to Emilia dataset constraints |
 | Fish-Speech | Apache 2.0 | Apache 2.0 | OK | Requires A100/L4 GPU (VRAM 24GB+) |
 
@@ -376,6 +391,8 @@ This repository itself is intended for short-term operational verification and t
   https://github.com/neuphonic/neutts
 - Voxtral-TTS
   https://huggingface.co/mistralai/Voxtral-4B-TTS-2603
+- Sarashina-TTS
+  https://github.com/sbintuitions/sarashina2.2-tts
 - F5-TTS
   https://github.com/SWivid/F5-TTS
 - Fish Speech

--- a/colab/bootstrap.py
+++ b/colab/bootstrap.py
@@ -60,6 +60,11 @@ def parse_args():
     parser.add_argument("--voxtral-hf-model", default="mistralai/Voxtral-4B-TTS-2603")
     parser.add_argument("--voxtral-default-voice", default="neutral_female")
     parser.add_argument("--voxtral-backend-port", type=int, default=5001)
+    parser.add_argument("--sarashina-hf-model", default="sbintuitions/sarashina2.2-tts")
+    parser.add_argument("--sarashina-use-vllm", action="store_true")
+    parser.add_argument("--sarashina-prompt-wav", default="")
+    parser.add_argument("--sarashina-prompt-text", default="")
+    parser.add_argument("--sarashina-default-voice", default="default")
     parser.add_argument("--root-dir", default="/content/openai-compatible-local-tts")
     return parser.parse_args()
 
@@ -108,6 +113,11 @@ def main():
         voxtral_hf_model=args.voxtral_hf_model,
         voxtral_default_voice=args.voxtral_default_voice,
         voxtral_backend_port=args.voxtral_backend_port,
+        sarashina_hf_model=args.sarashina_hf_model,
+        sarashina_use_vllm=args.sarashina_use_vllm,
+        sarashina_prompt_wav=args.sarashina_prompt_wav,
+        sarashina_prompt_text=args.sarashina_prompt_text,
+        sarashina_default_voice=args.sarashina_default_voice,
         root_dir=Path(args.root_dir),
         repo_dir=REPO_DIR,
     )

--- a/multi_tts_openai_colab.py
+++ b/multi_tts_openai_colab.py
@@ -11,7 +11,7 @@ REPO_URL = "https://github.com/shinshin86/local-tts-on-google-colab.git"  #@para
 REPO_REF = "main"  #@param {type:"string"}
 WORKDIR = "/content/local-tts-on-google-colab"  #@param {type:"string"}
 
-ENGINE = "Kokoro"  #@param ["F5-TTS", "Fish-Speech", "Irodori-TTS", "Kokoro", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "Piper", "Piper-Plus", "Qwen3-TTS", "Style-Bert-VITS2", "TinyTTS", "VoxCPM2", "Voxtral-TTS"]
+ENGINE = "Kokoro"  #@param ["F5-TTS", "Fish-Speech", "Irodori-TTS", "Kokoro", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "Piper", "Piper-Plus", "Qwen3-TTS", "Sarashina-TTS", "Style-Bert-VITS2", "TinyTTS", "VoxCPM2", "Voxtral-TTS"]
 EXPOSE_PUBLIC_URL = True  #@param {type:"boolean"}
 TEST_TEXT = "こんにちは。これは OpenAI 互換 TTS の動作確認です。"  #@param {type:"string"}
 TEST_SPEED = 1.0  #@param {type:"number"}
@@ -85,6 +85,14 @@ MOSS_TTS_NANO_MODE = "continuation"  #@param ["continuation", "voice_clone"]
 NEUTTS_BACKBONE_REPO = "neuphonic/neutts-air"  #@param ["neuphonic/neutts-air", "neuphonic/neutts-nano", "neuphonic/neutts-nano-french", "neuphonic/neutts-nano-german", "neuphonic/neutts-nano-spanish"]
 NEUTTS_CODEC_REPO = "neuphonic/neucodec"  #@param {type:"string"}
 NEUTTS_DEFAULT_VOICE = "jo"  #@param ["dave", "jo", "greta", "juliette", "mateo"]
+
+#@markdown ---
+#@markdown Sarashina-TTS (GPU required, ~6GB VRAM, JP/EN, NonCommercial)
+SARASHINA_HF_MODEL = "sbintuitions/sarashina2.2-tts"  #@param {type:"string"}
+SARASHINA_USE_VLLM = False  #@param {type:"boolean"}
+SARASHINA_PROMPT_WAV = ""  #@param {type:"string"}
+SARASHINA_PROMPT_TEXT = ""  #@param {type:"string"}
+SARASHINA_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
 
 import shlex
 import subprocess
@@ -194,7 +202,17 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         NEUTTS_CODEC_REPO,
         "--neutts-default-voice",
         NEUTTS_DEFAULT_VOICE,
+        "--sarashina-hf-model",
+        SARASHINA_HF_MODEL,
+        "--sarashina-prompt-wav",
+        SARASHINA_PROMPT_WAV,
+        "--sarashina-prompt-text",
+        SARASHINA_PROMPT_TEXT,
+        "--sarashina-default-voice",
+        SARASHINA_DEFAULT_VOICE,
     ]
+    if SARASHINA_USE_VLLM:
+        cmd.append("--sarashina-use-vllm")
     cmd.append("--expose-public-url" if EXPOSE_PUBLIC_URL else "--no-expose-public-url")
     return cmd
 

--- a/src/apps/sarashina_tts_app.py
+++ b/src/apps/sarashina_tts_app.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import io
+import logging
+import os
+import wave
+from pathlib import Path
+from typing import Any
+
+import torch
+from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+from sarashina_tts.generate.generate import SarashinaTTSGenerator
+
+logger = logging.getLogger("uvicorn.error")
+
+OPENAI_MODEL_ID = os.environ.get("OPENAI_MODEL_ID", "sarashina-tts")
+SARASHINA_HF_MODEL = os.environ.get("SARASHINA_HF_MODEL", "sbintuitions/sarashina2.2-tts")
+SARASHINA_USE_VLLM = os.environ.get("SARASHINA_USE_VLLM", "0") == "1"
+SARASHINA_PROMPT_WAV = os.environ.get("SARASHINA_PROMPT_WAV", "").strip()
+SARASHINA_PROMPT_TEXT = os.environ.get("SARASHINA_PROMPT_TEXT", "").strip()
+SARASHINA_DEFAULT_VOICE = os.environ.get("SARASHINA_DEFAULT_VOICE", "default").strip() or "default"
+SARASHINA_MODEL_DIR = os.environ.get("SARASHINA_MODEL_DIR", "").strip()
+
+SAMPLE_RATE = 24000
+
+# Voice presets:
+#   - "default": plain TTS without any voice prompt (no zero-shot cloning).
+#   - "clone"  : zero-shot voice cloning, only available when both
+#                SARASHINA_PROMPT_WAV and SARASHINA_PROMPT_TEXT are configured.
+VOICE_DEFAULT = "default"
+VOICE_CLONE = "clone"
+
+app = FastAPI(title="Sarashina-TTS OpenAI Compatible TTS")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[],
+    allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
+    allow_credentials=False,
+    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_headers=["*"],
+    expose_headers=["x-openai-model", "x-openai-voice"],
+)
+
+
+class AudioSpeechRequest(BaseModel):
+    model: str = OPENAI_MODEL_ID
+    input: str
+    voice: str | None = None
+    response_format: str = "wav"
+    speed: float = 1.0
+
+
+_generator: SarashinaTTSGenerator | None = None
+_clone_cache: tuple[Any, Any, Any] | None = None
+
+
+def _has_clone_voice() -> bool:
+    return bool(SARASHINA_PROMPT_WAV) and bool(SARASHINA_PROMPT_TEXT)
+
+
+def get_generator() -> SarashinaTTSGenerator:
+    global _generator
+    if _generator is None:
+        kwargs: dict[str, Any] = {
+            "model_id": SARASHINA_HF_MODEL,
+            "use_vllm": SARASHINA_USE_VLLM,
+        }
+        if SARASHINA_MODEL_DIR:
+            kwargs["model_dir"] = SARASHINA_MODEL_DIR
+        logger.info(
+            "Loading Sarashina-TTS: model_id=%s use_vllm=%s",
+            SARASHINA_HF_MODEL,
+            SARASHINA_USE_VLLM,
+        )
+        _generator = SarashinaTTSGenerator(**kwargs)
+        logger.info("Sarashina-TTS generator loaded")
+    return _generator
+
+
+def get_clone_features(generator: SarashinaTTSGenerator) -> tuple[Any, Any, Any]:
+    global _clone_cache
+    if _clone_cache is None:
+        wav_path = Path(SARASHINA_PROMPT_WAV)
+        if not wav_path.is_file():
+            raise HTTPException(
+                status_code=500,
+                detail=f"Configured SARASHINA_PROMPT_WAV not found: {wav_path}",
+            )
+        logger.info("Encoding voice clone reference from %s", wav_path)
+        flow_embedding = generator._extract_zero_shot_embedding(str(wav_path))
+        prompt_tokens = generator._extract_audio_prompt_tokens(str(wav_path))
+        prompt_feat = generator._extract_audio_prompt_feat(str(wav_path))
+        _clone_cache = (flow_embedding, prompt_tokens, prompt_feat)
+    return _clone_cache
+
+
+def _to_wav_bytes(audio: torch.Tensor) -> bytes:
+    if audio.ndim == 1:
+        audio = audio.unsqueeze(0)
+    elif audio.ndim != 2:
+        raise HTTPException(status_code=500, detail=f"Unexpected audio tensor shape: {tuple(audio.shape)}")
+
+    audio = torch.clamp(audio.detach().to("cpu", torch.float32), -1.0, 1.0)
+    audio_i16 = (audio * 32767.0).round().to(torch.int16)
+
+    num_channels, _ = audio_i16.shape
+    interleaved = audio_i16.transpose(0, 1).contiguous().numpy().tobytes()
+
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(num_channels)
+        wf.setsampwidth(2)
+        wf.setframerate(SAMPLE_RATE)
+        wf.writeframes(interleaved)
+    return buf.getvalue()
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, exc: Exception):
+    logger.exception("Unhandled exception while serving request")
+    return JSONResponse(
+        status_code=500,
+        content={"error": type(exc).__name__, "detail": str(exc)},
+    )
+
+
+@app.get("/")
+def root():
+    return {
+        "ok": True,
+        "engine": "Sarashina-TTS",
+        "model": OPENAI_MODEL_ID,
+        "hf_model": SARASHINA_HF_MODEL,
+        "default_voice": SARASHINA_DEFAULT_VOICE,
+        "clone_voice_available": _has_clone_voice(),
+    }
+
+
+@app.get("/v1/models")
+def list_models():
+    return {
+        "object": "list",
+        "data": [{"id": OPENAI_MODEL_ID, "object": "model", "owned_by": "sbintuitions"}],
+    }
+
+
+@app.get("/v1/voices")
+def list_voices():
+    voices = [{"id": VOICE_DEFAULT, "object": "voice", "language": "ja"}]
+    if _has_clone_voice():
+        voices.append({"id": VOICE_CLONE, "object": "voice", "language": "ja"})
+    return {"object": "list", "data": voices}
+
+
+@app.post("/v1/audio/speech")
+async def audio_speech(payload: AudioSpeechRequest):
+    if payload.response_format.lower() != "wav":
+        raise HTTPException(status_code=400, detail="This wrapper currently supports only wav.")
+
+    voice = (payload.voice or SARASHINA_DEFAULT_VOICE).strip() or VOICE_DEFAULT
+    if voice not in {VOICE_DEFAULT, VOICE_CLONE}:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown voice '{voice}'. Available: ['default'] + (['clone'] if configured)",
+        )
+    if voice == VOICE_CLONE and not _has_clone_voice():
+        raise HTTPException(
+            status_code=400,
+            detail="Voice 'clone' requested but SARASHINA_PROMPT_WAV / SARASHINA_PROMPT_TEXT are not configured.",
+        )
+
+    generator = get_generator()
+
+    decode_kwargs = {"speed": payload.speed} if payload.speed and payload.speed > 0 else {}
+
+    if voice == VOICE_CLONE:
+        flow_embedding, prompt_tokens, prompt_feat = get_clone_features(generator)
+        wavs = generator.generate(
+            texts=[payload.input],
+            flow_embedding=flow_embedding,
+            audio_prompt_text=SARASHINA_PROMPT_TEXT,
+            audio_prompt_tokens=prompt_tokens,
+            audio_prompt_feat=prompt_feat,
+            audio_prompt_path=SARASHINA_PROMPT_WAV,
+            decode_kwargs=decode_kwargs or None,
+        )
+    else:
+        wavs = generator.generate(
+            texts=[payload.input],
+            flow_embedding=None,
+            decode_kwargs=decode_kwargs or None,
+        )
+
+    if not wavs:
+        raise HTTPException(status_code=500, detail="No audio was generated.")
+
+    audio = wavs[0]
+    if not torch.is_tensor(audio) or audio.numel() == 0:
+        raise HTTPException(status_code=500, detail="Generated audio is empty.")
+
+    audio_bytes = _to_wav_bytes(audio)
+
+    return Response(
+        content=audio_bytes,
+        media_type="audio/wav",
+        headers={
+            "Content-Length": str(len(audio_bytes)),
+            "x-openai-model": payload.model,
+            "x-openai-voice": voice,
+        },
+    )

--- a/src/config.py
+++ b/src/config.py
@@ -81,6 +81,11 @@ class Settings:
     voxtral_hf_model: str = "mistralai/Voxtral-4B-TTS-2603"
     voxtral_default_voice: str = "neutral_female"
     voxtral_backend_port: int = 5001
+    sarashina_hf_model: str = "sbintuitions/sarashina2.2-tts"
+    sarashina_use_vllm: bool = False
+    sarashina_prompt_wav: str = ""
+    sarashina_prompt_text: str = ""
+    sarashina_default_voice: str = "default"
     root_dir: Path = Path("/content/openai-compatible-local-tts")
     repo_dir: Path = field(default_factory=default_repo_dir)
     app_port: int = 8000

--- a/src/installers/__init__.py
+++ b/src/installers/__init__.py
@@ -8,6 +8,7 @@ from .moss_tts_nano import install as install_moss_tts_nano
 from .neutts import install as install_neutts
 from .piper import install as install_piper
 from .piper_plus import install as install_piper_plus
+from .sarashina_tts import install as install_sarashina_tts
 from .style_bert import install as install_style_bert
 from .voxcpm import install as install_voxcpm
 from .tiny_tts import install as install_tiny_tts
@@ -26,6 +27,7 @@ INSTALLERS = {
     "Piper": install_piper,
     "Piper-Plus": install_piper_plus,
     "Qwen3-TTS": install_qwen3_tts,
+    "Sarashina-TTS": install_sarashina_tts,
     "TinyTTS": install_tiny_tts,
     "VoxCPM2": install_voxcpm,
     "Voxtral-TTS": install_voxtral,

--- a/src/installers/sarashina_tts.py
+++ b/src/installers/sarashina_tts.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import os
+
+from src.config import Settings
+from src.runtime import ensure_git_clone, ensure_venv, popen, uv_pip_install, write_text
+
+
+SARASHINA_REPO_URL = "https://github.com/sbintuitions/sarashina2.2-tts.git"
+
+
+def install(settings: Settings) -> dict:
+    engine_dir = settings.engines_dir / "sarashina-tts"
+    engine_dir.mkdir(parents=True, exist_ok=True)
+
+    repo_dir = engine_dir / "sarashina2.2-tts"
+    ensure_git_clone(SARASHINA_REPO_URL, repo_dir)
+
+    python_bin = ensure_venv(engine_dir)
+
+    # Install the upstream package as editable. pyproject pins core deps
+    # (torch<=2.9, transformers, librosa, s3tokenizer, diffusers, silentcipher git, ...).
+    install_spec = f"-e {repo_dir}"
+    if settings.sarashina_use_vllm:
+        install_spec = f"-e {repo_dir}[vllm]"
+    uv_pip_install(python_bin, [install_spec])
+    uv_pip_install(python_bin, ["fastapi", "uvicorn"])
+
+    write_text(engine_dir / "app.py", settings.read_repo_text("src/apps/sarashina_tts_app.py"))
+
+    env = {
+        **os.environ,
+        "PYTHONUNBUFFERED": "1",
+        "OPENAI_MODEL_ID": settings.openai_model_id or "sarashina-tts",
+        "SARASHINA_HF_MODEL": settings.sarashina_hf_model,
+        "SARASHINA_USE_VLLM": "1" if settings.sarashina_use_vllm else "0",
+        "SARASHINA_PROMPT_WAV": settings.sarashina_prompt_wav,
+        "SARASHINA_PROMPT_TEXT": settings.sarashina_prompt_text,
+        "SARASHINA_DEFAULT_VOICE": settings.sarashina_default_voice,
+        "SARASHINA_MODEL_DIR": str(engine_dir / "pretrained_models"),
+    }
+    proc = popen(
+        [
+            str(engine_dir / ".venv" / "bin" / "uvicorn"),
+            "app:app",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            str(settings.app_port),
+            "--log-level",
+            "info",
+        ],
+        cwd=str(engine_dir),
+        env=env,
+        log_path=settings.log_dir / "sarashina-tts-uvicorn.log",
+    )
+    return {
+        "proc": proc,
+        "app_dir": engine_dir,
+        "log_path": settings.log_dir / "sarashina-tts-uvicorn.log",
+    }

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -30,6 +30,8 @@ def resolve_selected_voice(settings: Settings) -> str:
         return settings.melo_default_voice
     if settings.engine == "NeuTTS":
         return settings.neutts_default_voice
+    if settings.engine == "Sarashina-TTS":
+        return settings.sarashina_default_voice
     return ""
 
 
@@ -91,6 +93,19 @@ def print_engine_voice_hints(settings: Settings):
         print("対応言語: 英語 / 西語 / 独語 / 仏語（日本語非対応）。")
         print("注意: 非英語の voice を使う場合は、対応言語の Nano backbone を指定してください。")
         print("ライセンス: neutts-air=Apache-2.0 / neutts-nano=NeuTTS Open License 1.0")
+    elif settings.engine == "Sarashina-TTS":
+        print("Sarashina-TTS は SB Intuitions の日本語中心 TTS です（日本語＋英語、ゼロショット音声クローン対応）。")
+        print(f"モデル: {settings.sarashina_hf_model}")
+        print(f"vLLM backend: {'有効' if settings.sarashina_use_vllm else '無効（HuggingFace transformers）'}")
+        print(f"デフォルト voice: {settings.sarashina_default_voice}")
+        print("voice 候補: default（プロンプトなしの plain TTS）")
+        if settings.sarashina_prompt_wav and settings.sarashina_prompt_text:
+            print(f"             clone（参照音声: {settings.sarashina_prompt_wav}）")
+        else:
+            print("             clone は --sarashina-prompt-wav / --sarashina-prompt-text を指定すると有効になります")
+        print("注意: GPU 推奨（VRAM ~6GB / vLLM はさらに必要）。日本語は MOS が高い tier 1 サポート。")
+        print("ライセンス: Sarashina Model NonCommercial License Agreement（商用利用不可）")
+        print("生成音声には SilentCipher による不可聴ウォーターマークが埋め込まれます（モデル規約により除去禁止）。")
     elif settings.engine == "MOSS-TTS-Nano":
         print("MOSS-TTS-Nano は OpenMOSS の軽量 TTS です（100M パラメータ、20言語対応、CPU 動作）。")
         print(f"モデル: {settings.moss_tts_nano_hf_model}")


### PR DESCRIPTION
## Summary

- Wraps [`sbintuitions/sarashina2.2-tts`](https://huggingface.co/sbintuitions/sarashina2.2-tts) as an OpenAI-compatible `/v1/audio/speech` endpoint. 0.8B-parameter LLM-based TTS, Japanese (primary) + English, with zero-shot voice cloning support.
- Defaults to plain TTS (`voice=default`, no reference audio); zero-shot cloning is opt-in via `--sarashina-prompt-wav` and `--sarashina-prompt-text` (exposed as `voice=clone`).
- Output is 24 kHz WAV. The upstream SilentCipher watermark is left intact per the model's terms — do not remove.
- License: Sarashina Model NonCommercial License Agreement (commercial use prohibited). README license tables updated accordingly.

## Verified on Colab (L4 GPU, ~23 GB VRAM)

- Bootstrap from `feat/sarashina-tts` succeeded end-to-end on a fresh runtime.
- Endpoints verified: `GET /` / `GET /v1/models` / `GET /v1/voices` / `POST /v1/audio/speech` (200 OK, WAV returned).
- Generation profile for a ~60-character mixed JP/EN test sentence: LLM 8.90 s + Flow/HiFT decode 0.93 s + watermark 0.29 s = **10.11 s total, RTF 0.810**.
- `✓ SilentCipher watermark applied` confirmed in logs.
- cloudflared public URL exposed and reachable.

## Test plan

- [x] `python colab/bootstrap.py --engine Sarashina-TTS --dry-run` summary is correct
- [x] Bootstrap on Colab GPU runtime (L4) — server starts, `/v1/voices` returns `default`
- [x] `POST /v1/audio/speech` returns valid 24 kHz WAV in default mode
- [x] cloudflared public URL works
- [ ] (Optional, future) Verify `voice=clone` end-to-end with a user-provided reference audio + transcript