### PR TITLE
Add 6 new TTS engines (Chatterbox, Zonos, OuteTTS, Dia, OpenVoice V2, VibeVoice)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,109 @@
+# CLAUDE.md
+
+Repository-specific operational rules for Claude Code. These take precedence
+over default behavior.
+
+## Repository at a glance
+
+This repo wraps several local TTS engines as an OpenAI-compatible
+`/v1/audio/speech` endpoint, intended to be launched on Google Colab. The
+codebase is organized as:
+
+- `colab/bootstrap.py` — entrypoint invoked from a Colab cell. Parses CLI flags
+  and dispatches to the selected engine.
+- `multi_tts_openai_colab.py` — canonical Colab cell. **Source of truth** for
+  the embedded cells in `README.md` / `README.ja.md`.
+- `src/config.py` — `Settings` dataclass holding every engine's tunables.
+- `src/installers/<engine>.py` — clones / pip-installs the upstream engine,
+  spawns its uvicorn process, returns a state dict.
+- `src/installers/__init__.py` — `INSTALLERS` registry. Engine names here are
+  what the `--engine` flag accepts.
+- `src/apps/<engine>_app.py` — FastAPI app implementing `/v1/audio/speech`.
+- `src/launcher.py` — orchestrates install → wait_http → smoke test → optional
+  cloudflared. Also owns the per-engine voice resolution + hint text.
+- `src/runtime.py` — shared shell / venv / cloudflared helpers.
+
+## Mandatory procedure when adding (or changing) an engine
+
+When the user asks to add a new TTS engine, or modify an existing one, you
+**must** complete every step below before declaring the work done. Skipping
+the Colab verification step is not acceptable, because nothing in this repo is
+exercised on the developer's local machine.
+
+1. **Verify the upstream license** — fetch the GitHub LICENSE file *and* every
+   Hugging Face model card you intend to ship as a default. Code license and
+   weights license can differ; weights license can differ between model sizes
+   (this bit us with OuteTTS: 0.6B is Apache 2.0 but the 1B Llama-based
+   variant is CC-BY-NC-SA-4.0 + Llama Community License). Record both in the
+   README license table.
+2. **Implement the engine** in the standard layout:
+   - `src/installers/<engine>.py`
+   - `src/apps/<engine>_app.py`
+   - Register in `src/installers/__init__.py`
+   - Add tunables to `src/config.py` (`Settings` dataclass)
+   - Add CLI flags + Settings-kwarg passthrough in `colab/bootstrap.py`
+   - Add `resolve_selected_voice` branch + `print_engine_voice_hints` block in
+     `src/launcher.py`
+   - Add form params + cmd args in `multi_tts_openai_colab.py`
+3. **Update the READMEs** in *both* `README.md` and `README.ja.md`:
+   - Supported-engines table row (Colab status + languages)
+   - Engine-specific notes section
+   - License table row (separate rows per model variant if licenses differ)
+   - References list link at the bottom
+4. **Sync the embedded Colab cells**. `multi_tts_openai_colab.py` is the
+   source of truth; the cells inside `README.md` and `README.ja.md` must
+   match it byte-for-byte. The mechanical sync looks like:
+
+   ```bash
+   python3 - <<'PY'
+   import pathlib
+   src = pathlib.Path("multi_tts_openai_colab.py").read_text(encoding="utf-8")
+   cell = "".join(src.splitlines(keepends=True)[8:])  # drop the 7-line docstring + blank line
+   if not cell.endswith("\n"):
+       cell += "\n"
+   for r in ["README.md", "README.ja.md"]:
+       p = pathlib.Path(r)
+       text = p.read_text(encoding="utf-8")
+       s = text.find("#@title Local TTS on Google Colab")
+       e = text.find("\nmain()\n", s) + len("\nmain()\n")
+       p.write_text(text[:s] + cell + text[e:], encoding="utf-8")
+   PY
+   ```
+
+   Run this any time you touch `multi_tts_openai_colab.py`.
+5. **Commit per engine**, with English commit messages. Mention the license
+   findings explicitly when they differ between code and weights, or between
+   model sizes.
+6. **Push** the feature branch (`git push -u origin <branch>`) before testing.
+   Colab pulls from the remote, so verification can't run against unpushed
+   commits.
+7. **Verify on Google Colab** using the Colab MCP. Do *not* attempt to run
+   `bootstrap.py` or any engine locally — the engines target Linux + CUDA +
+   Colab's preinstalled toolchain. Instead:
+   - Call `mcp__colab-mcp__open_colab_browser_connection` to attach.
+   - Open or create a notebook, set `REPO_REF` to the feature branch name.
+   - Run the cell, confirm the trycloudflare public URL appears, and exercise
+     `/v1/audio/speech` against that public URL (this is the contract the repo
+     is built around — local-only validation does not count).
+   - Capture failures (logs, stack traces, OOM messages) before iterating.
+8. **Open a PR** with an English title and body summarizing the new engine,
+   its license, and the Colab verification result. Always link the trycloudflare
+   verification.
+
+## Conventions
+
+- **PR titles and descriptions are written in English** for this repo.
+- **Never run engines or `colab/bootstrap.py` locally.** It will not work and
+  it is not the supported environment. All functional verification happens on
+  Google Colab.
+- Engine names use upper camel / hyphenated form (`Chatterbox`, `OpenVoice-V2`,
+  `MOSS-TTS-Nano`). Match what's already in the `INSTALLERS` registry.
+- Voice presets are exposed as the OpenAI `voice` parameter. The convention is
+  `default` (no reference / built-in speaker) and `clone` (uses
+  `--<engine>-prompt-wav` and possibly `--<engine>-prompt-text`). If `clone`
+  is unavailable because the user did not configure a prompt wav, return a
+  4xx with a clear message rather than silently falling back.
+- Watermarks and inaudible markers (e.g. SilentCipher in Sarashina-TTS) must
+  not be removed — surface the requirement in the engine's README section.
+- Every engine must work behind a `trycloudflare` public URL — this is the
+  product's primary contract, not a nice-to-have.

--- a/README.ja.md
+++ b/README.ja.md
@@ -368,6 +368,19 @@ Resemble AI の [resemble-ai/chatterbox](https://github.com/resemble-ai/chatterb
 
 音声クローンを使う場合は、必ず権利を持っている音声（本人の同意がある音声）でのみ行ってください。
 
+### Dia
+
+[nari-labs/dia](https://github.com/nari-labs/dia) を使った対話特化 TTS です。1.6B パラメータのモデルで、`[S1]` / `[S2]` 話者タグをプロンプトに含めることで、マルチスピーカー対話を 1 パスで生成します。現状は英語のみ対応。入力に話者タグが無い場合はラッパーが先頭に `[S1]` を自動挿入するので、シングルスピーカーの平文 TTS としても利用できます。デフォルトモデル: `nari-labs/Dia-1.6B-0626`。`--dia-prompt-wav` と `--dia-prompt-text` の両方を指定すると `clone` voice が有効になり、参照音声で声色を条件付けられます。GPU 推奨（VRAM ~4.4GB at float16/bfloat16、~7.9GB at float32）。ライセンス: Apache 2.0（コードと重み）。
+
+`voice` パラメータには次の値を指定できます。
+
+| voice | 説明 |
+|---|---|
+| `default` | 参照音声なしの plain TTS。`input` に `[S1]` / `[S2]` を含めるとマルチスピーカー対話になります |
+| `clone` | 音声クローン。`--dia-prompt-wav` と `--dia-prompt-text` の両方が必要 |
+
+音声クローンを使う場合は、必ず権利を持っている音声（本人の同意がある音声）でのみ行ってください。
+
 ### Fish-Speech (現在動作不可)
 
 [fishaudio/fish-speech](https://github.com/fishaudio/fish-speech) を使った高品質 TTS です。日本語は Tier 1 サポート（最高品質）で、80 言語以上に対応しています。VRAM 24GB 以上が必要で A100/L4 GPU を想定していますが、Colab 環境ではモデルロード時に OOM（メモリ不足）でランタイムがクラッシュするため、現時点では動作しません。ライセンス: Apache 2.0。

--- a/README.ja.md
+++ b/README.ja.md
@@ -24,6 +24,7 @@ Google Colab 上で選択したローカル TTS を一時的に OpenAI 互換 `/
 | OuteTTS | 動作OK (CPU可) | 日本語 / 英語 / 中国語 他 多言語 |
 | Dia | 動作OK (GPU推奨) | 英語（マルチスピーカー対話） |
 | OpenVoice-V2 | 動作要注意（MeloTTS 依存） | 日本語 / 英語 / 西 / 仏 / 中 / 韓 |
+| VibeVoice | 動作OK (GPU必須・research-only ライセンス) | 英語 / 中国語（長尺・最大 4 話者） |
 | Fish-Speech | 動作不可 | 日本語 / 英語 / 中国語 他 80言語以上 |
 | MeloTTS | 動作不可 | - |
 | Style-Bert-VITS2 | 動作不可 | - |
@@ -397,6 +398,21 @@ Resemble AI の [resemble-ai/chatterbox](https://github.com/resemble-ai/chatterb
 
 音声クローンを使う場合は、必ず権利を持っている音声（本人の同意がある音声）でのみ行ってください。
 
+### VibeVoice
+
+[microsoft/VibeVoice](https://github.com/microsoft/VibeVoice) を使った長尺・マルチスピーカー対応 TTS です。1.5B パラメータのモデルで、最大 4 話者・約 90 分の音声を 1 パスで生成できます（ポッドキャストや長尺対話向け）。各話者は短い参照音声で条件付けされます。デフォルト voice は upstream に同梱の `demo/voices/<VIBEVOICE_DEFAULT_SPEAKER>.wav`（例: `en-Alice_woman`）を参照として使用し、`--vibevoice-prompt-wav` を指定すると `clone` voice が独自参照に切り替わります。マルチスピーカー対話を使う場合は `input` を `Speaker 1: ...\nSpeaker 2: ...` 形式にしてください（平文の場合はラッパーが自動で `Speaker 1:` を先頭に追加）。GPU 必須（bf16）。チューニング項目: `--vibevoice-ddpm-steps`（デフォルト 10）、`--vibevoice-cfg-scale`（デフォルト 1.3）。
+
+**ライセンス注意:** コード / 重みとも MIT ですが、Microsoft 公式モデルカードに **「research purpose only」** と明記されており、英語・中国語以外の言語、なりすまし、ディスインフォメーション、リアルタイム音声変換などは禁止されています。本エンジンは研究 / 評価目的の利用のみに留めてください。
+
+`voice` パラメータには次の値を指定できます。
+
+| voice | 説明 |
+|---|---|
+| `default` | upstream に同梱の `demo/voices/<--vibevoice-default-speaker>.wav` を参照音声として使用 |
+| `clone` | `--vibevoice-prompt-wav` を参照音声として使用（指定時のみ有効） |
+
+音声クローンを使う場合は、必ず権利を持っている音声（本人の同意がある音声）でのみ行ってください。
+
 ### Fish-Speech (現在動作不可)
 
 [fishaudio/fish-speech](https://github.com/fishaudio/fish-speech) を使った高品質 TTS です。日本語は Tier 1 サポート（最高品質）で、80 言語以上に対応しています。VRAM 24GB 以上が必要で A100/L4 GPU を想定していますが、Colab 環境ではモデルロード時に OOM（メモリ不足）でランタイムがクラッシュするため、現時点では動作しません。ライセンス: Apache 2.0。
@@ -437,6 +453,7 @@ Resemble AI の [resemble-ai/chatterbox](https://github.com/resemble-ai/chatterb
 | OuteTTS (1B)   | Apache 2.0 | CC-BY-NC-SA-4.0 + Llama 3.2 Community License | 不可 | Llama-3.2 ベース。重みは非商用 |
 | Dia | Apache 2.0 | Apache 2.0 | OK | 英語のみ。`[S1]`/`[S2]` でマルチスピーカー対話 TTS |
 | OpenVoice-V2 | MIT | MIT | OK | 多言語（日本語含む）。voice cloning。MeloTTS 依存（環境次第で導入不可） |
+| VibeVoice | MIT | MIT | 要注意（research-only） | 英 / 中のみ。Microsoft 公式に「research purpose only」と明記 |
 | Fish-Speech | Apache 2.0 | Apache 2.0 | OK | A100/L4 GPU 必須（VRAM 24GB+） |
 
 **Piper について**: `piper-tts` パッケージは GPL-3.0 です。また、デフォルトの `en_US-lessac-medium` 音声は Lessac Technologies 提供の Blizzard 2013 データセットで学習されており、このデータセットのライセンスは商用利用を禁止しています。商用利用が必要な場合は、許容的なライセンスで学習された別の voice モデルを選択してください。
@@ -491,6 +508,8 @@ Resemble AI の [resemble-ai/chatterbox](https://github.com/resemble-ai/chatterb
   https://github.com/nari-labs/dia
 - OpenVoice
   https://github.com/myshell-ai/OpenVoice
+- VibeVoice
+  https://github.com/microsoft/VibeVoice
 - Fish Speech
   https://github.com/fishaudio/fish-speech
 - CosyVoice

--- a/README.ja.md
+++ b/README.ja.md
@@ -22,6 +22,7 @@ Google Colab 上で選択したローカル TTS を一時的に OpenAI 互換 `/
 | Chatterbox | 動作OK (GPU推奨) | 日本語 / 英語 / 中国語 他 23言語 |
 | Zonos | 動作OK (GPU必須・VRAM ~6GB) | 日本語 / 英語 / 中国語 / フランス語 / ドイツ語 |
 | OuteTTS | 動作OK (CPU可) | 日本語 / 英語 / 中国語 他 多言語 |
+| Dia | 動作OK (GPU推奨) | 英語（マルチスピーカー対話） |
 | Fish-Speech | 動作不可 | 日本語 / 英語 / 中国語 他 80言語以上 |
 | MeloTTS | 動作不可 | - |
 | Style-Bert-VITS2 | 動作不可 | - |
@@ -405,6 +406,7 @@ Resemble AI の [resemble-ai/chatterbox](https://github.com/resemble-ai/chatterb
 | Zonos | Apache 2.0 | Apache 2.0 | OK | 英 / 日 / 中 / 仏 / 独。ゼロショット voice cloning。`espeak-ng` 必須 |
 | OuteTTS (0.6B) | Apache 2.0 | Apache 2.0 | OK | 日本語含む多言語、CPU 動作可、voice cloning |
 | OuteTTS (1B)   | Apache 2.0 | CC-BY-NC-SA-4.0 + Llama 3.2 Community License | 不可 | Llama-3.2 ベース。重みは非商用 |
+| Dia | Apache 2.0 | Apache 2.0 | OK | 英語のみ。`[S1]`/`[S2]` でマルチスピーカー対話 TTS |
 | Fish-Speech | Apache 2.0 | Apache 2.0 | OK | A100/L4 GPU 必須（VRAM 24GB+） |
 
 **Piper について**: `piper-tts` パッケージは GPL-3.0 です。また、デフォルトの `en_US-lessac-medium` 音声は Lessac Technologies 提供の Blizzard 2013 データセットで学習されており、このデータセットのライセンスは商用利用を禁止しています。商用利用が必要な場合は、許容的なライセンスで学習された別の voice モデルを選択してください。
@@ -455,6 +457,8 @@ Resemble AI の [resemble-ai/chatterbox](https://github.com/resemble-ai/chatterb
   https://github.com/Zyphra/Zonos
 - OuteTTS
   https://github.com/edwko/OuteTTS
+- Dia
+  https://github.com/nari-labs/dia
 - Fish Speech
   https://github.com/fishaudio/fish-speech
 - CosyVoice

--- a/README.ja.md
+++ b/README.ja.md
@@ -347,7 +347,16 @@ Resemble AI の [resemble-ai/chatterbox](https://github.com/resemble-ai/chatterb
 
 ### OuteTTS
 
-[edwko/OuteTTS](https://github.com/edwko/OuteTTS) を使った軽量多言語 TTS です。日本語を含む多言語に対応し、モデルサイズ（`0.6B` / `1B`）と backend（`HF` = transformers / `LLAMACPP` = GGUF）を選択できます。`--outetts-prompt-wav`（必要なら `--outetts-prompt-text` も）で voice cloning を有効にできます。デフォルト voice は `--outetts-default-speaker`（例: `EN-FEMALE-1-NEUTRAL`）で内蔵 speaker プロファイルを切り替えられます。日本語を発話させる場合は、日本語の参照音声から `clone` で speaker プロファイルを作るのが推奨です。CPU / GPU の両方で動作します。ライセンス: Apache 2.0（コードと重み）。
+[edwko/OuteTTS](https://github.com/edwko/OuteTTS) を使った軽量多言語 TTS です。日本語を含む多言語に対応し、モデルサイズ（`0.6B` / `1B`）と backend（`HF` = transformers / `LLAMACPP` = GGUF）を選択できます。`--outetts-prompt-wav`（必要なら `--outetts-prompt-text` も）で voice cloning を有効にできます。デフォルト voice は `--outetts-default-speaker`（例: `EN-FEMALE-1-NEUTRAL`）で内蔵 speaker プロファイルを切り替えられます。日本語を発話させる場合は、日本語の参照音声から `clone` で speaker プロファイルを作るのが推奨です。CPU / GPU の両方で動作します。
+
+**ライセンス（モデルサイズで異なります）:**
+
+| モデル | コード | モデル重み | 商用利用 |
+|---|---|---|---|
+| `OuteAI/OuteTTS-1.0-0.6B` | Apache 2.0 | Apache 2.0 | OK |
+| `OuteAI/Llama-OuteTTS-1.0-1B` | Apache 2.0 | CC-BY-NC-SA-4.0 + Llama 3.2 Community License | **不可** |
+
+このラッパーのデフォルトサイズは `0.6B`（Apache 2.0）です。`1B` に切り替えると重みが非商用ライセンスになります。
 
 `voice` パラメータには次の値を指定できます。
 
@@ -394,7 +403,8 @@ Resemble AI の [resemble-ai/chatterbox](https://github.com/resemble-ai/chatterb
 | F5-TTS | MIT | CC-BY-NC | 不可（モデル） | モデル重みは Emilia データセットの制約により非商用 |
 | Chatterbox | MIT | MIT | OK | 多言語（23言語、日本語含む）。ゼロショット voice cloning |
 | Zonos | Apache 2.0 | Apache 2.0 | OK | 英 / 日 / 中 / 仏 / 独。ゼロショット voice cloning。`espeak-ng` 必須 |
-| OuteTTS | Apache 2.0 | Apache 2.0 | OK | 0.6B / 1B。日本語含む多言語、CPU 動作可、voice cloning |
+| OuteTTS (0.6B) | Apache 2.0 | Apache 2.0 | OK | 日本語含む多言語、CPU 動作可、voice cloning |
+| OuteTTS (1B)   | Apache 2.0 | CC-BY-NC-SA-4.0 + Llama 3.2 Community License | 不可 | Llama-3.2 ベース。重みは非商用 |
 | Fish-Speech | Apache 2.0 | Apache 2.0 | OK | A100/L4 GPU 必須（VRAM 24GB+） |
 
 **Piper について**: `piper-tts` パッケージは GPL-3.0 です。また、デフォルトの `en_US-lessac-medium` 音声は Lessac Technologies 提供の Blizzard 2013 データセットで学習されており、このデータセットのライセンスは商用利用を禁止しています。商用利用が必要な場合は、許容的なライセンスで学習された別の voice モデルを選択してください。

--- a/README.ja.md
+++ b/README.ja.md
@@ -21,6 +21,7 @@ Google Colab 上で選択したローカル TTS を一時的に OpenAI 互換 `/
 | F5-TTS | 動作OK (GPU必須) | 英語 / 中国語（日本語は別モデル） |
 | Chatterbox | 動作OK (GPU推奨) | 日本語 / 英語 / 中国語 他 23言語 |
 | Zonos | 動作OK (GPU必須・VRAM ~6GB) | 日本語 / 英語 / 中国語 / フランス語 / ドイツ語 |
+| OuteTTS | 動作OK (CPU可) | 日本語 / 英語 / 中国語 他 多言語 |
 | Fish-Speech | 動作不可 | 日本語 / 英語 / 中国語 他 80言語以上 |
 | MeloTTS | 動作不可 | - |
 | Style-Bert-VITS2 | 動作不可 | - |
@@ -344,6 +345,19 @@ Resemble AI の [resemble-ai/chatterbox](https://github.com/resemble-ai/chatterb
 
 音声クローンを使う場合は、必ず権利を持っている音声（本人の同意がある音声）でのみ行ってください。
 
+### OuteTTS
+
+[edwko/OuteTTS](https://github.com/edwko/OuteTTS) を使った軽量多言語 TTS です。日本語を含む多言語に対応し、モデルサイズ（`0.6B` / `1B`）と backend（`HF` = transformers / `LLAMACPP` = GGUF）を選択できます。`--outetts-prompt-wav`（必要なら `--outetts-prompt-text` も）で voice cloning を有効にできます。デフォルト voice は `--outetts-default-speaker`（例: `EN-FEMALE-1-NEUTRAL`）で内蔵 speaker プロファイルを切り替えられます。日本語を発話させる場合は、日本語の参照音声から `clone` で speaker プロファイルを作るのが推奨です。CPU / GPU の両方で動作します。ライセンス: Apache 2.0（コードと重み）。
+
+`voice` パラメータには次の値を指定できます。
+
+| voice | 説明 |
+|---|---|
+| `default` | `--outetts-default-speaker` で選んだ内蔵 speaker プロファイルで合成 |
+| `clone` | 音声クローン。`--outetts-prompt-wav` を指定したときのみ有効 |
+
+音声クローンを使う場合は、必ず権利を持っている音声（本人の同意がある音声）でのみ行ってください。
+
 ### Fish-Speech (現在動作不可)
 
 [fishaudio/fish-speech](https://github.com/fishaudio/fish-speech) を使った高品質 TTS です。日本語は Tier 1 サポート（最高品質）で、80 言語以上に対応しています。VRAM 24GB 以上が必要で A100/L4 GPU を想定していますが、Colab 環境ではモデルロード時に OOM（メモリ不足）でランタイムがクラッシュするため、現時点では動作しません。ライセンス: Apache 2.0。
@@ -380,6 +394,7 @@ Resemble AI の [resemble-ai/chatterbox](https://github.com/resemble-ai/chatterb
 | F5-TTS | MIT | CC-BY-NC | 不可（モデル） | モデル重みは Emilia データセットの制約により非商用 |
 | Chatterbox | MIT | MIT | OK | 多言語（23言語、日本語含む）。ゼロショット voice cloning |
 | Zonos | Apache 2.0 | Apache 2.0 | OK | 英 / 日 / 中 / 仏 / 独。ゼロショット voice cloning。`espeak-ng` 必須 |
+| OuteTTS | Apache 2.0 | Apache 2.0 | OK | 0.6B / 1B。日本語含む多言語、CPU 動作可、voice cloning |
 | Fish-Speech | Apache 2.0 | Apache 2.0 | OK | A100/L4 GPU 必須（VRAM 24GB+） |
 
 **Piper について**: `piper-tts` パッケージは GPL-3.0 です。また、デフォルトの `en_US-lessac-medium` 音声は Lessac Technologies 提供の Blizzard 2013 データセットで学習されており、このデータセットのライセンスは商用利用を禁止しています。商用利用が必要な場合は、許容的なライセンスで学習された別の voice モデルを選択してください。
@@ -428,6 +443,8 @@ Resemble AI の [resemble-ai/chatterbox](https://github.com/resemble-ai/chatterb
   https://github.com/resemble-ai/chatterbox
 - Zonos
   https://github.com/Zyphra/Zonos
+- OuteTTS
+  https://github.com/edwko/OuteTTS
 - Fish Speech
   https://github.com/fishaudio/fish-speech
 - CosyVoice

--- a/README.ja.md
+++ b/README.ja.md
@@ -20,6 +20,7 @@ Google Colab 上で選択したローカル TTS を一時的に OpenAI 互換 `/
 | Sarashina-TTS | 動作OK (GPU必須・VRAM ~6GB) | 日本語 / 英語 |
 | F5-TTS | 動作OK (GPU必須) | 英語 / 中国語（日本語は別モデル） |
 | Chatterbox | 動作OK (GPU推奨) | 日本語 / 英語 / 中国語 他 23言語 |
+| Zonos | 動作OK (GPU必須・VRAM ~6GB) | 日本語 / 英語 / 中国語 / フランス語 / ドイツ語 |
 | Fish-Speech | 動作不可 | 日本語 / 英語 / 中国語 他 80言語以上 |
 | MeloTTS | 動作不可 | - |
 | Style-Bert-VITS2 | 動作不可 | - |
@@ -330,6 +331,19 @@ Resemble AI の [resemble-ai/chatterbox](https://github.com/resemble-ai/chatterb
 
 音声クローンを使う場合は、必ず権利を持っている音声（本人の同意がある音声）でのみ行ってください。
 
+### Zonos
+
+[Zyphra/Zonos](https://github.com/Zyphra/Zonos) を使った多言語 TTS です。英語・日本語・中国語・フランス語・ドイツ語に対応し、ゼロショット音声クローニングを備えています。デフォルトモデルは `Zyphra/Zonos-v0.1-transformer`（Apache 2.0）。音素化に `espeak-ng` を利用するため、インストーラが自動で `apt-get install espeak-ng` を実行します。デフォルト voice では upstream に同梱の `assets/exampleaudio.mp3` を参照音声として使用し、`--zonos-prompt-wav` を指定すると独自参照の `clone` voice が有効になります。GPU 必須（VRAM 6GB+、T4 動作可）。Hybrid backbone は Ampere 世代以降の GPU と `mamba-ssm` 依存を要求するため、ポータビリティのためデフォルトでは Transformer backbone を使用します。ライセンス: Apache 2.0（コードと重み）。
+
+`voice` パラメータには次の値を指定できます。
+
+| voice | 説明 |
+|---|---|
+| `default` | upstream に同梱の参照音声をそのまま使用 |
+| `clone` | ゼロショット音声クローン。`--zonos-prompt-wav` を指定したときのみ有効 |
+
+音声クローンを使う場合は、必ず権利を持っている音声（本人の同意がある音声）でのみ行ってください。
+
 ### Fish-Speech (現在動作不可)
 
 [fishaudio/fish-speech](https://github.com/fishaudio/fish-speech) を使った高品質 TTS です。日本語は Tier 1 サポート（最高品質）で、80 言語以上に対応しています。VRAM 24GB 以上が必要で A100/L4 GPU を想定していますが、Colab 環境ではモデルロード時に OOM（メモリ不足）でランタイムがクラッシュするため、現時点では動作しません。ライセンス: Apache 2.0。
@@ -365,6 +379,7 @@ Resemble AI の [resemble-ai/chatterbox](https://github.com/resemble-ai/chatterb
 | Sarashina-TTS | — | Sarashina Model NonCommercial License | 不可 | 日本語 / 英語。ゼロショット音声クローン対応。出力には SilentCipher のウォーターマークが付与される（除去禁止） |
 | F5-TTS | MIT | CC-BY-NC | 不可（モデル） | モデル重みは Emilia データセットの制約により非商用 |
 | Chatterbox | MIT | MIT | OK | 多言語（23言語、日本語含む）。ゼロショット voice cloning |
+| Zonos | Apache 2.0 | Apache 2.0 | OK | 英 / 日 / 中 / 仏 / 独。ゼロショット voice cloning。`espeak-ng` 必須 |
 | Fish-Speech | Apache 2.0 | Apache 2.0 | OK | A100/L4 GPU 必須（VRAM 24GB+） |
 
 **Piper について**: `piper-tts` パッケージは GPL-3.0 です。また、デフォルトの `en_US-lessac-medium` 音声は Lessac Technologies 提供の Blizzard 2013 データセットで学習されており、このデータセットのライセンスは商用利用を禁止しています。商用利用が必要な場合は、許容的なライセンスで学習された別の voice モデルを選択してください。
@@ -411,6 +426,8 @@ Resemble AI の [resemble-ai/chatterbox](https://github.com/resemble-ai/chatterb
   https://github.com/SWivid/F5-TTS
 - Chatterbox
   https://github.com/resemble-ai/chatterbox
+- Zonos
+  https://github.com/Zyphra/Zonos
 - Fish Speech
   https://github.com/fishaudio/fish-speech
 - CosyVoice

--- a/README.ja.md
+++ b/README.ja.md
@@ -23,6 +23,7 @@ Google Colab 上で選択したローカル TTS を一時的に OpenAI 互換 `/
 | Zonos | 動作OK (GPU必須・VRAM ~6GB) | 日本語 / 英語 / 中国語 / フランス語 / ドイツ語 |
 | OuteTTS | 動作OK (CPU可) | 日本語 / 英語 / 中国語 他 多言語 |
 | Dia | 動作OK (GPU推奨) | 英語（マルチスピーカー対話） |
+| OpenVoice-V2 | 動作要注意（MeloTTS 依存） | 日本語 / 英語 / 西 / 仏 / 中 / 韓 |
 | Fish-Speech | 動作不可 | 日本語 / 英語 / 中国語 他 80言語以上 |
 | MeloTTS | 動作不可 | - |
 | Style-Bert-VITS2 | 動作不可 | - |
@@ -381,6 +382,21 @@ Resemble AI の [resemble-ai/chatterbox](https://github.com/resemble-ai/chatterb
 
 音声クローンを使う場合は、必ず権利を持っている音声（本人の同意がある音声）でのみ行ってください。
 
+### OpenVoice-V2
+
+[myshell-ai/OpenVoice](https://github.com/myshell-ai/OpenVoice) V2 を使った 2 段階構成の voice cloning TTS です。まず MeloTTS で目的言語（EN / ES / FR / ZH / JP / KR）のベース音声を生成し、その後 ToneColorConverter（V2 checkpoints）で参照音声の声色に変換します。デフォルト言語は `JP`。`--openvoice-prompt-wav` を指定するまでは upstream に同梱の `resources/example_reference.mp3` を参照音声として使用し、指定すると `clone` voice が独自参照に切り替わります。ライセンス: コードと重みの両方が MIT（2024-04 以降）— 商用利用 OK。
+
+**注意:** OpenVoice V2 はベース TTS に MeloTTS を使用するため、現状本リポの MeloTTS 単体エンジンを動作不可にしている依存解決問題（`tokenizers` のビルドに Rust ツールチェーンが必要）と同じ理由でインストールに失敗する可能性があります。MeloTTS のインストールが成功するランタイムでは動作する想定です。
+
+`voice` パラメータには次の値を指定できます。
+
+| voice | 説明 |
+|---|---|
+| `default` | upstream に同梱の `resources/example_reference.mp3` を参照音声として使用 |
+| `clone` | `--openvoice-prompt-wav` を参照音声として使用（指定時のみ有効） |
+
+音声クローンを使う場合は、必ず権利を持っている音声（本人の同意がある音声）でのみ行ってください。
+
 ### Fish-Speech (現在動作不可)
 
 [fishaudio/fish-speech](https://github.com/fishaudio/fish-speech) を使った高品質 TTS です。日本語は Tier 1 サポート（最高品質）で、80 言語以上に対応しています。VRAM 24GB 以上が必要で A100/L4 GPU を想定していますが、Colab 環境ではモデルロード時に OOM（メモリ不足）でランタイムがクラッシュするため、現時点では動作しません。ライセンス: Apache 2.0。
@@ -420,6 +436,7 @@ Resemble AI の [resemble-ai/chatterbox](https://github.com/resemble-ai/chatterb
 | OuteTTS (0.6B) | Apache 2.0 | Apache 2.0 | OK | 日本語含む多言語、CPU 動作可、voice cloning |
 | OuteTTS (1B)   | Apache 2.0 | CC-BY-NC-SA-4.0 + Llama 3.2 Community License | 不可 | Llama-3.2 ベース。重みは非商用 |
 | Dia | Apache 2.0 | Apache 2.0 | OK | 英語のみ。`[S1]`/`[S2]` でマルチスピーカー対話 TTS |
+| OpenVoice-V2 | MIT | MIT | OK | 多言語（日本語含む）。voice cloning。MeloTTS 依存（環境次第で導入不可） |
 | Fish-Speech | Apache 2.0 | Apache 2.0 | OK | A100/L4 GPU 必須（VRAM 24GB+） |
 
 **Piper について**: `piper-tts` パッケージは GPL-3.0 です。また、デフォルトの `en_US-lessac-medium` 音声は Lessac Technologies 提供の Blizzard 2013 データセットで学習されており、このデータセットのライセンスは商用利用を禁止しています。商用利用が必要な場合は、許容的なライセンスで学習された別の voice モデルを選択してください。
@@ -472,6 +489,8 @@ Resemble AI の [resemble-ai/chatterbox](https://github.com/resemble-ai/chatterb
   https://github.com/edwko/OuteTTS
 - Dia
   https://github.com/nari-labs/dia
+- OpenVoice
+  https://github.com/myshell-ai/OpenVoice
 - Fish Speech
   https://github.com/fishaudio/fish-speech
 - CosyVoice

--- a/README.ja.md
+++ b/README.ja.md
@@ -25,7 +25,7 @@ Google Colab 上で選択したローカル TTS を一時的に OpenAI 互換 `/
 | OuteTTS | 動作OK (CPU可) | 日本語 / 英語 / 中国語 他 多言語 |
 | Dia | 動作OK (GPU推奨) | 英語（マルチスピーカー対話） |
 | OpenVoice-V2 | 動作要注意（MeloTTS 依存） | 日本語 / 英語 / 西 / 仏 / 中 / 韓 |
-| VibeVoice | 動作OK (GPU必須・research-only ライセンス) | 英語 / 中国語（長尺・最大 4 話者） |
+| VibeVoice | 動作不可（upstream API 移行中） | 英語 / 中国語（長尺・最大 4 話者） |
 | Fish-Speech | 動作不可 | 日本語 / 英語 / 中国語 他 80言語以上 |
 | MeloTTS | 動作不可 | - |
 | Style-Bert-VITS2 | 動作不可 | - |
@@ -575,20 +575,15 @@ Resemble AI の [resemble-ai/chatterbox](https://github.com/resemble-ai/chatterb
 
 音声クローンを使う場合は、必ず権利を持っている音声（本人の同意がある音声）でのみ行ってください。
 
-### VibeVoice
+### VibeVoice (現在動作不可)
 
-[microsoft/VibeVoice](https://github.com/microsoft/VibeVoice) を使った長尺・マルチスピーカー対応 TTS です。1.5B パラメータのモデルで、最大 4 話者・約 90 分の音声を 1 パスで生成できます（ポッドキャストや長尺対話向け）。各話者は短い参照音声で条件付けされます。デフォルト voice は upstream に同梱の `demo/voices/<VIBEVOICE_DEFAULT_SPEAKER>.wav`（例: `en-Alice_woman`）を参照として使用し、`--vibevoice-prompt-wav` を指定すると `clone` voice が独自参照に切り替わります。マルチスピーカー対話を使う場合は `input` を `Speaker 1: ...\nSpeaker 2: ...` 形式にしてください（平文の場合はラッパーが自動で `Speaker 1:` を先頭に追加）。GPU 必須（bf16）。チューニング項目: `--vibevoice-ddpm-steps`（デフォルト 10）、`--vibevoice-cfg-scale`（デフォルト 1.3）。
+[microsoft/VibeVoice](https://github.com/microsoft/VibeVoice) を使う構成で、1.5B パラメータの長尺・マルチスピーカー TTS（最大 4 話者・約 90 分を 1 パスで生成）として実装しています。Colab L4 GPU 上でモデルロードまでは到達しますが、upstream Microsoft リポジトリが現在 **破壊的な API 移行中** で、合成リクエストが完了しません:
 
-**ライセンス注意:** コード / 重みとも MIT ですが、Microsoft 公式モデルカードに **「research purpose only」** と明記されており、英語・中国語以外の言語、なりすまし、ディスインフォメーション、リアルタイム音声変換などは禁止されています。本エンジンは研究 / 評価目的の利用のみに留めてください。
+- 推論クラスが `VibeVoiceForConditionalGenerationInference` → `VibeVoiceForConditionalGeneration` にリネーム（ラッパーで吸収済み）
+- `model.set_ddpm_inference_steps(...)` が削除され、DDPM ステップは `model.model.noise_scheduler.set_timesteps(...)` 経由で設定する形に変更（ラッパーで吸収済み）
+- 致命的なのが reference 配布形式の変更: upstream は **`.wav` 参照音声ファイルを `demo/voices/` から取り下げ**、代わりに事前計算済みの **`.pt` (prompt cache)** を `demo/voices/streaming_model/` で配布する形になりました（例: `en-Carter_man.pt` / `jp-Spk1_woman.pt`）。推奨パスも `processor.process_input_with_cached_prompt(cached_prompt=torch.load(...))` に変わっており、本ラッパーが使っている `processor(text=..., voice_samples=[wav_path])` API では使い物になる参照音声が無くなっています。
 
-`voice` パラメータには次の値を指定できます。
-
-| voice | 説明 |
-|---|---|
-| `default` | upstream に同梱の `demo/voices/<--vibevoice-default-speaker>.wav` を参照音声として使用 |
-| `clone` | `--vibevoice-prompt-wav` を参照音声として使用（指定時のみ有効） |
-
-音声クローンを使う場合は、必ず権利を持っている音声（本人の同意がある音声）でのみ行ってください。
+upstream の API が落ち着いた段階で再アクティベートできるよう、ラッパー側の実装はそのままツリーに残しています。**ライセンス注意（仮に動いた場合でも）:** モデルカードに **「research purpose only」** と明記されており、英語・中国語以外の言語、なりすまし、ディスインフォメーション、リアルタイム音声変換などは禁止です。動くようになっても商用 / 実運用には使わないでください。
 
 ### Fish-Speech (現在動作不可)
 
@@ -630,7 +625,7 @@ Resemble AI の [resemble-ai/chatterbox](https://github.com/resemble-ai/chatterb
 | OuteTTS (1B)   | Apache 2.0 | CC-BY-NC-SA-4.0 + Llama 3.2 Community License | 不可 | Llama-3.2 ベース。重みは非商用 |
 | Dia | Apache 2.0 | Apache 2.0 | OK | 英語のみ。`[S1]`/`[S2]` でマルチスピーカー対話 TTS |
 | OpenVoice-V2 | MIT | MIT | OK | 多言語（日本語含む）。voice cloning。MeloTTS 依存（環境次第で導入不可） |
-| VibeVoice | MIT | MIT | 要注意（research-only） | 英 / 中のみ。Microsoft 公式に「research purpose only」と明記 |
+| VibeVoice | MIT | MIT | 要注意（research-only） | 英 / 中のみ。現在は動作不可: upstream API 移行中（.wav speaker ファイル → .pt prompt cache へ移行） |
 | Fish-Speech | Apache 2.0 | Apache 2.0 | OK | A100/L4 GPU 必須（VRAM 24GB+） |
 
 **Piper について**: `piper-tts` パッケージは GPL-3.0 です。また、デフォルトの `en_US-lessac-medium` 音声は Lessac Technologies 提供の Blizzard 2013 データセットで学習されており、このデータセットのライセンスは商用利用を禁止しています。商用利用が必要な場合は、許容的なライセンスで学習された別の voice モデルを選択してください。

--- a/README.ja.md
+++ b/README.ja.md
@@ -15,6 +15,7 @@ Google Colab 上で選択したローカル TTS を一時的に OpenAI 互換 `/
 | Qwen3-TTS | 動作OK (GPU必須) | 日本語 / 英語 / 中国語 他 10言語 |
 | VoxCPM2 | 動作OK (GPU必須) | 日本語 / 英語 / 中国語 他 30言語 |
 | MOSS-TTS-Nano | 動作（出力が約2秒で切れる） | 日本語 / 英語 / 中国語 他 20言語 |
+| NeuTTS | 動作OK (CPU可・voice cloning) | 英語 / スペイン語 / ドイツ語 / フランス語 |
 | TinyTTS | 動作OK | 英語 |
 | Voxtral-TTS | 動作OK (GPU必須・VRAM 16GB+) | 英語 / フランス語 / スペイン語 他 9言語 |
 | Sarashina-TTS | 動作OK (GPU必須・VRAM ~6GB) | 日本語 / 英語 |
@@ -62,12 +63,22 @@ REPO_URL = "https://github.com/shinshin86/local-tts-on-google-colab.git"  #@para
 REPO_REF = "main"  #@param {type:"string"}
 WORKDIR = "/content/local-tts-on-google-colab"  #@param {type:"string"}
 
-ENGINE = "Kokoro"  #@param ["Irodori-TTS", "Kokoro", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "Piper", "Piper-Plus", "Qwen3-TTS", "Sarashina-TTS", "Style-Bert-VITS2", "TinyTTS", "Voxtral-TTS"]
+ENGINE = "Kokoro"  #@param ["Chatterbox", "Dia", "F5-TTS", "Fish-Speech", "Irodori-TTS", "Kokoro", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "OpenVoice-V2", "OuteTTS", "Piper", "Piper-Plus", "Qwen3-TTS", "Sarashina-TTS", "Style-Bert-VITS2", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos"]
 EXPOSE_PUBLIC_URL = True  #@param {type:"boolean"}
 TEST_TEXT = "こんにちは。これは OpenAI 互換 TTS の動作確認です。"  #@param {type:"string"}
 TEST_SPEED = 1.0  #@param {type:"number"}
 TEST_VOICE = ""  #@param {type:"string"}
 OPENAI_MODEL_ID = ""  #@param {type:"string"}
+
+#@markdown ---
+#@markdown F5-TTS (GPU required)
+F5TTS_MODEL = "F5TTS_v1_Base"  #@param {type:"string"}
+F5TTS_CKPT_FILE = ""  #@param {type:"string"}
+F5TTS_VOCAB_FILE = ""  #@param {type:"string"}
+
+#@markdown ---
+#@markdown Fish-Speech (A100/L4 GPU required, VRAM 24GB+)
+FISH_SPEECH_MODEL = "fishaudio/s2-pro"  #@param {type:"string"}
 
 #@markdown ---
 #@markdown Irodori-TTS
@@ -109,6 +120,82 @@ PIPER_PLUS_MODEL = "tsukuyomi"  #@param {type:"string"}
 QWEN3_HF_MODEL = "Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice"  #@param ["Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice", "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice"]
 QWEN3_LANGUAGE = "Japanese"  #@param ["Chinese", "English", "Japanese", "Korean", "German", "French", "Russian", "Portuguese", "Spanish", "Italian"]
 QWEN3_DEFAULT_SPEAKER = "ono_anna"  #@param ["aiden", "dylan", "eric", "ono_anna", "ryan", "serena", "sohee", "uncle_fu", "vivian"]
+
+#@markdown ---
+#@markdown VoxCPM2 (GPU required)
+VOXCPM_HF_MODEL = "openbmb/VoxCPM2"  #@param {type:"string"}
+VOXCPM_CFG_VALUE = 2.0  #@param {type:"number"}
+VOXCPM_INFERENCE_TIMESTEPS = 10  #@param {type:"integer"}
+
+#@markdown ---
+#@markdown MOSS-TTS-Nano (CPU OK)
+MOSS_TTS_NANO_HF_MODEL = "OpenMOSS-Team/MOSS-TTS-Nano-100M"  #@param {type:"string"}
+MOSS_TTS_NANO_MODE = "continuation"  #@param ["continuation", "voice_clone"]
+
+#@markdown ---
+#@markdown NeuTTS (CPU OK, EN/ES/DE/FR, voice cloning)
+NEUTTS_BACKBONE_REPO = "neuphonic/neutts-air"  #@param ["neuphonic/neutts-air", "neuphonic/neutts-nano", "neuphonic/neutts-nano-french", "neuphonic/neutts-nano-german", "neuphonic/neutts-nano-spanish"]
+NEUTTS_CODEC_REPO = "neuphonic/neucodec"  #@param {type:"string"}
+NEUTTS_DEFAULT_VOICE = "jo"  #@param ["dave", "jo", "greta", "juliette", "mateo"]
+
+#@markdown ---
+#@markdown Sarashina-TTS (GPU required, ~6GB VRAM, JP/EN, NonCommercial)
+SARASHINA_HF_MODEL = "sbintuitions/sarashina2.2-tts"  #@param {type:"string"}
+SARASHINA_USE_VLLM = False  #@param {type:"boolean"}
+SARASHINA_PROMPT_WAV = ""  #@param {type:"string"}
+SARASHINA_PROMPT_TEXT = ""  #@param {type:"string"}
+SARASHINA_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
+
+#@markdown ---
+#@markdown Chatterbox (GPU recommended, multilingual incl JP, voice cloning)
+CHATTERBOX_LANGUAGE = "ja"  #@param ["ar", "da", "de", "el", "en", "es", "fi", "fr", "he", "hi", "it", "ja", "ko", "ms", "nl", "no", "pl", "pt", "ru", "sv", "sw", "tr", "zh"]
+CHATTERBOX_PROMPT_WAV = ""  #@param {type:"string"}
+CHATTERBOX_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
+
+#@markdown ---
+#@markdown Zonos (GPU recommended, JP/EN/ZH/FR/DE, voice cloning, Apache 2.0)
+ZONOS_HF_MODEL = "Zyphra/Zonos-v0.1-transformer"  #@param {type:"string"}
+ZONOS_LANGUAGE = "ja"  #@param ["en", "ja", "zh", "fr", "de"]
+ZONOS_PROMPT_WAV = ""  #@param {type:"string"}
+ZONOS_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
+
+#@markdown ---
+#@markdown OuteTTS (CPU OK, multilingual incl JP, voice cloning)
+#@markdown - 0.6B: code/weights both Apache 2.0 (commercial use OK).
+#@markdown - 1B: weights are CC-BY-NC-SA-4.0 + Llama 3.2 Community License (non-commercial only).
+OUTETTS_MODEL_SIZE = "0.6B"  #@param ["0.6B", "1B"]
+OUTETTS_BACKEND = "HF"  #@param ["HF", "LLAMACPP"]
+OUTETTS_DEFAULT_SPEAKER = "EN-FEMALE-1-NEUTRAL"  #@param {type:"string"}
+OUTETTS_PROMPT_WAV = ""  #@param {type:"string"}
+OUTETTS_PROMPT_TEXT = ""  #@param {type:"string"}
+OUTETTS_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
+
+#@markdown ---
+#@markdown Dia (GPU recommended, English-only, [S1]/[S2] dialogue, Apache 2.0)
+DIA_HF_MODEL = "nari-labs/Dia-1.6B-0626"  #@param {type:"string"}
+DIA_COMPUTE_DTYPE = "float16"  #@param ["float16", "bfloat16", "float32"]
+DIA_PROMPT_WAV = ""  #@param {type:"string"}
+DIA_PROMPT_TEXT = ""  #@param {type:"string"}
+DIA_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
+
+#@markdown ---
+#@markdown OpenVoice V2 (GPU recommended, multilingual incl JP, voice cloning, MIT)
+#@markdown - Pipeline: MeloTTS base TTS -> ToneColorConverter (V2 checkpoints).
+#@markdown - May hit the same MeloTTS dependency issue that breaks the standalone MeloTTS engine.
+OPENVOICE_LANGUAGE = "JP"  #@param ["EN", "ES", "FR", "ZH", "JP", "KR"]
+OPENVOICE_PROMPT_WAV = ""  #@param {type:"string"}
+OPENVOICE_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
+
+#@markdown ---
+#@markdown VibeVoice (GPU required, English/Chinese, long-form multi-speaker)
+#@markdown - License: MIT, but Microsoft tags this as "research purpose only".
+#@markdown - Non-EN/ZH languages, voice impersonation, and disinformation use are prohibited.
+VIBEVOICE_HF_MODEL = "microsoft/VibeVoice-1.5B"  #@param {type:"string"}
+VIBEVOICE_DEFAULT_SPEAKER = "en-Alice_woman"  #@param {type:"string"}
+VIBEVOICE_PROMPT_WAV = ""  #@param {type:"string"}
+VIBEVOICE_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
+VIBEVOICE_DDPM_STEPS = 10  #@param {type:"integer"}
+VIBEVOICE_CFG_SCALE = 1.3  #@param {type:"number"}
 
 import shlex
 import subprocess
@@ -156,8 +243,18 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         TEST_VOICE,
         "--openai-model-id",
         OPENAI_MODEL_ID,
+        "--f5tts-model",
+        F5TTS_MODEL,
+        "--f5tts-ckpt-file",
+        F5TTS_CKPT_FILE,
+        "--f5tts-vocab-file",
+        F5TTS_VOCAB_FILE,
+        "--fish-speech-model",
+        FISH_SPEECH_MODEL,
         "--irodori-hf-checkpoint",
         IRODORI_HF_CHECKPOINT,
+        "--irodori-codec-repo",
+        IRODORI_CODEC_REPO,
         "--irodori-model-precision",
         IRODORI_MODEL_PRECISION,
         "--irodori-codec-precision",
@@ -192,7 +289,87 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         QWEN3_LANGUAGE,
         "--qwen3-default-speaker",
         QWEN3_DEFAULT_SPEAKER,
+        "--voxcpm-hf-model",
+        VOXCPM_HF_MODEL,
+        "--voxcpm-cfg-value",
+        str(VOXCPM_CFG_VALUE),
+        "--voxcpm-inference-timesteps",
+        str(VOXCPM_INFERENCE_TIMESTEPS),
+        "--moss-tts-nano-hf-model",
+        MOSS_TTS_NANO_HF_MODEL,
+        "--moss-tts-nano-mode",
+        MOSS_TTS_NANO_MODE,
+        "--neutts-backbone-repo",
+        NEUTTS_BACKBONE_REPO,
+        "--neutts-codec-repo",
+        NEUTTS_CODEC_REPO,
+        "--neutts-default-voice",
+        NEUTTS_DEFAULT_VOICE,
+        "--sarashina-hf-model",
+        SARASHINA_HF_MODEL,
+        "--sarashina-prompt-wav",
+        SARASHINA_PROMPT_WAV,
+        "--sarashina-prompt-text",
+        SARASHINA_PROMPT_TEXT,
+        "--sarashina-default-voice",
+        SARASHINA_DEFAULT_VOICE,
+        "--chatterbox-language",
+        CHATTERBOX_LANGUAGE,
+        "--chatterbox-prompt-wav",
+        CHATTERBOX_PROMPT_WAV,
+        "--chatterbox-default-voice",
+        CHATTERBOX_DEFAULT_VOICE,
+        "--zonos-hf-model",
+        ZONOS_HF_MODEL,
+        "--zonos-language",
+        ZONOS_LANGUAGE,
+        "--zonos-prompt-wav",
+        ZONOS_PROMPT_WAV,
+        "--zonos-default-voice",
+        ZONOS_DEFAULT_VOICE,
+        "--outetts-model-size",
+        OUTETTS_MODEL_SIZE,
+        "--outetts-backend",
+        OUTETTS_BACKEND,
+        "--outetts-default-speaker",
+        OUTETTS_DEFAULT_SPEAKER,
+        "--outetts-prompt-wav",
+        OUTETTS_PROMPT_WAV,
+        "--outetts-prompt-text",
+        OUTETTS_PROMPT_TEXT,
+        "--outetts-default-voice",
+        OUTETTS_DEFAULT_VOICE,
+        "--dia-hf-model",
+        DIA_HF_MODEL,
+        "--dia-compute-dtype",
+        DIA_COMPUTE_DTYPE,
+        "--dia-prompt-wav",
+        DIA_PROMPT_WAV,
+        "--dia-prompt-text",
+        DIA_PROMPT_TEXT,
+        "--dia-default-voice",
+        DIA_DEFAULT_VOICE,
+        "--openvoice-language",
+        OPENVOICE_LANGUAGE,
+        "--openvoice-prompt-wav",
+        OPENVOICE_PROMPT_WAV,
+        "--openvoice-default-voice",
+        OPENVOICE_DEFAULT_VOICE,
+        "--vibevoice-hf-model",
+        VIBEVOICE_HF_MODEL,
+        "--vibevoice-default-speaker",
+        VIBEVOICE_DEFAULT_SPEAKER,
+        "--vibevoice-prompt-wav",
+        VIBEVOICE_PROMPT_WAV,
+        "--vibevoice-default-voice",
+        VIBEVOICE_DEFAULT_VOICE,
+        "--vibevoice-ddpm-steps",
+        str(VIBEVOICE_DDPM_STEPS),
+        "--vibevoice-cfg-scale",
+        str(VIBEVOICE_CFG_SCALE),
     ]
+    if SARASHINA_USE_VLLM:
+        cmd.append("--sarashina-use-vllm")
     cmd.append("--expose-public-url" if EXPOSE_PUBLIC_URL else "--no-expose-public-url")
     return cmd
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -19,6 +19,7 @@ Google Colab 上で選択したローカル TTS を一時的に OpenAI 互換 `/
 | Voxtral-TTS | 動作OK (GPU必須・VRAM 16GB+) | 英語 / フランス語 / スペイン語 他 9言語 |
 | Sarashina-TTS | 動作OK (GPU必須・VRAM ~6GB) | 日本語 / 英語 |
 | F5-TTS | 動作OK (GPU必須) | 英語 / 中国語（日本語は別モデル） |
+| Chatterbox | 動作OK (GPU推奨) | 日本語 / 英語 / 中国語 他 23言語 |
 | Fish-Speech | 動作不可 | 日本語 / 英語 / 中国語 他 80言語以上 |
 | MeloTTS | 動作不可 | - |
 | Style-Bert-VITS2 | 動作不可 | - |
@@ -316,6 +317,19 @@ SB Intuitions の [sbintuitions/sarashina2.2-tts](https://huggingface.co/sbintui
 
 [SWivid/F5-TTS](https://github.com/SWivid/F5-TTS) を使ったゼロショット音声クローニング TTS です。参照音声の声質を模倣して音声を生成します。パッケージ同梱のデフォルト参照音声（英語女性）を使用します。日本語モデルを使う場合は `--f5tts-ckpt-file` / `--f5tts-vocab-file` でコミュニティ提供の日本語チェックポイントを指定してください。GPU ランタイム（T4 以上）が必要です。ライセンス: コード MIT / モデル CC-BY-NC。
 
+### Chatterbox
+
+Resemble AI の [resemble-ai/chatterbox](https://github.com/resemble-ai/chatterbox) を使った多言語 TTS です。Chatterbox Multilingual モデルは日本語・英語・中国語・フランス語・ドイツ語・スペイン語・韓国語など 23 言語に対応し、ゼロショット音声クローンを備えています。デフォルト言語は `ja`（日本語）。`--chatterbox-prompt-wav` を指定すると `clone` voice が有効になり、参照音声の声色で合成されます。GPU 推奨（VRAM ~2-4GB）。ライセンス: MIT（コードと重みの両方）。
+
+`voice` パラメータには次の値を指定できます。
+
+| voice | 説明 |
+|---|---|
+| `default` | 参照音声なしの plain TTS |
+| `clone` | ゼロショット音声クローン。`--chatterbox-prompt-wav` を指定したときのみ有効 |
+
+音声クローンを使う場合は、必ず権利を持っている音声（本人の同意がある音声）でのみ行ってください。
+
 ### Fish-Speech (現在動作不可)
 
 [fishaudio/fish-speech](https://github.com/fishaudio/fish-speech) を使った高品質 TTS です。日本語は Tier 1 サポート（最高品質）で、80 言語以上に対応しています。VRAM 24GB 以上が必要で A100/L4 GPU を想定していますが、Colab 環境ではモデルロード時に OOM（メモリ不足）でランタイムがクラッシュするため、現時点では動作しません。ライセンス: Apache 2.0。
@@ -350,6 +364,7 @@ SB Intuitions の [sbintuitions/sarashina2.2-tts](https://huggingface.co/sbintui
 | Voxtral-TTS | — | CC BY-NC 4.0 | 不可 | vLLM + vllm-omni 経由。音声データセットのライセンス制約により非商用 |
 | Sarashina-TTS | — | Sarashina Model NonCommercial License | 不可 | 日本語 / 英語。ゼロショット音声クローン対応。出力には SilentCipher のウォーターマークが付与される（除去禁止） |
 | F5-TTS | MIT | CC-BY-NC | 不可（モデル） | モデル重みは Emilia データセットの制約により非商用 |
+| Chatterbox | MIT | MIT | OK | 多言語（23言語、日本語含む）。ゼロショット voice cloning |
 | Fish-Speech | Apache 2.0 | Apache 2.0 | OK | A100/L4 GPU 必須（VRAM 24GB+） |
 
 **Piper について**: `piper-tts` パッケージは GPL-3.0 です。また、デフォルトの `en_US-lessac-medium` 音声は Lessac Technologies 提供の Blizzard 2013 データセットで学習されており、このデータセットのライセンスは商用利用を禁止しています。商用利用が必要な場合は、許容的なライセンスで学習された別の voice モデルを選択してください。
@@ -394,6 +409,8 @@ SB Intuitions の [sbintuitions/sarashina2.2-tts](https://huggingface.co/sbintui
   https://github.com/sbintuitions/sarashina2.2-tts
 - F5-TTS
   https://github.com/SWivid/F5-TTS
+- Chatterbox
+  https://github.com/resemble-ai/chatterbox
 - Fish Speech
   https://github.com/fishaudio/fish-speech
 - CosyVoice

--- a/README.ja.md
+++ b/README.ja.md
@@ -24,7 +24,7 @@ Google Colab 上で選択したローカル TTS を一時的に OpenAI 互換 `/
 | Zonos | 動作OK (GPU必須・VRAM ~6GB) | 日本語 / 英語 / 中国語 / フランス語 / ドイツ語 |
 | OuteTTS | 動作OK (CPU可) | 日本語 / 英語 / 中国語 他 多言語 |
 | Dia | 動作OK (GPU推奨) | 英語（マルチスピーカー対話） |
-| OpenVoice-V2 | 動作要注意（MeloTTS 依存） | 日本語 / 英語 / 西 / 仏 / 中 / 韓 |
+| OpenVoice-V2 | 動作不可（Python 3.13 で `av==10` がビルドできない） | 日本語 / 英語 / 西 / 仏 / 中 / 韓 |
 | VibeVoice | 動作不可（upstream API 移行中） | 英語 / 中国語（長尺・最大 4 話者） |
 | Fish-Speech | 動作不可 | 日本語 / 英語 / 中国語 他 80言語以上 |
 | MeloTTS | 動作不可 | - |
@@ -560,20 +560,20 @@ Resemble AI の [resemble-ai/chatterbox](https://github.com/resemble-ai/chatterb
 
 音声クローンを使う場合は、必ず権利を持っている音声（本人の同意がある音声）でのみ行ってください。
 
-### OpenVoice-V2
+### OpenVoice-V2 (現在動作不可)
 
-[myshell-ai/OpenVoice](https://github.com/myshell-ai/OpenVoice) V2 を使った 2 段階構成の voice cloning TTS です。まず MeloTTS で目的言語（EN / ES / FR / ZH / JP / KR）のベース音声を生成し、その後 ToneColorConverter（V2 checkpoints）で参照音声の声色に変換します。デフォルト言語は `JP`。`--openvoice-prompt-wav` を指定するまでは upstream に同梱の `resources/example_reference.mp3` を参照音声として使用し、指定すると `clone` voice が独自参照に切り替わります。ライセンス: コードと重みの両方が MIT（2024-04 以降）— 商用利用 OK。
+[myshell-ai/OpenVoice](https://github.com/myshell-ai/OpenVoice) V2 を使う構成で、2 段階の voice cloning TTS（MeloTTS でベース合成 → ToneColorConverter で声色変換）として実装しています。コード・重みともに MIT で商用利用可。
 
-**注意:** OpenVoice V2 はベース TTS に MeloTTS を使用するため、現状本リポの MeloTTS 単体エンジンを動作不可にしている依存解決問題（`tokenizers` のビルドに Rust ツールチェーンが必要）と同じ理由でインストールに失敗する可能性があります。MeloTTS のインストールが成功するランタイムでは動作する想定です。
+**Colab で動かない理由**: OpenVoice の `pyproject.toml` が `faster-whisper==0.9.0` をハードピンしており、その推移依存で `av>=10.dev0,<11.dev0` も固定されます。`av` の 10.x 系列は Python 3.13（現在の Colab の既定）向けに wheel が無く、Cython 3.x ではソースのビルドにも失敗します:
 
-`voice` パラメータには次の値を指定できます。
+```
+av/logging.pyx:216:22: Cannot assign type 'const char *(void *) except?
+NULL nogil' to 'const char *(*)(void *) noexcept nogil'.
+```
 
-| voice | 説明 |
-|---|---|
-| `default` | upstream に同梱の `resources/example_reference.mp3` を参照音声として使用 |
-| `clone` | `--openvoice-prompt-wav` を参照音声として使用（指定時のみ有効） |
+`faster-whisper>=1.0`（`av==17.x` で py3.13 wheel あり）を先に入れても、uv が OpenVoice 側のピンを優先して 0.9.0 に巻き戻すため改善しません。回避するには `--no-deps` で入れて OpenVoice + MeloTTS の依存ツリーを手動で再構成する必要があり、その過程で本リポの MeloTTS 単体エンジンも壊している Rust ツールチェーン問題まで巻き込みます。
 
-音声クローンを使う場合は、必ず権利を持っている音声（本人の同意がある音声）でのみ行ってください。
+upstream がピンを緩めた段階で再アクティベートできるよう、ラッパー側のコードはそのまま残しています。**ライセンス（仮に動いた場合）:** コード・重みとも MIT（2024-04 以降）。
 
 ### VibeVoice (現在動作不可)
 
@@ -624,7 +624,7 @@ upstream の API が落ち着いた段階で再アクティベートできるよ
 | OuteTTS (0.6B) | Apache 2.0 | Apache 2.0 | OK | 日本語含む多言語、CPU 動作可、voice cloning |
 | OuteTTS (1B)   | Apache 2.0 | CC-BY-NC-SA-4.0 + Llama 3.2 Community License | 不可 | Llama-3.2 ベース。重みは非商用 |
 | Dia | Apache 2.0 | Apache 2.0 | OK | 英語のみ。`[S1]`/`[S2]` でマルチスピーカー対話 TTS |
-| OpenVoice-V2 | MIT | MIT | OK | 多言語（日本語含む）。voice cloning。MeloTTS 依存（環境次第で導入不可） |
+| OpenVoice-V2 | MIT | MIT | OK | 多言語（日本語含む）。voice cloning。現在動作不可: `faster-whisper==0.9.0` 経由の `av==10` が Python 3.13 でビルドできない |
 | VibeVoice | MIT | MIT | 要注意（research-only） | 英 / 中のみ。現在は動作不可: upstream API 移行中（.wav speaker ファイル → .pt prompt cache へ移行） |
 | Fish-Speech | Apache 2.0 | Apache 2.0 | OK | A100/L4 GPU 必須（VRAM 24GB+） |
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Supported engines:
 | Sarashina-TTS | Works (GPU required, ~6GB VRAM) | Japanese / English |
 | F5-TTS | Works (GPU required) | English / Chinese (Japanese via separate model) |
 | Chatterbox | Works (GPU recommended) | Japanese / English / Chinese and 23 languages |
+| Zonos | Works (GPU required, ~6GB VRAM) | Japanese / English / Chinese / French / German |
 | Fish-Speech | Not working | Japanese / English / Chinese and 80+ languages |
 | MeloTTS | Not working | - |
 | Style-Bert-VITS2 | Not working | - |
@@ -331,6 +332,19 @@ The `voice` parameter exposes:
 
 For voice cloning, only use reference audio you have rights to (consent of the speaker).
 
+### Zonos
+
+A multilingual TTS using [Zyphra/Zonos](https://github.com/Zyphra/Zonos). Supports English, Japanese, Chinese, French, and German with zero-shot voice cloning. Default model: `Zyphra/Zonos-v0.1-transformer` (Apache 2.0). Phonemization is done by `espeak-ng`, which is installed automatically. The wrapper uses the bundled `assets/exampleaudio.mp3` as the default speaker reference; supplying `--zonos-prompt-wav` enables a `clone` voice with your own reference audio. A GPU runtime is required (VRAM 6GB+, T4 OK). The optional Hybrid backbone needs an Ampere or newer GPU and additional `mamba-ssm` deps; the Transformer backbone is used by default for portability. License: Apache 2.0 (code and weights).
+
+The `voice` parameter exposes:
+
+| voice | description |
+|---|---|
+| `default` | Uses the bundled reference audio shipped in the upstream repo. |
+| `clone` | Zero-shot voice cloning. Only available when `--zonos-prompt-wav` is configured. |
+
+For voice cloning, only use reference audio you have rights to (consent of the speaker).
+
 ### Fish-Speech (currently not working)
 
 A high-quality TTS using [fishaudio/fish-speech](https://github.com/fishaudio/fish-speech). Japanese is Tier 1 supported (highest quality) and it supports 80+ languages. It requires 24GB+ VRAM and targets A100/L4 GPUs, but on Colab the runtime crashes with OOM during model loading, so it currently does not work. License: Apache 2.0.
@@ -366,6 +380,7 @@ The license for each engine is as follows. When using them, always check each pr
 | Sarashina-TTS | — | Sarashina Model NonCommercial License | Not allowed | Japanese / English. Zero-shot voice cloning. Output contains a SilentCipher watermark (do not remove) |
 | F5-TTS | MIT | CC-BY-NC | Not allowed (model) | Model weights are non-commercial due to Emilia dataset constraints |
 | Chatterbox | MIT | MIT | OK | Multilingual (23 languages incl JP). Zero-shot voice cloning |
+| Zonos | Apache 2.0 | Apache 2.0 | OK | EN/JA/ZH/FR/DE. Zero-shot voice cloning. Requires `espeak-ng` |
 | Fish-Speech | Apache 2.0 | Apache 2.0 | OK | Requires A100/L4 GPU (VRAM 24GB+) |
 
 **About Piper**: The `piper-tts` package is GPL-3.0. Also, the default `en_US-lessac-medium` voice is trained on the Blizzard 2013 dataset provided by Lessac Technologies, and its license prohibits commercial use. If you need commercial use, choose another voice model trained with a permissive license.
@@ -412,6 +427,8 @@ This repository itself is intended for short-term operational verification and t
   https://github.com/SWivid/F5-TTS
 - Chatterbox
   https://github.com/resemble-ai/chatterbox
+- Zonos
+  https://github.com/Zyphra/Zonos
 - Fish Speech
   https://github.com/fishaudio/fish-speech
 - CosyVoice

--- a/README.md
+++ b/README.md
@@ -560,20 +560,20 @@ The `voice` parameter exposes:
 
 For voice cloning, only use reference audio you have rights to (consent of the speaker).
 
-### OpenVoice-V2
+### OpenVoice-V2 (currently not working)
 
-A two-stage voice cloning TTS using [myshell-ai/OpenVoice](https://github.com/myshell-ai/OpenVoice) V2. The pipeline first synthesizes base speech with MeloTTS in the chosen language (EN / ES / FR / ZH / JP / KR), then applies a ToneColorConverter (V2 checkpoints) to match the timbre of a reference clip. Default language: `JP` (Japanese). The wrapper uses `resources/example_reference.mp3` from the upstream repo as the default reference; supplying `--openvoice-prompt-wav` enables a `clone` voice with your own reference audio. License: MIT (both code and weights, since April 2024) — commercial use is allowed.
+Intended to use [myshell-ai/OpenVoice](https://github.com/myshell-ai/OpenVoice) V2 — a two-stage voice cloning TTS that first synthesises base speech with MeloTTS, then runs a ToneColorConverter (V2 checkpoints) to match the timbre of a reference clip. Both the code and the weights are MIT, so commercial use is allowed.
 
-**Caveat:** OpenVoice V2 depends on MeloTTS as the base TTS, which is what currently breaks the standalone `MeloTTS` engine in this repo (the `tokenizers` build needs a Rust toolchain that Colab's `uv + venv` setup does not always provide). OpenVoice V2 may fail at install time for the same reason. If MeloTTS install succeeds in your runtime, OpenVoice V2 should work.
+**Why it fails on Colab today**: OpenVoice's `pyproject.toml` hard-pins `faster-whisper==0.9.0`, which transitively pins `av>=10.dev0,<11.dev0`. The 10.x line of `av` does not have wheels for Python 3.13 (Colab's current default) and its Cython source no longer compiles against Cython 3.x:
 
-The `voice` parameter exposes:
+```
+av/logging.pyx:216:22: Cannot assign type 'const char *(void *) except?
+NULL nogil' to 'const char *(*)(void *) noexcept nogil'.
+```
 
-| voice | description |
-|---|---|
-| `default` | Uses `resources/example_reference.mp3` shipped in the OpenVoice repo as the timbre reference. |
-| `clone` | Uses `--openvoice-prompt-wav` as the timbre reference. Only available when configured. |
+Pre-installing `faster-whisper>=1.0` (which has `av==17.x` with py3.13 wheels) does not help — uv respects OpenVoice's pin and downgrades back to 0.9.0. Working around it would require `--no-deps` plus reconstructing the entire OpenVoice + MeloTTS dependency tree by hand, which sweeps in the standalone `MeloTTS` engine's own Rust-toolchain breakage as well.
 
-For voice cloning, only use reference audio you have rights to (consent of the speaker).
+The wrapper code is kept in tree so OpenVoice V2 can be reactivated once upstream relaxes its pins. **License (when working):** MIT for both code and weights (since April 2024).
 
 ### VibeVoice (currently not working)
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Supported engines:
 | Chatterbox | Works (GPU recommended) | Japanese / English / Chinese and 23 languages |
 | Zonos | Works (GPU required, ~6GB VRAM) | Japanese / English / Chinese / French / German |
 | OuteTTS | Works (CPU OK) | Japanese / English / Chinese and many languages |
+| Dia | Works (GPU recommended) | English (multi-speaker dialogue) |
 | Fish-Speech | Not working | Japanese / English / Chinese and 80+ languages |
 | MeloTTS | Not working | - |
 | Style-Bert-VITS2 | Not working | - |
@@ -406,6 +407,7 @@ The license for each engine is as follows. When using them, always check each pr
 | Zonos | Apache 2.0 | Apache 2.0 | OK | EN/JA/ZH/FR/DE. Zero-shot voice cloning. Requires `espeak-ng` |
 | OuteTTS (0.6B) | Apache 2.0 | Apache 2.0 | OK | Multilingual incl JP. CPU OK. Voice cloning |
 | OuteTTS (1B)   | Apache 2.0 | CC-BY-NC-SA-4.0 + Llama 3.2 Community License | Not allowed | Llama-3.2-based; non-commercial weights |
+| Dia | Apache 2.0 | Apache 2.0 | OK | EN only. Multi-speaker `[S1]`/`[S2]` dialogue TTS |
 | Fish-Speech | Apache 2.0 | Apache 2.0 | OK | Requires A100/L4 GPU (VRAM 24GB+) |
 
 **About Piper**: The `piper-tts` package is GPL-3.0. Also, the default `en_US-lessac-medium` voice is trained on the Blizzard 2013 dataset provided by Lessac Technologies, and its license prohibits commercial use. If you need commercial use, choose another voice model trained with a permissive license.
@@ -456,6 +458,8 @@ This repository itself is intended for short-term operational verification and t
   https://github.com/Zyphra/Zonos
 - OuteTTS
   https://github.com/edwko/OuteTTS
+- Dia
+  https://github.com/nari-labs/dia
 - Fish Speech
   https://github.com/fishaudio/fish-speech
 - CosyVoice

--- a/README.md
+++ b/README.md
@@ -369,6 +369,19 @@ The `voice` parameter exposes:
 
 For voice cloning, only use reference audio you have rights to (consent of the speaker).
 
+### Dia
+
+A dialogue-oriented TTS using [nari-labs/dia](https://github.com/nari-labs/dia). The 1.6B-parameter model generates multi-speaker conversations in a single pass via `[S1]` / `[S2]` speaker tags directly in the prompt. English-only at the moment. The wrapper automatically prepends `[S1]` if your input has no speaker tag, so plain text still works for single-speaker TTS. Default model: `nari-labs/Dia-1.6B-0626`. With `--dia-prompt-wav` and `--dia-prompt-text`, the `clone` voice becomes available and conditions on a reference clip. A GPU runtime is recommended (VRAM ~4.4GB at float16/bfloat16, ~7.9GB at float32). License: Apache 2.0 (code and weights).
+
+The `voice` parameter exposes:
+
+| voice | description |
+|---|---|
+| `default` | Plain TTS without any reference. Use `[S1]` / `[S2]` tags in `input` for multi-speaker dialogue. |
+| `clone` | Voice cloning. Only available when both `--dia-prompt-wav` and `--dia-prompt-text` are configured. |
+
+For voice cloning, only use reference audio you have rights to (consent of the speaker).
+
 ### Fish-Speech (currently not working)
 
 A high-quality TTS using [fishaudio/fish-speech](https://github.com/fishaudio/fish-speech). Japanese is Tier 1 supported (highest quality) and it supports 80+ languages. It requires 24GB+ VRAM and targets A100/L4 GPUs, but on Colab the runtime crashes with OOM during model loading, so it currently does not work. License: Apache 2.0.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Supported engines:
 | OuteTTS | Works (CPU OK) | Japanese / English / Chinese and many languages |
 | Dia | Works (GPU recommended) | English (multi-speaker dialogue) |
 | OpenVoice-V2 | At your own risk (MeloTTS deps) | Japanese / English / Spanish / French / Chinese / Korean |
+| VibeVoice | Works (GPU required) - research-only license | English / Chinese (long-form, up to 4 speakers) |
 | Fish-Speech | Not working | Japanese / English / Chinese and 80+ languages |
 | MeloTTS | Not working | - |
 | Style-Bert-VITS2 | Not working | - |
@@ -398,6 +399,21 @@ The `voice` parameter exposes:
 
 For voice cloning, only use reference audio you have rights to (consent of the speaker).
 
+### VibeVoice
+
+A long-form multi-speaker TTS using [microsoft/VibeVoice](https://github.com/microsoft/VibeVoice). The 1.5B-parameter model can generate up to ~90 minutes of audio with up to 4 distinct speakers in a single pass — useful for podcasts and long dialogues. Each speaker conditions on a short reference clip. The wrapper resolves the default reference from `demo/voices/<VIBEVOICE_DEFAULT_SPEAKER>.wav` shipped in the upstream repo (e.g., `en-Alice_woman`); supplying `--vibevoice-prompt-wav` enables a `clone` voice. Use `Speaker 1: ... \n Speaker 2: ...` formatting in `input` for multi-speaker dialogues; the wrapper auto-prepends `Speaker 1:` for plain text. A GPU runtime is required (bf16). Tunable: `--vibevoice-ddpm-steps` (default 10) and `--vibevoice-cfg-scale` (default 1.3).
+
+**License caveat:** the code and weights are nominally MIT, **but** Microsoft tags VibeVoice as **"research purpose only"** on the model card and explicitly prohibits non-EN/ZH languages, voice impersonation, disinformation, and real-time voice conversion. Treat this engine as research / evaluation only — do not ship into commercial or real-world products.
+
+The `voice` parameter exposes:
+
+| voice | description |
+|---|---|
+| `default` | Uses the bundled `demo/voices/<--vibevoice-default-speaker>.wav` reference. |
+| `clone` | Uses `--vibevoice-prompt-wav` as the reference. Only available when configured. |
+
+For voice cloning, only use reference audio you have rights to (consent of the speaker).
+
 ### Fish-Speech (currently not working)
 
 A high-quality TTS using [fishaudio/fish-speech](https://github.com/fishaudio/fish-speech). Japanese is Tier 1 supported (highest quality) and it supports 80+ languages. It requires 24GB+ VRAM and targets A100/L4 GPUs, but on Colab the runtime crashes with OOM during model loading, so it currently does not work. License: Apache 2.0.
@@ -438,6 +454,7 @@ The license for each engine is as follows. When using them, always check each pr
 | OuteTTS (1B)   | Apache 2.0 | CC-BY-NC-SA-4.0 + Llama 3.2 Community License | Not allowed | Llama-3.2-based; non-commercial weights |
 | Dia | Apache 2.0 | Apache 2.0 | OK | EN only. Multi-speaker `[S1]`/`[S2]` dialogue TTS |
 | OpenVoice-V2 | MIT | MIT | OK | Multilingual (incl JP). Voice cloning. Depends on MeloTTS (may not install) |
+| VibeVoice | MIT | MIT | Caution (research-only) | EN/ZH only per model card. Microsoft tags this "research purpose only" |
 | Fish-Speech | Apache 2.0 | Apache 2.0 | OK | Requires A100/L4 GPU (VRAM 24GB+) |
 
 **About Piper**: The `piper-tts` package is GPL-3.0. Also, the default `en_US-lessac-medium` voice is trained on the Blizzard 2013 dataset provided by Lessac Technologies, and its license prohibits commercial use. If you need commercial use, choose another voice model trained with a permissive license.
@@ -492,6 +509,8 @@ This repository itself is intended for short-term operational verification and t
   https://github.com/nari-labs/dia
 - OpenVoice
   https://github.com/myshell-ai/OpenVoice
+- VibeVoice
+  https://github.com/microsoft/VibeVoice
 - Fish Speech
   https://github.com/fishaudio/fish-speech
 - CosyVoice

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Supported engines:
 | OuteTTS | Works (CPU OK) | Japanese / English / Chinese and many languages |
 | Dia | Works (GPU recommended) | English (multi-speaker dialogue) |
 | OpenVoice-V2 | At your own risk (MeloTTS deps) | Japanese / English / Spanish / French / Chinese / Korean |
-| VibeVoice | Works (GPU required) - research-only license | English / Chinese (long-form, up to 4 speakers) |
+| VibeVoice | Not working (upstream API churn) | English / Chinese (long-form, up to 4 speakers) |
 | Fish-Speech | Not working | Japanese / English / Chinese and 80+ languages |
 | MeloTTS | Not working | - |
 | Style-Bert-VITS2 | Not working | - |
@@ -575,20 +575,15 @@ The `voice` parameter exposes:
 
 For voice cloning, only use reference audio you have rights to (consent of the speaker).
 
-### VibeVoice
+### VibeVoice (currently not working)
 
-A long-form multi-speaker TTS using [microsoft/VibeVoice](https://github.com/microsoft/VibeVoice). The 1.5B-parameter model can generate up to ~90 minutes of audio with up to 4 distinct speakers in a single pass — useful for podcasts and long dialogues. Each speaker conditions on a short reference clip. The wrapper resolves the default reference from `demo/voices/<VIBEVOICE_DEFAULT_SPEAKER>.wav` shipped in the upstream repo (e.g., `en-Alice_woman`); supplying `--vibevoice-prompt-wav` enables a `clone` voice. Use `Speaker 1: ... \n Speaker 2: ...` formatting in `input` for multi-speaker dialogues; the wrapper auto-prepends `Speaker 1:` for plain text. A GPU runtime is required (bf16). Tunable: `--vibevoice-ddpm-steps` (default 10) and `--vibevoice-cfg-scale` (default 1.3).
+Intended to use [microsoft/VibeVoice](https://github.com/microsoft/VibeVoice) — a 1.5B-parameter long-form multi-speaker TTS that can generate up to ~90 minutes of audio with up to 4 speakers in a single pass. The wrapper has been verified end-to-end up to model load on a Colab L4 GPU, but the upstream Microsoft repository is in the middle of a breaking API migration and synthesis cannot complete cleanly today:
 
-**License caveat:** the code and weights are nominally MIT, **but** Microsoft tags VibeVoice as **"research purpose only"** on the model card and explicitly prohibits non-EN/ZH languages, voice impersonation, disinformation, and real-time voice conversion. Treat this engine as research / evaluation only — do not ship into commercial or real-world products.
+- The reference inference class was renamed: `VibeVoiceForConditionalGenerationInference` → `VibeVoiceForConditionalGeneration` (this part the wrapper now handles).
+- `model.set_ddpm_inference_steps(...)` has been removed; DDPM steps must now be set via `model.model.noise_scheduler.set_timesteps(...)` (handled).
+- The bigger break: upstream **stopped shipping reference `.wav` speaker files** in `demo/voices/`. They now ship pre-extracted `.pt` prompt caches (e.g. `en-Carter_man.pt`, `jp-Spk1_woman.pt`) and the recommended path is `processor.process_input_with_cached_prompt(cached_prompt=torch.load(...))` rather than `processor(text=..., voice_samples=[wav_path])`. The non-streaming `voice_samples`-based path the wrapper currently uses no longer has working defaults.
 
-The `voice` parameter exposes:
-
-| voice | description |
-|---|---|
-| `default` | Uses the bundled `demo/voices/<--vibevoice-default-speaker>.wav` reference. |
-| `clone` | Uses `--vibevoice-prompt-wav` as the reference. Only available when configured. |
-
-For voice cloning, only use reference audio you have rights to (consent of the speaker).
+The wrapper code is kept in tree so it can be rebuilt against the upstream API once it stabilises. **License caveat:** even when working, the model card tags VibeVoice as **"research purpose only"**: non-EN/ZH languages, voice impersonation, disinformation, and real-time voice conversion are prohibited. Don't ship into commercial / real-world products regardless of how the API ends up.
 
 ### Fish-Speech (currently not working)
 
@@ -630,7 +625,7 @@ The license for each engine is as follows. When using them, always check each pr
 | OuteTTS (1B)   | Apache 2.0 | CC-BY-NC-SA-4.0 + Llama 3.2 Community License | Not allowed | Llama-3.2-based; non-commercial weights |
 | Dia | Apache 2.0 | Apache 2.0 | OK | EN only. Multi-speaker `[S1]`/`[S2]` dialogue TTS |
 | OpenVoice-V2 | MIT | MIT | OK | Multilingual (incl JP). Voice cloning. Depends on MeloTTS (may not install) |
-| VibeVoice | MIT | MIT | Caution (research-only) | EN/ZH only per model card. Microsoft tags this "research purpose only" |
+| VibeVoice | MIT | MIT | Caution (research-only) | EN/ZH only per model card. Currently not working: upstream is mid-API migration (.wav speakers replaced with .pt caches) |
 | Fish-Speech | Apache 2.0 | Apache 2.0 | OK | Requires A100/L4 GPU (VRAM 24GB+) |
 
 **About Piper**: The `piper-tts` package is GPL-3.0. Also, the default `en_US-lessac-medium` voice is trained on the Blizzard 2013 dataset provided by Lessac Technologies, and its license prohibits commercial use. If you need commercial use, choose another voice model trained with a permissive license.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ REPO_URL = "https://github.com/shinshin86/local-tts-on-google-colab.git"  #@para
 REPO_REF = "main"  #@param {type:"string"}
 WORKDIR = "/content/local-tts-on-google-colab"  #@param {type:"string"}
 
-ENGINE = "Kokoro"  #@param ["Chatterbox", "Irodori-TTS", "Kokoro", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "Piper", "Piper-Plus", "Qwen3-TTS", "Sarashina-TTS", "Style-Bert-VITS2", "TinyTTS", "Voxtral-TTS"]
+ENGINE = "Kokoro"  #@param ["Chatterbox", "Dia", "F5-TTS", "Fish-Speech", "Irodori-TTS", "Kokoro", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "OpenVoice-V2", "OuteTTS", "Piper", "Piper-Plus", "Qwen3-TTS", "Sarashina-TTS", "Style-Bert-VITS2", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos"]
 EXPOSE_PUBLIC_URL = True  #@param {type:"boolean"}
 TEST_TEXT = "こんにちは。これは OpenAI 互換 TTS の動作確認です。"  #@param {type:"string"}
 TEST_SPEED = 1.0  #@param {type:"number"}
@@ -71,8 +71,18 @@ TEST_VOICE = ""  #@param {type:"string"}
 OPENAI_MODEL_ID = ""  #@param {type:"string"}
 
 #@markdown ---
+#@markdown F5-TTS (GPU required)
+F5TTS_MODEL = "F5TTS_v1_Base"  #@param {type:"string"}
+F5TTS_CKPT_FILE = ""  #@param {type:"string"}
+F5TTS_VOCAB_FILE = ""  #@param {type:"string"}
+
+#@markdown ---
+#@markdown Fish-Speech (A100/L4 GPU required, VRAM 24GB+)
+FISH_SPEECH_MODEL = "fishaudio/s2-pro"  #@param {type:"string"}
+
+#@markdown ---
 #@markdown Irodori-TTS
-# To use V1: checkpoint="Aratako/Irodori-TTS-500M", codec_repo="facebook/dacvae-watermarked"
+# V1を利用する場合: checkpoint="Aratako/Irodori-TTS-500M", codec_repo="facebook/dacvae-watermarked"
 IRODORI_HF_CHECKPOINT = "Aratako/Irodori-TTS-500M-v2"  #@param {type:"string"}
 IRODORI_CODEC_REPO = "Aratako/Semantic-DACVAE-Japanese-32dim"  #@param {type:"string"}
 IRODORI_MODEL_PRECISION = "fp32"  #@param ["fp32", "bf16", "fp16"]
@@ -110,6 +120,82 @@ PIPER_PLUS_MODEL = "tsukuyomi"  #@param {type:"string"}
 QWEN3_HF_MODEL = "Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice"  #@param ["Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice", "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice"]
 QWEN3_LANGUAGE = "Japanese"  #@param ["Chinese", "English", "Japanese", "Korean", "German", "French", "Russian", "Portuguese", "Spanish", "Italian"]
 QWEN3_DEFAULT_SPEAKER = "ono_anna"  #@param ["aiden", "dylan", "eric", "ono_anna", "ryan", "serena", "sohee", "uncle_fu", "vivian"]
+
+#@markdown ---
+#@markdown VoxCPM2 (GPU required)
+VOXCPM_HF_MODEL = "openbmb/VoxCPM2"  #@param {type:"string"}
+VOXCPM_CFG_VALUE = 2.0  #@param {type:"number"}
+VOXCPM_INFERENCE_TIMESTEPS = 10  #@param {type:"integer"}
+
+#@markdown ---
+#@markdown MOSS-TTS-Nano (CPU OK)
+MOSS_TTS_NANO_HF_MODEL = "OpenMOSS-Team/MOSS-TTS-Nano-100M"  #@param {type:"string"}
+MOSS_TTS_NANO_MODE = "continuation"  #@param ["continuation", "voice_clone"]
+
+#@markdown ---
+#@markdown NeuTTS (CPU OK, EN/ES/DE/FR, voice cloning)
+NEUTTS_BACKBONE_REPO = "neuphonic/neutts-air"  #@param ["neuphonic/neutts-air", "neuphonic/neutts-nano", "neuphonic/neutts-nano-french", "neuphonic/neutts-nano-german", "neuphonic/neutts-nano-spanish"]
+NEUTTS_CODEC_REPO = "neuphonic/neucodec"  #@param {type:"string"}
+NEUTTS_DEFAULT_VOICE = "jo"  #@param ["dave", "jo", "greta", "juliette", "mateo"]
+
+#@markdown ---
+#@markdown Sarashina-TTS (GPU required, ~6GB VRAM, JP/EN, NonCommercial)
+SARASHINA_HF_MODEL = "sbintuitions/sarashina2.2-tts"  #@param {type:"string"}
+SARASHINA_USE_VLLM = False  #@param {type:"boolean"}
+SARASHINA_PROMPT_WAV = ""  #@param {type:"string"}
+SARASHINA_PROMPT_TEXT = ""  #@param {type:"string"}
+SARASHINA_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
+
+#@markdown ---
+#@markdown Chatterbox (GPU recommended, multilingual incl JP, voice cloning)
+CHATTERBOX_LANGUAGE = "ja"  #@param ["ar", "da", "de", "el", "en", "es", "fi", "fr", "he", "hi", "it", "ja", "ko", "ms", "nl", "no", "pl", "pt", "ru", "sv", "sw", "tr", "zh"]
+CHATTERBOX_PROMPT_WAV = ""  #@param {type:"string"}
+CHATTERBOX_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
+
+#@markdown ---
+#@markdown Zonos (GPU recommended, JP/EN/ZH/FR/DE, voice cloning, Apache 2.0)
+ZONOS_HF_MODEL = "Zyphra/Zonos-v0.1-transformer"  #@param {type:"string"}
+ZONOS_LANGUAGE = "ja"  #@param ["en", "ja", "zh", "fr", "de"]
+ZONOS_PROMPT_WAV = ""  #@param {type:"string"}
+ZONOS_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
+
+#@markdown ---
+#@markdown OuteTTS (CPU OK, multilingual incl JP, voice cloning)
+#@markdown - 0.6B: code/weights both Apache 2.0 (commercial use OK).
+#@markdown - 1B: weights are CC-BY-NC-SA-4.0 + Llama 3.2 Community License (non-commercial only).
+OUTETTS_MODEL_SIZE = "0.6B"  #@param ["0.6B", "1B"]
+OUTETTS_BACKEND = "HF"  #@param ["HF", "LLAMACPP"]
+OUTETTS_DEFAULT_SPEAKER = "EN-FEMALE-1-NEUTRAL"  #@param {type:"string"}
+OUTETTS_PROMPT_WAV = ""  #@param {type:"string"}
+OUTETTS_PROMPT_TEXT = ""  #@param {type:"string"}
+OUTETTS_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
+
+#@markdown ---
+#@markdown Dia (GPU recommended, English-only, [S1]/[S2] dialogue, Apache 2.0)
+DIA_HF_MODEL = "nari-labs/Dia-1.6B-0626"  #@param {type:"string"}
+DIA_COMPUTE_DTYPE = "float16"  #@param ["float16", "bfloat16", "float32"]
+DIA_PROMPT_WAV = ""  #@param {type:"string"}
+DIA_PROMPT_TEXT = ""  #@param {type:"string"}
+DIA_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
+
+#@markdown ---
+#@markdown OpenVoice V2 (GPU recommended, multilingual incl JP, voice cloning, MIT)
+#@markdown - Pipeline: MeloTTS base TTS -> ToneColorConverter (V2 checkpoints).
+#@markdown - May hit the same MeloTTS dependency issue that breaks the standalone MeloTTS engine.
+OPENVOICE_LANGUAGE = "JP"  #@param ["EN", "ES", "FR", "ZH", "JP", "KR"]
+OPENVOICE_PROMPT_WAV = ""  #@param {type:"string"}
+OPENVOICE_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
+
+#@markdown ---
+#@markdown VibeVoice (GPU required, English/Chinese, long-form multi-speaker)
+#@markdown - License: MIT, but Microsoft tags this as "research purpose only".
+#@markdown - Non-EN/ZH languages, voice impersonation, and disinformation use are prohibited.
+VIBEVOICE_HF_MODEL = "microsoft/VibeVoice-1.5B"  #@param {type:"string"}
+VIBEVOICE_DEFAULT_SPEAKER = "en-Alice_woman"  #@param {type:"string"}
+VIBEVOICE_PROMPT_WAV = ""  #@param {type:"string"}
+VIBEVOICE_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
+VIBEVOICE_DDPM_STEPS = 10  #@param {type:"integer"}
+VIBEVOICE_CFG_SCALE = 1.3  #@param {type:"number"}
 
 import shlex
 import subprocess
@@ -157,8 +243,18 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         TEST_VOICE,
         "--openai-model-id",
         OPENAI_MODEL_ID,
+        "--f5tts-model",
+        F5TTS_MODEL,
+        "--f5tts-ckpt-file",
+        F5TTS_CKPT_FILE,
+        "--f5tts-vocab-file",
+        F5TTS_VOCAB_FILE,
+        "--fish-speech-model",
+        FISH_SPEECH_MODEL,
         "--irodori-hf-checkpoint",
         IRODORI_HF_CHECKPOINT,
+        "--irodori-codec-repo",
+        IRODORI_CODEC_REPO,
         "--irodori-model-precision",
         IRODORI_MODEL_PRECISION,
         "--irodori-codec-precision",
@@ -193,7 +289,87 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         QWEN3_LANGUAGE,
         "--qwen3-default-speaker",
         QWEN3_DEFAULT_SPEAKER,
+        "--voxcpm-hf-model",
+        VOXCPM_HF_MODEL,
+        "--voxcpm-cfg-value",
+        str(VOXCPM_CFG_VALUE),
+        "--voxcpm-inference-timesteps",
+        str(VOXCPM_INFERENCE_TIMESTEPS),
+        "--moss-tts-nano-hf-model",
+        MOSS_TTS_NANO_HF_MODEL,
+        "--moss-tts-nano-mode",
+        MOSS_TTS_NANO_MODE,
+        "--neutts-backbone-repo",
+        NEUTTS_BACKBONE_REPO,
+        "--neutts-codec-repo",
+        NEUTTS_CODEC_REPO,
+        "--neutts-default-voice",
+        NEUTTS_DEFAULT_VOICE,
+        "--sarashina-hf-model",
+        SARASHINA_HF_MODEL,
+        "--sarashina-prompt-wav",
+        SARASHINA_PROMPT_WAV,
+        "--sarashina-prompt-text",
+        SARASHINA_PROMPT_TEXT,
+        "--sarashina-default-voice",
+        SARASHINA_DEFAULT_VOICE,
+        "--chatterbox-language",
+        CHATTERBOX_LANGUAGE,
+        "--chatterbox-prompt-wav",
+        CHATTERBOX_PROMPT_WAV,
+        "--chatterbox-default-voice",
+        CHATTERBOX_DEFAULT_VOICE,
+        "--zonos-hf-model",
+        ZONOS_HF_MODEL,
+        "--zonos-language",
+        ZONOS_LANGUAGE,
+        "--zonos-prompt-wav",
+        ZONOS_PROMPT_WAV,
+        "--zonos-default-voice",
+        ZONOS_DEFAULT_VOICE,
+        "--outetts-model-size",
+        OUTETTS_MODEL_SIZE,
+        "--outetts-backend",
+        OUTETTS_BACKEND,
+        "--outetts-default-speaker",
+        OUTETTS_DEFAULT_SPEAKER,
+        "--outetts-prompt-wav",
+        OUTETTS_PROMPT_WAV,
+        "--outetts-prompt-text",
+        OUTETTS_PROMPT_TEXT,
+        "--outetts-default-voice",
+        OUTETTS_DEFAULT_VOICE,
+        "--dia-hf-model",
+        DIA_HF_MODEL,
+        "--dia-compute-dtype",
+        DIA_COMPUTE_DTYPE,
+        "--dia-prompt-wav",
+        DIA_PROMPT_WAV,
+        "--dia-prompt-text",
+        DIA_PROMPT_TEXT,
+        "--dia-default-voice",
+        DIA_DEFAULT_VOICE,
+        "--openvoice-language",
+        OPENVOICE_LANGUAGE,
+        "--openvoice-prompt-wav",
+        OPENVOICE_PROMPT_WAV,
+        "--openvoice-default-voice",
+        OPENVOICE_DEFAULT_VOICE,
+        "--vibevoice-hf-model",
+        VIBEVOICE_HF_MODEL,
+        "--vibevoice-default-speaker",
+        VIBEVOICE_DEFAULT_SPEAKER,
+        "--vibevoice-prompt-wav",
+        VIBEVOICE_PROMPT_WAV,
+        "--vibevoice-default-voice",
+        VIBEVOICE_DEFAULT_VOICE,
+        "--vibevoice-ddpm-steps",
+        str(VIBEVOICE_DDPM_STEPS),
+        "--vibevoice-cfg-scale",
+        str(VIBEVOICE_CFG_SCALE),
     ]
+    if SARASHINA_USE_VLLM:
+        cmd.append("--sarashina-use-vllm")
     cmd.append("--expose-public-url" if EXPOSE_PUBLIC_URL else "--no-expose-public-url")
     return cmd
 

--- a/README.md
+++ b/README.md
@@ -348,7 +348,16 @@ For voice cloning, only use reference audio you have rights to (consent of the s
 
 ### OuteTTS
 
-A lightweight multilingual TTS using [edwko/OuteTTS](https://github.com/edwko/OuteTTS). Supports many languages including Japanese, with two model sizes (`0.6B` and `1B`) and multiple backends (`HF` for transformers, `LLAMACPP` for GGUF). Voice cloning is exposed via `--outetts-prompt-wav` (and an optional `--outetts-prompt-text` transcript). The default voice uses one of the bundled built-in speaker profiles, configurable via `--outetts-default-speaker` (e.g., `EN-FEMALE-1-NEUTRAL`). For best Japanese results, create a Japanese speaker profile from a reference clip with `clone`. Runs on CPU or GPU. License: Apache 2.0 (code and weights).
+A lightweight multilingual TTS using [edwko/OuteTTS](https://github.com/edwko/OuteTTS). Supports many languages including Japanese, with two model sizes (`0.6B` and `1B`) and multiple backends (`HF` for transformers, `LLAMACPP` for GGUF). Voice cloning is exposed via `--outetts-prompt-wav` (and an optional `--outetts-prompt-text` transcript). The default voice uses one of the bundled built-in speaker profiles, configurable via `--outetts-default-speaker` (e.g., `EN-FEMALE-1-NEUTRAL`). For best Japanese results, create a Japanese speaker profile from a reference clip with `clone`. Runs on CPU or GPU.
+
+**License (depends on model size):**
+
+| Model | Code | Weights | Commercial use |
+|---|---|---|---|
+| `OuteAI/OuteTTS-1.0-0.6B` | Apache 2.0 | Apache 2.0 | OK |
+| `OuteAI/Llama-OuteTTS-1.0-1B` | Apache 2.0 | CC-BY-NC-SA-4.0 + Llama 3.2 Community License | **Not allowed** |
+
+The default model size in this wrapper is `0.6B` (Apache 2.0). If you switch to `1B`, the weights become non-commercial.
 
 The `voice` parameter exposes:
 
@@ -395,7 +404,8 @@ The license for each engine is as follows. When using them, always check each pr
 | F5-TTS | MIT | CC-BY-NC | Not allowed (model) | Model weights are non-commercial due to Emilia dataset constraints |
 | Chatterbox | MIT | MIT | OK | Multilingual (23 languages incl JP). Zero-shot voice cloning |
 | Zonos | Apache 2.0 | Apache 2.0 | OK | EN/JA/ZH/FR/DE. Zero-shot voice cloning. Requires `espeak-ng` |
-| OuteTTS | Apache 2.0 | Apache 2.0 | OK | 0.6B / 1B. Multilingual incl JP. CPU OK. Voice cloning |
+| OuteTTS (0.6B) | Apache 2.0 | Apache 2.0 | OK | Multilingual incl JP. CPU OK. Voice cloning |
+| OuteTTS (1B)   | Apache 2.0 | CC-BY-NC-SA-4.0 + Llama 3.2 Community License | Not allowed | Llama-3.2-based; non-commercial weights |
 | Fish-Speech | Apache 2.0 | Apache 2.0 | OK | Requires A100/L4 GPU (VRAM 24GB+) |
 
 **About Piper**: The `piper-tts` package is GPL-3.0. Also, the default `en_US-lessac-medium` voice is trained on the Blizzard 2013 dataset provided by Lessac Technologies, and its license prohibits commercial use. If you need commercial use, choose another voice model trained with a permissive license.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Supported engines:
 | Voxtral-TTS | Works (GPU required, VRAM 16GB+) | English / French / Spanish and 9 languages |
 | Sarashina-TTS | Works (GPU required, ~6GB VRAM) | Japanese / English |
 | F5-TTS | Works (GPU required) | English / Chinese (Japanese via separate model) |
+| Chatterbox | Works (GPU recommended) | Japanese / English / Chinese and 23 languages |
 | Fish-Speech | Not working | Japanese / English / Chinese and 80+ languages |
 | MeloTTS | Not working | - |
 | Style-Bert-VITS2 | Not working | - |
@@ -57,7 +58,7 @@ REPO_URL = "https://github.com/shinshin86/local-tts-on-google-colab.git"  #@para
 REPO_REF = "main"  #@param {type:"string"}
 WORKDIR = "/content/local-tts-on-google-colab"  #@param {type:"string"}
 
-ENGINE = "Kokoro"  #@param ["Irodori-TTS", "Kokoro", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "Piper", "Piper-Plus", "Qwen3-TTS", "Sarashina-TTS", "Style-Bert-VITS2", "TinyTTS", "Voxtral-TTS"]
+ENGINE = "Kokoro"  #@param ["Chatterbox", "Irodori-TTS", "Kokoro", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "Piper", "Piper-Plus", "Qwen3-TTS", "Sarashina-TTS", "Style-Bert-VITS2", "TinyTTS", "Voxtral-TTS"]
 EXPOSE_PUBLIC_URL = True  #@param {type:"boolean"}
 TEST_TEXT = "こんにちは。これは OpenAI 互換 TTS の動作確認です。"  #@param {type:"string"}
 TEST_SPEED = 1.0  #@param {type:"number"}
@@ -317,6 +318,19 @@ For voice cloning, only use reference audio you have rights to (consent of the s
 
 A zero-shot voice cloning TTS using [SWivid/F5-TTS](https://github.com/SWivid/F5-TTS). It mimics the voice quality of a reference audio to generate speech. Uses the default reference audio bundled with the package (English female). To use a Japanese model, specify a community-provided Japanese checkpoint with `--f5tts-ckpt-file` / `--f5tts-vocab-file`. A GPU runtime (T4 or higher) is required. License: code MIT / model CC-BY-NC.
 
+### Chatterbox
+
+A multilingual TTS using [resemble-ai/chatterbox](https://github.com/resemble-ai/chatterbox) by Resemble AI. The Chatterbox Multilingual model supports 23 languages including Japanese, English, Chinese, French, German, Spanish, Korean, etc., and supports zero-shot voice cloning. Default language is `ja` (Japanese). When `--chatterbox-prompt-wav` is provided, the `clone` voice becomes available and uses the reference audio. A GPU runtime is recommended (VRAM ~2-4GB). License: MIT (both code and weights).
+
+The `voice` parameter exposes:
+
+| voice | description |
+|---|---|
+| `default` | Plain TTS without any reference audio. |
+| `clone` | Zero-shot voice cloning. Only available when `--chatterbox-prompt-wav` is configured. |
+
+For voice cloning, only use reference audio you have rights to (consent of the speaker).
+
 ### Fish-Speech (currently not working)
 
 A high-quality TTS using [fishaudio/fish-speech](https://github.com/fishaudio/fish-speech). Japanese is Tier 1 supported (highest quality) and it supports 80+ languages. It requires 24GB+ VRAM and targets A100/L4 GPUs, but on Colab the runtime crashes with OOM during model loading, so it currently does not work. License: Apache 2.0.
@@ -351,6 +365,7 @@ The license for each engine is as follows. When using them, always check each pr
 | Voxtral-TTS | — | CC BY-NC 4.0 | Not allowed | Via vLLM + vllm-omni. Non-commercial due to voice dataset license constraints |
 | Sarashina-TTS | — | Sarashina Model NonCommercial License | Not allowed | Japanese / English. Zero-shot voice cloning. Output contains a SilentCipher watermark (do not remove) |
 | F5-TTS | MIT | CC-BY-NC | Not allowed (model) | Model weights are non-commercial due to Emilia dataset constraints |
+| Chatterbox | MIT | MIT | OK | Multilingual (23 languages incl JP). Zero-shot voice cloning |
 | Fish-Speech | Apache 2.0 | Apache 2.0 | OK | Requires A100/L4 GPU (VRAM 24GB+) |
 
 **About Piper**: The `piper-tts` package is GPL-3.0. Also, the default `en_US-lessac-medium` voice is trained on the Blizzard 2013 dataset provided by Lessac Technologies, and its license prohibits commercial use. If you need commercial use, choose another voice model trained with a permissive license.
@@ -395,6 +410,8 @@ This repository itself is intended for short-term operational verification and t
   https://github.com/sbintuitions/sarashina2.2-tts
 - F5-TTS
   https://github.com/SWivid/F5-TTS
+- Chatterbox
+  https://github.com/resemble-ai/chatterbox
 - Fish Speech
   https://github.com/fishaudio/fish-speech
 - CosyVoice

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Supported engines:
 | Zonos | Works (GPU required, ~6GB VRAM) | Japanese / English / Chinese / French / German |
 | OuteTTS | Works (CPU OK) | Japanese / English / Chinese and many languages |
 | Dia | Works (GPU recommended) | English (multi-speaker dialogue) |
-| OpenVoice-V2 | At your own risk (MeloTTS deps) | Japanese / English / Spanish / French / Chinese / Korean |
+| OpenVoice-V2 | Not working (Python 3.13 / `av==10` build failure) | Japanese / English / Spanish / French / Chinese / Korean |
 | VibeVoice | Not working (upstream API churn) | English / Chinese (long-form, up to 4 speakers) |
 | Fish-Speech | Not working | Japanese / English / Chinese and 80+ languages |
 | MeloTTS | Not working | - |
@@ -624,7 +624,7 @@ The license for each engine is as follows. When using them, always check each pr
 | OuteTTS (0.6B) | Apache 2.0 | Apache 2.0 | OK | Multilingual incl JP. CPU OK. Voice cloning |
 | OuteTTS (1B)   | Apache 2.0 | CC-BY-NC-SA-4.0 + Llama 3.2 Community License | Not allowed | Llama-3.2-based; non-commercial weights |
 | Dia | Apache 2.0 | Apache 2.0 | OK | EN only. Multi-speaker `[S1]`/`[S2]` dialogue TTS |
-| OpenVoice-V2 | MIT | MIT | OK | Multilingual (incl JP). Voice cloning. Depends on MeloTTS (may not install) |
+| OpenVoice-V2 | MIT | MIT | OK | Multilingual (incl JP). Voice cloning. Currently not working: `av==10` (via `faster-whisper==0.9.0` pin) won't build on Python 3.13 |
 | VibeVoice | MIT | MIT | Caution (research-only) | EN/ZH only per model card. Currently not working: upstream is mid-API migration (.wav speakers replaced with .pt caches) |
 | Fish-Speech | Apache 2.0 | Apache 2.0 | OK | Requires A100/L4 GPU (VRAM 24GB+) |
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Supported engines:
 | F5-TTS | Works (GPU required) | English / Chinese (Japanese via separate model) |
 | Chatterbox | Works (GPU recommended) | Japanese / English / Chinese and 23 languages |
 | Zonos | Works (GPU required, ~6GB VRAM) | Japanese / English / Chinese / French / German |
+| OuteTTS | Works (CPU OK) | Japanese / English / Chinese and many languages |
 | Fish-Speech | Not working | Japanese / English / Chinese and 80+ languages |
 | MeloTTS | Not working | - |
 | Style-Bert-VITS2 | Not working | - |
@@ -345,6 +346,19 @@ The `voice` parameter exposes:
 
 For voice cloning, only use reference audio you have rights to (consent of the speaker).
 
+### OuteTTS
+
+A lightweight multilingual TTS using [edwko/OuteTTS](https://github.com/edwko/OuteTTS). Supports many languages including Japanese, with two model sizes (`0.6B` and `1B`) and multiple backends (`HF` for transformers, `LLAMACPP` for GGUF). Voice cloning is exposed via `--outetts-prompt-wav` (and an optional `--outetts-prompt-text` transcript). The default voice uses one of the bundled built-in speaker profiles, configurable via `--outetts-default-speaker` (e.g., `EN-FEMALE-1-NEUTRAL`). For best Japanese results, create a Japanese speaker profile from a reference clip with `clone`. Runs on CPU or GPU. License: Apache 2.0 (code and weights).
+
+The `voice` parameter exposes:
+
+| voice | description |
+|---|---|
+| `default` | Plain TTS using the built-in speaker profile selected by `--outetts-default-speaker`. |
+| `clone` | Voice cloning. Only available when `--outetts-prompt-wav` is configured. |
+
+For voice cloning, only use reference audio you have rights to (consent of the speaker).
+
 ### Fish-Speech (currently not working)
 
 A high-quality TTS using [fishaudio/fish-speech](https://github.com/fishaudio/fish-speech). Japanese is Tier 1 supported (highest quality) and it supports 80+ languages. It requires 24GB+ VRAM and targets A100/L4 GPUs, but on Colab the runtime crashes with OOM during model loading, so it currently does not work. License: Apache 2.0.
@@ -381,6 +395,7 @@ The license for each engine is as follows. When using them, always check each pr
 | F5-TTS | MIT | CC-BY-NC | Not allowed (model) | Model weights are non-commercial due to Emilia dataset constraints |
 | Chatterbox | MIT | MIT | OK | Multilingual (23 languages incl JP). Zero-shot voice cloning |
 | Zonos | Apache 2.0 | Apache 2.0 | OK | EN/JA/ZH/FR/DE. Zero-shot voice cloning. Requires `espeak-ng` |
+| OuteTTS | Apache 2.0 | Apache 2.0 | OK | 0.6B / 1B. Multilingual incl JP. CPU OK. Voice cloning |
 | Fish-Speech | Apache 2.0 | Apache 2.0 | OK | Requires A100/L4 GPU (VRAM 24GB+) |
 
 **About Piper**: The `piper-tts` package is GPL-3.0. Also, the default `en_US-lessac-medium` voice is trained on the Blizzard 2013 dataset provided by Lessac Technologies, and its license prohibits commercial use. If you need commercial use, choose another voice model trained with a permissive license.
@@ -429,6 +444,8 @@ This repository itself is intended for short-term operational verification and t
   https://github.com/resemble-ai/chatterbox
 - Zonos
   https://github.com/Zyphra/Zonos
+- OuteTTS
+  https://github.com/edwko/OuteTTS
 - Fish Speech
   https://github.com/fishaudio/fish-speech
 - CosyVoice

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Supported engines:
 | Zonos | Works (GPU required, ~6GB VRAM) | Japanese / English / Chinese / French / German |
 | OuteTTS | Works (CPU OK) | Japanese / English / Chinese and many languages |
 | Dia | Works (GPU recommended) | English (multi-speaker dialogue) |
+| OpenVoice-V2 | At your own risk (MeloTTS deps) | Japanese / English / Spanish / French / Chinese / Korean |
 | Fish-Speech | Not working | Japanese / English / Chinese and 80+ languages |
 | MeloTTS | Not working | - |
 | Style-Bert-VITS2 | Not working | - |
@@ -382,6 +383,21 @@ The `voice` parameter exposes:
 
 For voice cloning, only use reference audio you have rights to (consent of the speaker).
 
+### OpenVoice-V2
+
+A two-stage voice cloning TTS using [myshell-ai/OpenVoice](https://github.com/myshell-ai/OpenVoice) V2. The pipeline first synthesizes base speech with MeloTTS in the chosen language (EN / ES / FR / ZH / JP / KR), then applies a ToneColorConverter (V2 checkpoints) to match the timbre of a reference clip. Default language: `JP` (Japanese). The wrapper uses `resources/example_reference.mp3` from the upstream repo as the default reference; supplying `--openvoice-prompt-wav` enables a `clone` voice with your own reference audio. License: MIT (both code and weights, since April 2024) — commercial use is allowed.
+
+**Caveat:** OpenVoice V2 depends on MeloTTS as the base TTS, which is what currently breaks the standalone `MeloTTS` engine in this repo (the `tokenizers` build needs a Rust toolchain that Colab's `uv + venv` setup does not always provide). OpenVoice V2 may fail at install time for the same reason. If MeloTTS install succeeds in your runtime, OpenVoice V2 should work.
+
+The `voice` parameter exposes:
+
+| voice | description |
+|---|---|
+| `default` | Uses `resources/example_reference.mp3` shipped in the OpenVoice repo as the timbre reference. |
+| `clone` | Uses `--openvoice-prompt-wav` as the timbre reference. Only available when configured. |
+
+For voice cloning, only use reference audio you have rights to (consent of the speaker).
+
 ### Fish-Speech (currently not working)
 
 A high-quality TTS using [fishaudio/fish-speech](https://github.com/fishaudio/fish-speech). Japanese is Tier 1 supported (highest quality) and it supports 80+ languages. It requires 24GB+ VRAM and targets A100/L4 GPUs, but on Colab the runtime crashes with OOM during model loading, so it currently does not work. License: Apache 2.0.
@@ -421,6 +437,7 @@ The license for each engine is as follows. When using them, always check each pr
 | OuteTTS (0.6B) | Apache 2.0 | Apache 2.0 | OK | Multilingual incl JP. CPU OK. Voice cloning |
 | OuteTTS (1B)   | Apache 2.0 | CC-BY-NC-SA-4.0 + Llama 3.2 Community License | Not allowed | Llama-3.2-based; non-commercial weights |
 | Dia | Apache 2.0 | Apache 2.0 | OK | EN only. Multi-speaker `[S1]`/`[S2]` dialogue TTS |
+| OpenVoice-V2 | MIT | MIT | OK | Multilingual (incl JP). Voice cloning. Depends on MeloTTS (may not install) |
 | Fish-Speech | Apache 2.0 | Apache 2.0 | OK | Requires A100/L4 GPU (VRAM 24GB+) |
 
 **About Piper**: The `piper-tts` package is GPL-3.0. Also, the default `en_US-lessac-medium` voice is trained on the Blizzard 2013 dataset provided by Lessac Technologies, and its license prohibits commercial use. If you need commercial use, choose another voice model trained with a permissive license.
@@ -473,6 +490,8 @@ This repository itself is intended for short-term operational verification and t
   https://github.com/edwko/OuteTTS
 - Dia
   https://github.com/nari-labs/dia
+- OpenVoice
+  https://github.com/myshell-ai/OpenVoice
 - Fish Speech
   https://github.com/fishaudio/fish-speech
 - CosyVoice

--- a/colab/bootstrap.py
+++ b/colab/bootstrap.py
@@ -83,6 +83,9 @@ def parse_args():
     parser.add_argument("--dia-prompt-wav", default="")
     parser.add_argument("--dia-prompt-text", default="")
     parser.add_argument("--dia-default-voice", default="default")
+    parser.add_argument("--openvoice-language", default="JP")
+    parser.add_argument("--openvoice-prompt-wav", default="")
+    parser.add_argument("--openvoice-default-voice", default="default")
     parser.add_argument("--root-dir", default="/content/openai-compatible-local-tts")
     return parser.parse_args()
 
@@ -154,6 +157,9 @@ def main():
         dia_prompt_wav=args.dia_prompt_wav,
         dia_prompt_text=args.dia_prompt_text,
         dia_default_voice=args.dia_default_voice,
+        openvoice_language=args.openvoice_language,
+        openvoice_prompt_wav=args.openvoice_prompt_wav,
+        openvoice_default_voice=args.openvoice_default_voice,
         root_dir=Path(args.root_dir),
         repo_dir=REPO_DIR,
     )

--- a/colab/bootstrap.py
+++ b/colab/bootstrap.py
@@ -78,6 +78,11 @@ def parse_args():
     parser.add_argument("--outetts-prompt-wav", default="")
     parser.add_argument("--outetts-prompt-text", default="")
     parser.add_argument("--outetts-default-voice", default="default")
+    parser.add_argument("--dia-hf-model", default="nari-labs/Dia-1.6B-0626")
+    parser.add_argument("--dia-compute-dtype", default="float16")
+    parser.add_argument("--dia-prompt-wav", default="")
+    parser.add_argument("--dia-prompt-text", default="")
+    parser.add_argument("--dia-default-voice", default="default")
     parser.add_argument("--root-dir", default="/content/openai-compatible-local-tts")
     return parser.parse_args()
 
@@ -144,6 +149,11 @@ def main():
         outetts_prompt_wav=args.outetts_prompt_wav,
         outetts_prompt_text=args.outetts_prompt_text,
         outetts_default_voice=args.outetts_default_voice,
+        dia_hf_model=args.dia_hf_model,
+        dia_compute_dtype=args.dia_compute_dtype,
+        dia_prompt_wav=args.dia_prompt_wav,
+        dia_prompt_text=args.dia_prompt_text,
+        dia_default_voice=args.dia_default_voice,
         root_dir=Path(args.root_dir),
         repo_dir=REPO_DIR,
     )

--- a/colab/bootstrap.py
+++ b/colab/bootstrap.py
@@ -72,6 +72,12 @@ def parse_args():
     parser.add_argument("--zonos-language", default="ja")
     parser.add_argument("--zonos-prompt-wav", default="")
     parser.add_argument("--zonos-default-voice", default="default")
+    parser.add_argument("--outetts-model-size", default="0.6B")
+    parser.add_argument("--outetts-backend", default="HF")
+    parser.add_argument("--outetts-default-speaker", default="EN-FEMALE-1-NEUTRAL")
+    parser.add_argument("--outetts-prompt-wav", default="")
+    parser.add_argument("--outetts-prompt-text", default="")
+    parser.add_argument("--outetts-default-voice", default="default")
     parser.add_argument("--root-dir", default="/content/openai-compatible-local-tts")
     return parser.parse_args()
 
@@ -132,6 +138,12 @@ def main():
         zonos_language=args.zonos_language,
         zonos_prompt_wav=args.zonos_prompt_wav,
         zonos_default_voice=args.zonos_default_voice,
+        outetts_model_size=args.outetts_model_size,
+        outetts_backend=args.outetts_backend,
+        outetts_default_speaker=args.outetts_default_speaker,
+        outetts_prompt_wav=args.outetts_prompt_wav,
+        outetts_prompt_text=args.outetts_prompt_text,
+        outetts_default_voice=args.outetts_default_voice,
         root_dir=Path(args.root_dir),
         repo_dir=REPO_DIR,
     )

--- a/colab/bootstrap.py
+++ b/colab/bootstrap.py
@@ -68,6 +68,10 @@ def parse_args():
     parser.add_argument("--chatterbox-language", default="ja")
     parser.add_argument("--chatterbox-prompt-wav", default="")
     parser.add_argument("--chatterbox-default-voice", default="default")
+    parser.add_argument("--zonos-hf-model", default="Zyphra/Zonos-v0.1-transformer")
+    parser.add_argument("--zonos-language", default="ja")
+    parser.add_argument("--zonos-prompt-wav", default="")
+    parser.add_argument("--zonos-default-voice", default="default")
     parser.add_argument("--root-dir", default="/content/openai-compatible-local-tts")
     return parser.parse_args()
 
@@ -124,6 +128,10 @@ def main():
         chatterbox_language=args.chatterbox_language,
         chatterbox_prompt_wav=args.chatterbox_prompt_wav,
         chatterbox_default_voice=args.chatterbox_default_voice,
+        zonos_hf_model=args.zonos_hf_model,
+        zonos_language=args.zonos_language,
+        zonos_prompt_wav=args.zonos_prompt_wav,
+        zonos_default_voice=args.zonos_default_voice,
         root_dir=Path(args.root_dir),
         repo_dir=REPO_DIR,
     )

--- a/colab/bootstrap.py
+++ b/colab/bootstrap.py
@@ -86,6 +86,12 @@ def parse_args():
     parser.add_argument("--openvoice-language", default="JP")
     parser.add_argument("--openvoice-prompt-wav", default="")
     parser.add_argument("--openvoice-default-voice", default="default")
+    parser.add_argument("--vibevoice-hf-model", default="microsoft/VibeVoice-1.5B")
+    parser.add_argument("--vibevoice-default-speaker", default="en-Alice_woman")
+    parser.add_argument("--vibevoice-prompt-wav", default="")
+    parser.add_argument("--vibevoice-default-voice", default="default")
+    parser.add_argument("--vibevoice-ddpm-steps", type=int, default=10)
+    parser.add_argument("--vibevoice-cfg-scale", type=float, default=1.3)
     parser.add_argument("--root-dir", default="/content/openai-compatible-local-tts")
     return parser.parse_args()
 
@@ -160,6 +166,12 @@ def main():
         openvoice_language=args.openvoice_language,
         openvoice_prompt_wav=args.openvoice_prompt_wav,
         openvoice_default_voice=args.openvoice_default_voice,
+        vibevoice_hf_model=args.vibevoice_hf_model,
+        vibevoice_default_speaker=args.vibevoice_default_speaker,
+        vibevoice_prompt_wav=args.vibevoice_prompt_wav,
+        vibevoice_default_voice=args.vibevoice_default_voice,
+        vibevoice_ddpm_steps=args.vibevoice_ddpm_steps,
+        vibevoice_cfg_scale=args.vibevoice_cfg_scale,
         root_dir=Path(args.root_dir),
         repo_dir=REPO_DIR,
     )

--- a/colab/bootstrap.py
+++ b/colab/bootstrap.py
@@ -65,6 +65,9 @@ def parse_args():
     parser.add_argument("--sarashina-prompt-wav", default="")
     parser.add_argument("--sarashina-prompt-text", default="")
     parser.add_argument("--sarashina-default-voice", default="default")
+    parser.add_argument("--chatterbox-language", default="ja")
+    parser.add_argument("--chatterbox-prompt-wav", default="")
+    parser.add_argument("--chatterbox-default-voice", default="default")
     parser.add_argument("--root-dir", default="/content/openai-compatible-local-tts")
     return parser.parse_args()
 
@@ -118,6 +121,9 @@ def main():
         sarashina_prompt_wav=args.sarashina_prompt_wav,
         sarashina_prompt_text=args.sarashina_prompt_text,
         sarashina_default_voice=args.sarashina_default_voice,
+        chatterbox_language=args.chatterbox_language,
+        chatterbox_prompt_wav=args.chatterbox_prompt_wav,
+        chatterbox_default_voice=args.chatterbox_default_voice,
         root_dir=Path(args.root_dir),
         repo_dir=REPO_DIR,
     )

--- a/multi_tts_openai_colab.py
+++ b/multi_tts_openai_colab.py
@@ -108,7 +108,9 @@ ZONOS_PROMPT_WAV = ""  #@param {type:"string"}
 ZONOS_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
 
 #@markdown ---
-#@markdown OuteTTS (CPU OK, multilingual incl JP, voice cloning, Apache 2.0)
+#@markdown OuteTTS (CPU OK, multilingual incl JP, voice cloning)
+#@markdown - 0.6B: code/weights both Apache 2.0 (commercial use OK).
+#@markdown - 1B: weights are CC-BY-NC-SA-4.0 + Llama 3.2 Community License (non-commercial only).
 OUTETTS_MODEL_SIZE = "0.6B"  #@param ["0.6B", "1B"]
 OUTETTS_BACKEND = "HF"  #@param ["HF", "LLAMACPP"]
 OUTETTS_DEFAULT_SPEAKER = "EN-FEMALE-1-NEUTRAL"  #@param {type:"string"}

--- a/multi_tts_openai_colab.py
+++ b/multi_tts_openai_colab.py
@@ -11,7 +11,7 @@ REPO_URL = "https://github.com/shinshin86/local-tts-on-google-colab.git"  #@para
 REPO_REF = "main"  #@param {type:"string"}
 WORKDIR = "/content/local-tts-on-google-colab"  #@param {type:"string"}
 
-ENGINE = "Kokoro"  #@param ["Chatterbox", "F5-TTS", "Fish-Speech", "Irodori-TTS", "Kokoro", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "Piper", "Piper-Plus", "Qwen3-TTS", "Sarashina-TTS", "Style-Bert-VITS2", "TinyTTS", "VoxCPM2", "Voxtral-TTS", "Zonos"]
+ENGINE = "Kokoro"  #@param ["Chatterbox", "F5-TTS", "Fish-Speech", "Irodori-TTS", "Kokoro", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "OuteTTS", "Piper", "Piper-Plus", "Qwen3-TTS", "Sarashina-TTS", "Style-Bert-VITS2", "TinyTTS", "VoxCPM2", "Voxtral-TTS", "Zonos"]
 EXPOSE_PUBLIC_URL = True  #@param {type:"boolean"}
 TEST_TEXT = "こんにちは。これは OpenAI 互換 TTS の動作確認です。"  #@param {type:"string"}
 TEST_SPEED = 1.0  #@param {type:"number"}
@@ -106,6 +106,15 @@ ZONOS_HF_MODEL = "Zyphra/Zonos-v0.1-transformer"  #@param {type:"string"}
 ZONOS_LANGUAGE = "ja"  #@param ["en", "ja", "zh", "fr", "de"]
 ZONOS_PROMPT_WAV = ""  #@param {type:"string"}
 ZONOS_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
+
+#@markdown ---
+#@markdown OuteTTS (CPU OK, multilingual incl JP, voice cloning, Apache 2.0)
+OUTETTS_MODEL_SIZE = "0.6B"  #@param ["0.6B", "1B"]
+OUTETTS_BACKEND = "HF"  #@param ["HF", "LLAMACPP"]
+OUTETTS_DEFAULT_SPEAKER = "EN-FEMALE-1-NEUTRAL"  #@param {type:"string"}
+OUTETTS_PROMPT_WAV = ""  #@param {type:"string"}
+OUTETTS_PROMPT_TEXT = ""  #@param {type:"string"}
+OUTETTS_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
 
 import shlex
 import subprocess
@@ -237,6 +246,18 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         ZONOS_PROMPT_WAV,
         "--zonos-default-voice",
         ZONOS_DEFAULT_VOICE,
+        "--outetts-model-size",
+        OUTETTS_MODEL_SIZE,
+        "--outetts-backend",
+        OUTETTS_BACKEND,
+        "--outetts-default-speaker",
+        OUTETTS_DEFAULT_SPEAKER,
+        "--outetts-prompt-wav",
+        OUTETTS_PROMPT_WAV,
+        "--outetts-prompt-text",
+        OUTETTS_PROMPT_TEXT,
+        "--outetts-default-voice",
+        OUTETTS_DEFAULT_VOICE,
     ]
     if SARASHINA_USE_VLLM:
         cmd.append("--sarashina-use-vllm")

--- a/multi_tts_openai_colab.py
+++ b/multi_tts_openai_colab.py
@@ -11,7 +11,7 @@ REPO_URL = "https://github.com/shinshin86/local-tts-on-google-colab.git"  #@para
 REPO_REF = "main"  #@param {type:"string"}
 WORKDIR = "/content/local-tts-on-google-colab"  #@param {type:"string"}
 
-ENGINE = "Kokoro"  #@param ["Chatterbox", "Dia", "F5-TTS", "Fish-Speech", "Irodori-TTS", "Kokoro", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "OuteTTS", "Piper", "Piper-Plus", "Qwen3-TTS", "Sarashina-TTS", "Style-Bert-VITS2", "TinyTTS", "VoxCPM2", "Voxtral-TTS", "Zonos"]
+ENGINE = "Kokoro"  #@param ["Chatterbox", "Dia", "F5-TTS", "Fish-Speech", "Irodori-TTS", "Kokoro", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "OpenVoice-V2", "OuteTTS", "Piper", "Piper-Plus", "Qwen3-TTS", "Sarashina-TTS", "Style-Bert-VITS2", "TinyTTS", "VoxCPM2", "Voxtral-TTS", "Zonos"]
 EXPOSE_PUBLIC_URL = True  #@param {type:"boolean"}
 TEST_TEXT = "こんにちは。これは OpenAI 互換 TTS の動作確認です。"  #@param {type:"string"}
 TEST_SPEED = 1.0  #@param {type:"number"}
@@ -125,6 +125,14 @@ DIA_COMPUTE_DTYPE = "float16"  #@param ["float16", "bfloat16", "float32"]
 DIA_PROMPT_WAV = ""  #@param {type:"string"}
 DIA_PROMPT_TEXT = ""  #@param {type:"string"}
 DIA_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
+
+#@markdown ---
+#@markdown OpenVoice V2 (GPU recommended, multilingual incl JP, voice cloning, MIT)
+#@markdown - Pipeline: MeloTTS base TTS -> ToneColorConverter (V2 checkpoints).
+#@markdown - May hit the same MeloTTS dependency issue that breaks the standalone MeloTTS engine.
+OPENVOICE_LANGUAGE = "JP"  #@param ["EN", "ES", "FR", "ZH", "JP", "KR"]
+OPENVOICE_PROMPT_WAV = ""  #@param {type:"string"}
+OPENVOICE_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
 
 import shlex
 import subprocess
@@ -278,6 +286,12 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         DIA_PROMPT_TEXT,
         "--dia-default-voice",
         DIA_DEFAULT_VOICE,
+        "--openvoice-language",
+        OPENVOICE_LANGUAGE,
+        "--openvoice-prompt-wav",
+        OPENVOICE_PROMPT_WAV,
+        "--openvoice-default-voice",
+        OPENVOICE_DEFAULT_VOICE,
     ]
     if SARASHINA_USE_VLLM:
         cmd.append("--sarashina-use-vllm")

--- a/multi_tts_openai_colab.py
+++ b/multi_tts_openai_colab.py
@@ -11,7 +11,7 @@ REPO_URL = "https://github.com/shinshin86/local-tts-on-google-colab.git"  #@para
 REPO_REF = "main"  #@param {type:"string"}
 WORKDIR = "/content/local-tts-on-google-colab"  #@param {type:"string"}
 
-ENGINE = "Kokoro"  #@param ["Chatterbox", "F5-TTS", "Fish-Speech", "Irodori-TTS", "Kokoro", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "OuteTTS", "Piper", "Piper-Plus", "Qwen3-TTS", "Sarashina-TTS", "Style-Bert-VITS2", "TinyTTS", "VoxCPM2", "Voxtral-TTS", "Zonos"]
+ENGINE = "Kokoro"  #@param ["Chatterbox", "Dia", "F5-TTS", "Fish-Speech", "Irodori-TTS", "Kokoro", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "OuteTTS", "Piper", "Piper-Plus", "Qwen3-TTS", "Sarashina-TTS", "Style-Bert-VITS2", "TinyTTS", "VoxCPM2", "Voxtral-TTS", "Zonos"]
 EXPOSE_PUBLIC_URL = True  #@param {type:"boolean"}
 TEST_TEXT = "こんにちは。これは OpenAI 互換 TTS の動作確認です。"  #@param {type:"string"}
 TEST_SPEED = 1.0  #@param {type:"number"}
@@ -117,6 +117,14 @@ OUTETTS_DEFAULT_SPEAKER = "EN-FEMALE-1-NEUTRAL"  #@param {type:"string"}
 OUTETTS_PROMPT_WAV = ""  #@param {type:"string"}
 OUTETTS_PROMPT_TEXT = ""  #@param {type:"string"}
 OUTETTS_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
+
+#@markdown ---
+#@markdown Dia (GPU recommended, English-only, [S1]/[S2] dialogue, Apache 2.0)
+DIA_HF_MODEL = "nari-labs/Dia-1.6B-0626"  #@param {type:"string"}
+DIA_COMPUTE_DTYPE = "float16"  #@param ["float16", "bfloat16", "float32"]
+DIA_PROMPT_WAV = ""  #@param {type:"string"}
+DIA_PROMPT_TEXT = ""  #@param {type:"string"}
+DIA_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
 
 import shlex
 import subprocess
@@ -260,6 +268,16 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         OUTETTS_PROMPT_TEXT,
         "--outetts-default-voice",
         OUTETTS_DEFAULT_VOICE,
+        "--dia-hf-model",
+        DIA_HF_MODEL,
+        "--dia-compute-dtype",
+        DIA_COMPUTE_DTYPE,
+        "--dia-prompt-wav",
+        DIA_PROMPT_WAV,
+        "--dia-prompt-text",
+        DIA_PROMPT_TEXT,
+        "--dia-default-voice",
+        DIA_DEFAULT_VOICE,
     ]
     if SARASHINA_USE_VLLM:
         cmd.append("--sarashina-use-vllm")

--- a/multi_tts_openai_colab.py
+++ b/multi_tts_openai_colab.py
@@ -11,7 +11,7 @@ REPO_URL = "https://github.com/shinshin86/local-tts-on-google-colab.git"  #@para
 REPO_REF = "main"  #@param {type:"string"}
 WORKDIR = "/content/local-tts-on-google-colab"  #@param {type:"string"}
 
-ENGINE = "Kokoro"  #@param ["Chatterbox", "F5-TTS", "Fish-Speech", "Irodori-TTS", "Kokoro", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "Piper", "Piper-Plus", "Qwen3-TTS", "Sarashina-TTS", "Style-Bert-VITS2", "TinyTTS", "VoxCPM2", "Voxtral-TTS"]
+ENGINE = "Kokoro"  #@param ["Chatterbox", "F5-TTS", "Fish-Speech", "Irodori-TTS", "Kokoro", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "Piper", "Piper-Plus", "Qwen3-TTS", "Sarashina-TTS", "Style-Bert-VITS2", "TinyTTS", "VoxCPM2", "Voxtral-TTS", "Zonos"]
 EXPOSE_PUBLIC_URL = True  #@param {type:"boolean"}
 TEST_TEXT = "こんにちは。これは OpenAI 互換 TTS の動作確認です。"  #@param {type:"string"}
 TEST_SPEED = 1.0  #@param {type:"number"}
@@ -99,6 +99,13 @@ SARASHINA_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
 CHATTERBOX_LANGUAGE = "ja"  #@param ["ar", "da", "de", "el", "en", "es", "fi", "fr", "he", "hi", "it", "ja", "ko", "ms", "nl", "no", "pl", "pt", "ru", "sv", "sw", "tr", "zh"]
 CHATTERBOX_PROMPT_WAV = ""  #@param {type:"string"}
 CHATTERBOX_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
+
+#@markdown ---
+#@markdown Zonos (GPU recommended, JP/EN/ZH/FR/DE, voice cloning, Apache 2.0)
+ZONOS_HF_MODEL = "Zyphra/Zonos-v0.1-transformer"  #@param {type:"string"}
+ZONOS_LANGUAGE = "ja"  #@param ["en", "ja", "zh", "fr", "de"]
+ZONOS_PROMPT_WAV = ""  #@param {type:"string"}
+ZONOS_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
 
 import shlex
 import subprocess
@@ -222,6 +229,14 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         CHATTERBOX_PROMPT_WAV,
         "--chatterbox-default-voice",
         CHATTERBOX_DEFAULT_VOICE,
+        "--zonos-hf-model",
+        ZONOS_HF_MODEL,
+        "--zonos-language",
+        ZONOS_LANGUAGE,
+        "--zonos-prompt-wav",
+        ZONOS_PROMPT_WAV,
+        "--zonos-default-voice",
+        ZONOS_DEFAULT_VOICE,
     ]
     if SARASHINA_USE_VLLM:
         cmd.append("--sarashina-use-vllm")

--- a/multi_tts_openai_colab.py
+++ b/multi_tts_openai_colab.py
@@ -11,7 +11,7 @@ REPO_URL = "https://github.com/shinshin86/local-tts-on-google-colab.git"  #@para
 REPO_REF = "main"  #@param {type:"string"}
 WORKDIR = "/content/local-tts-on-google-colab"  #@param {type:"string"}
 
-ENGINE = "Kokoro"  #@param ["Chatterbox", "Dia", "F5-TTS", "Fish-Speech", "Irodori-TTS", "Kokoro", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "OpenVoice-V2", "OuteTTS", "Piper", "Piper-Plus", "Qwen3-TTS", "Sarashina-TTS", "Style-Bert-VITS2", "TinyTTS", "VoxCPM2", "Voxtral-TTS", "Zonos"]
+ENGINE = "Kokoro"  #@param ["Chatterbox", "Dia", "F5-TTS", "Fish-Speech", "Irodori-TTS", "Kokoro", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "OpenVoice-V2", "OuteTTS", "Piper", "Piper-Plus", "Qwen3-TTS", "Sarashina-TTS", "Style-Bert-VITS2", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos"]
 EXPOSE_PUBLIC_URL = True  #@param {type:"boolean"}
 TEST_TEXT = "こんにちは。これは OpenAI 互換 TTS の動作確認です。"  #@param {type:"string"}
 TEST_SPEED = 1.0  #@param {type:"number"}
@@ -133,6 +133,17 @@ DIA_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
 OPENVOICE_LANGUAGE = "JP"  #@param ["EN", "ES", "FR", "ZH", "JP", "KR"]
 OPENVOICE_PROMPT_WAV = ""  #@param {type:"string"}
 OPENVOICE_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
+
+#@markdown ---
+#@markdown VibeVoice (GPU required, English/Chinese, long-form multi-speaker)
+#@markdown - License: MIT, but Microsoft tags this as "research purpose only".
+#@markdown - Non-EN/ZH languages, voice impersonation, and disinformation use are prohibited.
+VIBEVOICE_HF_MODEL = "microsoft/VibeVoice-1.5B"  #@param {type:"string"}
+VIBEVOICE_DEFAULT_SPEAKER = "en-Alice_woman"  #@param {type:"string"}
+VIBEVOICE_PROMPT_WAV = ""  #@param {type:"string"}
+VIBEVOICE_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
+VIBEVOICE_DDPM_STEPS = 10  #@param {type:"integer"}
+VIBEVOICE_CFG_SCALE = 1.3  #@param {type:"number"}
 
 import shlex
 import subprocess
@@ -292,6 +303,18 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         OPENVOICE_PROMPT_WAV,
         "--openvoice-default-voice",
         OPENVOICE_DEFAULT_VOICE,
+        "--vibevoice-hf-model",
+        VIBEVOICE_HF_MODEL,
+        "--vibevoice-default-speaker",
+        VIBEVOICE_DEFAULT_SPEAKER,
+        "--vibevoice-prompt-wav",
+        VIBEVOICE_PROMPT_WAV,
+        "--vibevoice-default-voice",
+        VIBEVOICE_DEFAULT_VOICE,
+        "--vibevoice-ddpm-steps",
+        str(VIBEVOICE_DDPM_STEPS),
+        "--vibevoice-cfg-scale",
+        str(VIBEVOICE_CFG_SCALE),
     ]
     if SARASHINA_USE_VLLM:
         cmd.append("--sarashina-use-vllm")

--- a/multi_tts_openai_colab.py
+++ b/multi_tts_openai_colab.py
@@ -11,7 +11,7 @@ REPO_URL = "https://github.com/shinshin86/local-tts-on-google-colab.git"  #@para
 REPO_REF = "main"  #@param {type:"string"}
 WORKDIR = "/content/local-tts-on-google-colab"  #@param {type:"string"}
 
-ENGINE = "Kokoro"  #@param ["F5-TTS", "Fish-Speech", "Irodori-TTS", "Kokoro", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "Piper", "Piper-Plus", "Qwen3-TTS", "Sarashina-TTS", "Style-Bert-VITS2", "TinyTTS", "VoxCPM2", "Voxtral-TTS"]
+ENGINE = "Kokoro"  #@param ["Chatterbox", "F5-TTS", "Fish-Speech", "Irodori-TTS", "Kokoro", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "Piper", "Piper-Plus", "Qwen3-TTS", "Sarashina-TTS", "Style-Bert-VITS2", "TinyTTS", "VoxCPM2", "Voxtral-TTS"]
 EXPOSE_PUBLIC_URL = True  #@param {type:"boolean"}
 TEST_TEXT = "こんにちは。これは OpenAI 互換 TTS の動作確認です。"  #@param {type:"string"}
 TEST_SPEED = 1.0  #@param {type:"number"}
@@ -93,6 +93,12 @@ SARASHINA_USE_VLLM = False  #@param {type:"boolean"}
 SARASHINA_PROMPT_WAV = ""  #@param {type:"string"}
 SARASHINA_PROMPT_TEXT = ""  #@param {type:"string"}
 SARASHINA_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
+
+#@markdown ---
+#@markdown Chatterbox (GPU recommended, multilingual incl JP, voice cloning)
+CHATTERBOX_LANGUAGE = "ja"  #@param ["ar", "da", "de", "el", "en", "es", "fi", "fr", "he", "hi", "it", "ja", "ko", "ms", "nl", "no", "pl", "pt", "ru", "sv", "sw", "tr", "zh"]
+CHATTERBOX_PROMPT_WAV = ""  #@param {type:"string"}
+CHATTERBOX_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
 
 import shlex
 import subprocess
@@ -210,6 +216,12 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         SARASHINA_PROMPT_TEXT,
         "--sarashina-default-voice",
         SARASHINA_DEFAULT_VOICE,
+        "--chatterbox-language",
+        CHATTERBOX_LANGUAGE,
+        "--chatterbox-prompt-wav",
+        CHATTERBOX_PROMPT_WAV,
+        "--chatterbox-default-voice",
+        CHATTERBOX_DEFAULT_VOICE,
     ]
     if SARASHINA_USE_VLLM:
         cmd.append("--sarashina-use-vllm")

--- a/src/apps/chatterbox_app.py
+++ b/src/apps/chatterbox_app.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import soundfile as sf
+import torch
+from chatterbox.mtl_tts import ChatterboxMultilingualTTS
+from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+logger = logging.getLogger("uvicorn.error")
+
+OPENAI_MODEL_ID = os.environ.get("OPENAI_MODEL_ID", "chatterbox")
+CHATTERBOX_LANGUAGE = os.environ.get("CHATTERBOX_LANGUAGE", "ja")
+CHATTERBOX_PROMPT_WAV = os.environ.get("CHATTERBOX_PROMPT_WAV", "")
+CHATTERBOX_DEFAULT_VOICE = os.environ.get("CHATTERBOX_DEFAULT_VOICE", "default")
+
+# Languages supported by Chatterbox Multilingual.
+SUPPORTED_LANGUAGES = [
+    "ar", "da", "de", "el", "en", "es", "fi", "fr", "he", "hi", "it",
+    "ja", "ko", "ms", "nl", "no", "pl", "pt", "ru", "sv", "sw", "tr", "zh",
+]
+
+app = FastAPI(title="Chatterbox OpenAI Compatible TTS")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[],
+    allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
+    allow_credentials=False,
+    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_headers=["*"],
+    expose_headers=["x-openai-model", "x-openai-voice"],
+)
+
+
+class AudioSpeechRequest(BaseModel):
+    model: str = OPENAI_MODEL_ID
+    input: str
+    voice: str | None = None
+    response_format: str = "wav"
+    speed: float = 1.0
+
+
+_model: ChatterboxMultilingualTTS | None = None
+
+
+def _device() -> str:
+    return "cuda" if torch.cuda.is_available() else "cpu"
+
+
+def get_model() -> ChatterboxMultilingualTTS:
+    global _model
+    if _model is None:
+        device = _device()
+        logger.info("Loading Chatterbox multilingual model on %s", device)
+        _model = ChatterboxMultilingualTTS.from_pretrained(device=device)
+        logger.info("Chatterbox model loaded (sr=%s)", getattr(_model, "sr", "?"))
+    return _model
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, exc: Exception):
+    logger.exception("Unhandled exception while serving request")
+    return JSONResponse(
+        status_code=500,
+        content={"error": type(exc).__name__, "detail": str(exc)},
+    )
+
+
+@app.get("/")
+def root():
+    return {
+        "ok": True,
+        "engine": "Chatterbox",
+        "model": OPENAI_MODEL_ID,
+        "language": CHATTERBOX_LANGUAGE,
+        "default_voice": CHATTERBOX_DEFAULT_VOICE,
+    }
+
+
+@app.get("/v1/models")
+def list_models():
+    return {
+        "object": "list",
+        "data": [{"id": OPENAI_MODEL_ID, "object": "model", "owned_by": "resemble-ai"}],
+    }
+
+
+@app.get("/v1/voices")
+def list_voices():
+    voices = [{"id": "default", "object": "voice", "language": CHATTERBOX_LANGUAGE}]
+    if CHATTERBOX_PROMPT_WAV:
+        voices.append({"id": "clone", "object": "voice", "language": CHATTERBOX_LANGUAGE})
+    return {"object": "list", "data": voices}
+
+
+@app.post("/v1/audio/speech")
+async def audio_speech(payload: AudioSpeechRequest):
+    if payload.response_format.lower() != "wav":
+        raise HTTPException(status_code=400, detail="This wrapper currently supports only wav.")
+
+    if CHATTERBOX_LANGUAGE not in SUPPORTED_LANGUAGES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported language '{CHATTERBOX_LANGUAGE}'. Supported: {SUPPORTED_LANGUAGES}",
+        )
+
+    voice = payload.voice or CHATTERBOX_DEFAULT_VOICE
+    if voice not in {"default", "clone"}:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown voice '{voice}'. Use 'default' or 'clone'.",
+        )
+    if voice == "clone" and not CHATTERBOX_PROMPT_WAV:
+        raise HTTPException(
+            status_code=400,
+            detail="voice='clone' requires --chatterbox-prompt-wav at startup.",
+        )
+
+    model = get_model()
+    kwargs = {"language_id": CHATTERBOX_LANGUAGE}
+    if voice == "clone":
+        kwargs["audio_prompt_path"] = CHATTERBOX_PROMPT_WAV
+
+    wav = model.generate(text=payload.input, **kwargs)
+
+    if hasattr(wav, "detach"):
+        wav_np = wav.detach().to("cpu").numpy()
+    else:
+        wav_np = np.asarray(wav)
+    if wav_np.ndim == 2:
+        wav_np = wav_np[0]
+
+    sample_rate = int(getattr(model, "sr", 24000))
+
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+        tmp_path = tmp.name
+
+    try:
+        sf.write(tmp_path, wav_np, sample_rate)
+        audio_bytes = Path(tmp_path).read_bytes()
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+
+    if not audio_bytes:
+        raise HTTPException(status_code=500, detail="No audio was generated.")
+
+    return Response(
+        content=audio_bytes,
+        media_type="audio/wav",
+        headers={
+            "Content-Length": str(len(audio_bytes)),
+            "x-openai-model": payload.model,
+            "x-openai-voice": voice,
+        },
+    )

--- a/src/apps/dia_app.py
+++ b/src/apps/dia_app.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+import torch
+from dia.model import Dia
+from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+logger = logging.getLogger("uvicorn.error")
+
+OPENAI_MODEL_ID = os.environ.get("OPENAI_MODEL_ID", "dia")
+DIA_HF_MODEL = os.environ.get("DIA_HF_MODEL", "nari-labs/Dia-1.6B-0626")
+DIA_COMPUTE_DTYPE = os.environ.get("DIA_COMPUTE_DTYPE", "float16")
+DIA_PROMPT_WAV = os.environ.get("DIA_PROMPT_WAV", "")
+DIA_PROMPT_TEXT = os.environ.get("DIA_PROMPT_TEXT", "")
+DIA_DEFAULT_VOICE = os.environ.get("DIA_DEFAULT_VOICE", "default")
+
+app = FastAPI(title="Dia OpenAI Compatible TTS")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[],
+    allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
+    allow_credentials=False,
+    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_headers=["*"],
+    expose_headers=["x-openai-model", "x-openai-voice"],
+)
+
+
+class AudioSpeechRequest(BaseModel):
+    model: str = OPENAI_MODEL_ID
+    input: str
+    voice: str | None = None
+    response_format: str = "wav"
+    speed: float = 1.0
+
+
+_model: Dia | None = None
+
+
+def get_model() -> Dia:
+    global _model
+    if _model is None:
+        compute_dtype = DIA_COMPUTE_DTYPE
+        if compute_dtype == "float16" and not torch.cuda.is_available():
+            # float16 on CPU is unsupported by most ops; fall back to float32.
+            compute_dtype = "float32"
+        logger.info("Loading Dia model %s (compute_dtype=%s)", DIA_HF_MODEL, compute_dtype)
+        _model = Dia.from_pretrained(DIA_HF_MODEL, compute_dtype=compute_dtype)
+        logger.info("Dia model loaded")
+    return _model
+
+
+def _ensure_speaker_tags(text: str) -> str:
+    # Dia expects speaker tags like [S1] / [S2] in the input. If the user passes
+    # plain text, prepend [S1] so single-speaker TTS still works.
+    stripped = text.lstrip()
+    if stripped.startswith("[S1]") or stripped.startswith("[S2]"):
+        return text
+    return f"[S1] {text}"
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, exc: Exception):
+    logger.exception("Unhandled exception while serving request")
+    return JSONResponse(
+        status_code=500,
+        content={"error": type(exc).__name__, "detail": str(exc)},
+    )
+
+
+@app.get("/")
+def root():
+    return {
+        "ok": True,
+        "engine": "Dia",
+        "model": OPENAI_MODEL_ID,
+        "hf_model": DIA_HF_MODEL,
+        "default_voice": DIA_DEFAULT_VOICE,
+    }
+
+
+@app.get("/v1/models")
+def list_models():
+    return {
+        "object": "list",
+        "data": [{"id": OPENAI_MODEL_ID, "object": "model", "owned_by": "nari-labs"}],
+    }
+
+
+@app.get("/v1/voices")
+def list_voices():
+    voices = [{"id": "default", "object": "voice", "language": "en"}]
+    if DIA_PROMPT_WAV and DIA_PROMPT_TEXT:
+        voices.append({"id": "clone", "object": "voice", "language": "en"})
+    return {"object": "list", "data": voices}
+
+
+@app.post("/v1/audio/speech")
+async def audio_speech(payload: AudioSpeechRequest):
+    if payload.response_format.lower() != "wav":
+        raise HTTPException(status_code=400, detail="This wrapper currently supports only wav.")
+
+    voice = payload.voice or DIA_DEFAULT_VOICE
+    if voice not in {"default", "clone"}:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown voice '{voice}'. Use 'default' or 'clone'.",
+        )
+    if voice == "clone" and not (DIA_PROMPT_WAV and DIA_PROMPT_TEXT):
+        raise HTTPException(
+            status_code=400,
+            detail="voice='clone' requires both --dia-prompt-wav and --dia-prompt-text at startup.",
+        )
+
+    model = get_model()
+
+    if voice == "clone":
+        # Per Dia docs, prepend the prompt transcript so the model conditions on it.
+        clone_text = _ensure_speaker_tags(DIA_PROMPT_TEXT)
+        new_text = _ensure_speaker_tags(payload.input)
+        text = f"{clone_text} {new_text}"
+        output = model.generate(text, audio_prompt=DIA_PROMPT_WAV, use_torch_compile=False)
+    else:
+        text = _ensure_speaker_tags(payload.input)
+        output = model.generate(text, use_torch_compile=False)
+
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+        tmp_path = tmp.name
+
+    try:
+        model.save_audio(tmp_path, output)
+        audio_bytes = Path(tmp_path).read_bytes()
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+
+    if not audio_bytes:
+        raise HTTPException(status_code=500, detail="No audio was generated.")
+
+    return Response(
+        content=audio_bytes,
+        media_type="audio/wav",
+        headers={
+            "Content-Length": str(len(audio_bytes)),
+            "x-openai-model": payload.model,
+            "x-openai-voice": voice,
+        },
+    )

--- a/src/apps/dia_app.py
+++ b/src/apps/dia_app.py
@@ -122,15 +122,27 @@ async def audio_speech(payload: AudioSpeechRequest):
 
     model = get_model()
 
+    # Without explicit guidance / sampling parameters, Dia tends to produce
+    # near-silent output -- the WAV is generated at the right duration but
+    # max_abs hovers around 0.01 (~ -40 dB), so it sounds empty. The values
+    # below match the upstream `generate.py` defaults that the Dia README
+    # walks through, and reliably produce intelligible speech on L4.
+    gen_kwargs = dict(
+        use_torch_compile=False,
+        cfg_scale=3.0,
+        temperature=1.3,
+        top_p=0.95,
+        cfg_filter_top_k=35,
+    )
     if voice == "clone":
         # Per Dia docs, prepend the prompt transcript so the model conditions on it.
         clone_text = _ensure_speaker_tags(DIA_PROMPT_TEXT)
         new_text = _ensure_speaker_tags(payload.input)
         text = f"{clone_text} {new_text}"
-        output = model.generate(text, audio_prompt=DIA_PROMPT_WAV, use_torch_compile=False)
+        output = model.generate(text, audio_prompt=DIA_PROMPT_WAV, **gen_kwargs)
     else:
         text = _ensure_speaker_tags(payload.input)
-        output = model.generate(text, use_torch_compile=False)
+        output = model.generate(text, **gen_kwargs)
 
     with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
         tmp_path = tmp.name

--- a/src/apps/openvoice_v2_app.py
+++ b/src/apps/openvoice_v2_app.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+import torch
+from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from melo.api import TTS
+from openvoice import se_extractor
+from openvoice.api import ToneColorConverter
+from pydantic import BaseModel
+
+logger = logging.getLogger("uvicorn.error")
+
+OPENAI_MODEL_ID = os.environ.get("OPENAI_MODEL_ID", "openvoice-v2")
+OPENVOICE_LANGUAGE = os.environ.get("OPENVOICE_LANGUAGE", "JP")
+OPENVOICE_CKPT_DIR = Path(os.environ.get("OPENVOICE_CKPT_DIR", "checkpoints_v2"))
+OPENVOICE_REPO_DIR = Path(os.environ.get("OPENVOICE_REPO_DIR", "OpenVoice"))
+OPENVOICE_PROMPT_WAV = os.environ.get("OPENVOICE_PROMPT_WAV", "")
+OPENVOICE_DEFAULT_VOICE = os.environ.get("OPENVOICE_DEFAULT_VOICE", "default")
+
+# Languages exposed by OpenVoice V2 + MeloTTS base speakers.
+SUPPORTED_LANGUAGES = ["EN", "ES", "FR", "ZH", "JP", "KR"]
+# Bundled reference audio shipped in the OpenVoice repo, used as the fallback
+# when the user does not provide --openvoice-prompt-wav.
+DEFAULT_REFERENCE = OPENVOICE_REPO_DIR / "resources" / "example_reference.mp3"
+
+app = FastAPI(title="OpenVoice V2 OpenAI Compatible TTS")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[],
+    allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
+    allow_credentials=False,
+    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_headers=["*"],
+    expose_headers=["x-openai-model", "x-openai-voice"],
+)
+
+
+class AudioSpeechRequest(BaseModel):
+    model: str = OPENAI_MODEL_ID
+    input: str
+    voice: str | None = None
+    response_format: str = "wav"
+    speed: float = 1.0
+
+
+_tone_converter: ToneColorConverter | None = None
+_base_tts: TTS | None = None
+_base_speaker_id: int | None = None
+_source_se: torch.Tensor | None = None
+_target_se_cache: dict[str, torch.Tensor] = {}
+
+
+def _device() -> str:
+    return "cuda" if torch.cuda.is_available() else "cpu"
+
+
+def get_tone_converter() -> ToneColorConverter:
+    global _tone_converter
+    if _tone_converter is None:
+        device = _device()
+        cfg = OPENVOICE_CKPT_DIR / "converter" / "config.json"
+        ckpt = OPENVOICE_CKPT_DIR / "converter" / "checkpoint.pth"
+        logger.info("Loading ToneColorConverter from %s", cfg)
+        _tone_converter = ToneColorConverter(str(cfg), device=device)
+        _tone_converter.load_ckpt(str(ckpt))
+    return _tone_converter
+
+
+def get_base_tts() -> tuple[TTS, int, torch.Tensor]:
+    global _base_tts, _base_speaker_id, _source_se
+    if _base_tts is None:
+        device = _device()
+        if OPENVOICE_LANGUAGE not in SUPPORTED_LANGUAGES:
+            raise RuntimeError(
+                f"Unsupported language '{OPENVOICE_LANGUAGE}'. Supported: {SUPPORTED_LANGUAGES}"
+            )
+        logger.info("Loading MeloTTS base for language=%s", OPENVOICE_LANGUAGE)
+        _base_tts = TTS(language=OPENVOICE_LANGUAGE, device=device)
+        speaker_ids = _base_tts.hps.data.spk2id
+        speaker_key = next(iter(speaker_ids.keys()))
+        _base_speaker_id = speaker_ids[speaker_key]
+        se_filename = speaker_key.lower().replace("_", "-")
+        se_path = OPENVOICE_CKPT_DIR / "base_speakers" / "ses" / f"{se_filename}.pth"
+        logger.info("Loading source speaker embedding from %s", se_path)
+        _source_se = torch.load(str(se_path), map_location=device)
+    assert _base_tts is not None and _base_speaker_id is not None and _source_se is not None
+    return _base_tts, _base_speaker_id, _source_se
+
+
+def get_target_se(voice: str) -> torch.Tensor:
+    if voice in _target_se_cache:
+        return _target_se_cache[voice]
+    converter = get_tone_converter()
+    if voice == "clone":
+        ref_path = OPENVOICE_PROMPT_WAV
+    else:
+        ref_path = str(DEFAULT_REFERENCE)
+    if not ref_path or not Path(ref_path).exists():
+        raise HTTPException(
+            status_code=500,
+            detail=f"Reference audio not found for voice '{voice}': {ref_path}",
+        )
+    logger.info("Extracting target SE for voice '%s' from %s", voice, ref_path)
+    target_se, _ = se_extractor.get_se(ref_path, converter, vad=True)
+    _target_se_cache[voice] = target_se
+    return target_se
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, exc: Exception):
+    logger.exception("Unhandled exception while serving request")
+    return JSONResponse(
+        status_code=500,
+        content={"error": type(exc).__name__, "detail": str(exc)},
+    )
+
+
+@app.get("/")
+def root():
+    return {
+        "ok": True,
+        "engine": "OpenVoice V2",
+        "model": OPENAI_MODEL_ID,
+        "language": OPENVOICE_LANGUAGE,
+        "default_voice": OPENVOICE_DEFAULT_VOICE,
+    }
+
+
+@app.get("/v1/models")
+def list_models():
+    return {
+        "object": "list",
+        "data": [{"id": OPENAI_MODEL_ID, "object": "model", "owned_by": "myshell-ai"}],
+    }
+
+
+@app.get("/v1/voices")
+def list_voices():
+    voices = [{"id": "default", "object": "voice", "language": OPENVOICE_LANGUAGE}]
+    if OPENVOICE_PROMPT_WAV:
+        voices.append({"id": "clone", "object": "voice", "language": OPENVOICE_LANGUAGE})
+    return {"object": "list", "data": voices}
+
+
+@app.post("/v1/audio/speech")
+async def audio_speech(payload: AudioSpeechRequest):
+    if payload.response_format.lower() != "wav":
+        raise HTTPException(status_code=400, detail="This wrapper currently supports only wav.")
+
+    voice = payload.voice or OPENVOICE_DEFAULT_VOICE
+    if voice not in {"default", "clone"}:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown voice '{voice}'. Use 'default' or 'clone'.",
+        )
+    if voice == "clone" and not OPENVOICE_PROMPT_WAV:
+        raise HTTPException(
+            status_code=400,
+            detail="voice='clone' requires --openvoice-prompt-wav at startup.",
+        )
+
+    tts, speaker_id, source_se = get_base_tts()
+    converter = get_tone_converter()
+    target_se = get_target_se(voice)
+
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp_src:
+        src_path = tmp_src.name
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp_out:
+        out_path = tmp_out.name
+
+    try:
+        tts.tts_to_file(payload.input, speaker_id, src_path, speed=payload.speed)
+        converter.convert(
+            audio_src_path=src_path,
+            src_se=source_se,
+            tgt_se=target_se,
+            output_path=out_path,
+            message="@MyShell",
+        )
+        audio_bytes = Path(out_path).read_bytes()
+    finally:
+        Path(src_path).unlink(missing_ok=True)
+        Path(out_path).unlink(missing_ok=True)
+
+    if not audio_bytes:
+        raise HTTPException(status_code=500, detail="No audio was generated.")
+
+    return Response(
+        content=audio_bytes,
+        media_type="audio/wav",
+        headers={
+            "Content-Length": str(len(audio_bytes)),
+            "x-openai-model": payload.model,
+            "x-openai-voice": voice,
+        },
+    )

--- a/src/apps/outetts_app.py
+++ b/src/apps/outetts_app.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+import outetts
+from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+logger = logging.getLogger("uvicorn.error")
+
+OPENAI_MODEL_ID = os.environ.get("OPENAI_MODEL_ID", "outetts")
+OUTETTS_MODEL_SIZE = os.environ.get("OUTETTS_MODEL_SIZE", "0.6B")
+OUTETTS_BACKEND = os.environ.get("OUTETTS_BACKEND", "HF")
+OUTETTS_DEFAULT_SPEAKER = os.environ.get("OUTETTS_DEFAULT_SPEAKER", "EN-FEMALE-1-NEUTRAL")
+OUTETTS_PROMPT_WAV = os.environ.get("OUTETTS_PROMPT_WAV", "")
+OUTETTS_PROMPT_TEXT = os.environ.get("OUTETTS_PROMPT_TEXT", "")
+OUTETTS_DEFAULT_VOICE = os.environ.get("OUTETTS_DEFAULT_VOICE", "default")
+
+app = FastAPI(title="OuteTTS OpenAI Compatible TTS")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[],
+    allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
+    allow_credentials=False,
+    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_headers=["*"],
+    expose_headers=["x-openai-model", "x-openai-voice"],
+)
+
+
+class AudioSpeechRequest(BaseModel):
+    model: str = OPENAI_MODEL_ID
+    input: str
+    voice: str | None = None
+    response_format: str = "wav"
+    speed: float = 1.0
+
+
+_interface: outetts.Interface | None = None
+_speaker_cache: dict[str, object] = {}
+
+
+def _resolve_model_enum() -> object:
+    size = OUTETTS_MODEL_SIZE.upper().replace(".", "_")
+    name = f"VERSION_1_0_SIZE_{size}"
+    if not hasattr(outetts.Models, name):
+        raise RuntimeError(
+            f"Unknown OuteTTS model size '{OUTETTS_MODEL_SIZE}'. Expected e.g. '0.6B' or '1B'."
+        )
+    return getattr(outetts.Models, name)
+
+
+def _resolve_backend_enum() -> object:
+    name = OUTETTS_BACKEND.upper()
+    if not hasattr(outetts.Backend, name):
+        raise RuntimeError(
+            f"Unknown OuteTTS backend '{OUTETTS_BACKEND}'. Expected e.g. 'HF' or 'LLAMACPP'."
+        )
+    return getattr(outetts.Backend, name)
+
+
+def get_interface() -> outetts.Interface:
+    global _interface
+    if _interface is None:
+        model_enum = _resolve_model_enum()
+        backend_enum = _resolve_backend_enum()
+        logger.info("Loading OuteTTS: model=%s backend=%s", model_enum, backend_enum)
+        config = outetts.ModelConfig.auto_config(model=model_enum, backend=backend_enum)
+        _interface = outetts.Interface(config=config)
+        logger.info("OuteTTS interface ready")
+    return _interface
+
+
+def get_speaker(voice: str):
+    if voice in _speaker_cache:
+        return _speaker_cache[voice]
+    interface = get_interface()
+    if voice == "clone":
+        if not OUTETTS_PROMPT_WAV:
+            raise HTTPException(
+                status_code=400,
+                detail="voice='clone' requires --outetts-prompt-wav at startup.",
+            )
+        kwargs = {"audio_path": OUTETTS_PROMPT_WAV}
+        if OUTETTS_PROMPT_TEXT:
+            kwargs["transcript"] = OUTETTS_PROMPT_TEXT
+        speaker = interface.create_speaker(**kwargs)
+    else:
+        speaker = interface.load_default_speaker(OUTETTS_DEFAULT_SPEAKER)
+    _speaker_cache[voice] = speaker
+    return speaker
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, exc: Exception):
+    logger.exception("Unhandled exception while serving request")
+    return JSONResponse(
+        status_code=500,
+        content={"error": type(exc).__name__, "detail": str(exc)},
+    )
+
+
+@app.get("/")
+def root():
+    return {
+        "ok": True,
+        "engine": "OuteTTS",
+        "model": OPENAI_MODEL_ID,
+        "size": OUTETTS_MODEL_SIZE,
+        "backend": OUTETTS_BACKEND,
+        "default_speaker": OUTETTS_DEFAULT_SPEAKER,
+        "default_voice": OUTETTS_DEFAULT_VOICE,
+    }
+
+
+@app.get("/v1/models")
+def list_models():
+    return {
+        "object": "list",
+        "data": [{"id": OPENAI_MODEL_ID, "object": "model", "owned_by": "outeai"}],
+    }
+
+
+@app.get("/v1/voices")
+def list_voices():
+    voices = [{"id": "default", "object": "voice", "speaker": OUTETTS_DEFAULT_SPEAKER}]
+    if OUTETTS_PROMPT_WAV:
+        voices.append({"id": "clone", "object": "voice"})
+    return {"object": "list", "data": voices}
+
+
+@app.post("/v1/audio/speech")
+async def audio_speech(payload: AudioSpeechRequest):
+    if payload.response_format.lower() != "wav":
+        raise HTTPException(status_code=400, detail="This wrapper currently supports only wav.")
+
+    voice = payload.voice or OUTETTS_DEFAULT_VOICE
+    if voice not in {"default", "clone"}:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown voice '{voice}'. Use 'default' or 'clone'.",
+        )
+
+    interface = get_interface()
+    speaker = get_speaker(voice)
+
+    output = interface.generate(
+        config=outetts.GenerationConfig(
+            text=payload.input,
+            generation_type=outetts.GenerationType.CHUNKED,
+            speaker=speaker,
+        )
+    )
+
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+        tmp_path = tmp.name
+
+    try:
+        output.save(tmp_path)
+        audio_bytes = Path(tmp_path).read_bytes()
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+
+    if not audio_bytes:
+        raise HTTPException(status_code=500, detail="No audio was generated.")
+
+    return Response(
+        content=audio_bytes,
+        media_type="audio/wav",
+        headers={
+            "Content-Length": str(len(audio_bytes)),
+            "x-openai-model": payload.model,
+            "x-openai-voice": voice,
+        },
+    )

--- a/src/apps/vibevoice_app.py
+++ b/src/apps/vibevoice_app.py
@@ -60,12 +60,21 @@ def get_model() -> tuple[VibeVoiceProcessor, VibeVoiceForConditionalGeneration]:
         dtype = torch.bfloat16 if device == "cuda" else torch.float32
         logger.info("Loading VibeVoice processor + model: %s on %s (%s)", VIBEVOICE_HF_MODEL, device, dtype)
         _processor = VibeVoiceProcessor.from_pretrained(VIBEVOICE_HF_MODEL)
+        # transformers deprecated `torch_dtype` in favor of `dtype`; pass both
+        # via `dtype` so we work on current versions.
         _model = VibeVoiceForConditionalGeneration.from_pretrained(
             VIBEVOICE_HF_MODEL,
-            torch_dtype=dtype,
+            dtype=dtype,
             device_map=device,
         )
-        _model.set_ddpm_inference_steps(num_steps=VIBEVOICE_DDPM_STEPS)
+        # Upstream `model.set_ddpm_inference_steps(...)` was removed when the
+        # class was renamed; configure the diffusion scheduler directly.
+        if hasattr(_model, "set_ddpm_inference_steps"):
+            _model.set_ddpm_inference_steps(num_steps=VIBEVOICE_DDPM_STEPS)
+        else:
+            _model.model.noise_scheduler.set_timesteps(
+                num_inference_steps=VIBEVOICE_DDPM_STEPS
+            )
         logger.info("VibeVoice ready (ddpm_steps=%s, cfg_scale=%s)", VIBEVOICE_DDPM_STEPS, VIBEVOICE_CFG_SCALE)
     return _processor, _model
 

--- a/src/apps/vibevoice_app.py
+++ b/src/apps/vibevoice_app.py
@@ -10,9 +10,7 @@ from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
-from vibevoice.modular.modeling_vibevoice_inference import (
-    VibeVoiceForConditionalGenerationInference,
-)
+from vibevoice.modular.modeling_vibevoice import VibeVoiceForConditionalGeneration
 from vibevoice.processor.vibevoice_processor import VibeVoiceProcessor
 
 logger = logging.getLogger("uvicorn.error")
@@ -48,21 +46,21 @@ class AudioSpeechRequest(BaseModel):
 
 
 _processor: VibeVoiceProcessor | None = None
-_model: VibeVoiceForConditionalGenerationInference | None = None
+_model: VibeVoiceForConditionalGeneration | None = None
 
 
 def _device() -> str:
     return "cuda" if torch.cuda.is_available() else "cpu"
 
 
-def get_model() -> tuple[VibeVoiceProcessor, VibeVoiceForConditionalGenerationInference]:
+def get_model() -> tuple[VibeVoiceProcessor, VibeVoiceForConditionalGeneration]:
     global _processor, _model
     if _processor is None or _model is None:
         device = _device()
         dtype = torch.bfloat16 if device == "cuda" else torch.float32
         logger.info("Loading VibeVoice processor + model: %s on %s (%s)", VIBEVOICE_HF_MODEL, device, dtype)
         _processor = VibeVoiceProcessor.from_pretrained(VIBEVOICE_HF_MODEL)
-        _model = VibeVoiceForConditionalGenerationInference.from_pretrained(
+        _model = VibeVoiceForConditionalGeneration.from_pretrained(
             VIBEVOICE_HF_MODEL,
             torch_dtype=dtype,
             device_map=device,

--- a/src/apps/vibevoice_app.py
+++ b/src/apps/vibevoice_app.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+import torch
+from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+from vibevoice.modular.modeling_vibevoice_inference import (
+    VibeVoiceForConditionalGenerationInference,
+)
+from vibevoice.processor.vibevoice_processor import VibeVoiceProcessor
+
+logger = logging.getLogger("uvicorn.error")
+
+OPENAI_MODEL_ID = os.environ.get("OPENAI_MODEL_ID", "vibevoice")
+VIBEVOICE_HF_MODEL = os.environ.get("VIBEVOICE_HF_MODEL", "microsoft/VibeVoice-1.5B")
+VIBEVOICE_VOICES_DIR = Path(os.environ.get("VIBEVOICE_VOICES_DIR", "demo/voices"))
+VIBEVOICE_DEFAULT_SPEAKER = os.environ.get("VIBEVOICE_DEFAULT_SPEAKER", "en-Alice_woman")
+VIBEVOICE_PROMPT_WAV = os.environ.get("VIBEVOICE_PROMPT_WAV", "")
+VIBEVOICE_DEFAULT_VOICE = os.environ.get("VIBEVOICE_DEFAULT_VOICE", "default")
+VIBEVOICE_DDPM_STEPS = int(os.environ.get("VIBEVOICE_DDPM_STEPS", "10"))
+VIBEVOICE_CFG_SCALE = float(os.environ.get("VIBEVOICE_CFG_SCALE", "1.3"))
+
+app = FastAPI(title="VibeVoice OpenAI Compatible TTS")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[],
+    allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
+    allow_credentials=False,
+    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_headers=["*"],
+    expose_headers=["x-openai-model", "x-openai-voice"],
+)
+
+
+class AudioSpeechRequest(BaseModel):
+    model: str = OPENAI_MODEL_ID
+    input: str
+    voice: str | None = None
+    response_format: str = "wav"
+    speed: float = 1.0
+
+
+_processor: VibeVoiceProcessor | None = None
+_model: VibeVoiceForConditionalGenerationInference | None = None
+
+
+def _device() -> str:
+    return "cuda" if torch.cuda.is_available() else "cpu"
+
+
+def get_model() -> tuple[VibeVoiceProcessor, VibeVoiceForConditionalGenerationInference]:
+    global _processor, _model
+    if _processor is None or _model is None:
+        device = _device()
+        dtype = torch.bfloat16 if device == "cuda" else torch.float32
+        logger.info("Loading VibeVoice processor + model: %s on %s (%s)", VIBEVOICE_HF_MODEL, device, dtype)
+        _processor = VibeVoiceProcessor.from_pretrained(VIBEVOICE_HF_MODEL)
+        _model = VibeVoiceForConditionalGenerationInference.from_pretrained(
+            VIBEVOICE_HF_MODEL,
+            torch_dtype=dtype,
+            device_map=device,
+        )
+        _model.set_ddpm_inference_steps(num_steps=VIBEVOICE_DDPM_STEPS)
+        logger.info("VibeVoice ready (ddpm_steps=%s, cfg_scale=%s)", VIBEVOICE_DDPM_STEPS, VIBEVOICE_CFG_SCALE)
+    return _processor, _model
+
+
+def _resolve_speaker_path(voice: str) -> Path:
+    if voice == "clone":
+        if not VIBEVOICE_PROMPT_WAV:
+            raise HTTPException(
+                status_code=400,
+                detail="voice='clone' requires --vibevoice-prompt-wav at startup.",
+            )
+        return Path(VIBEVOICE_PROMPT_WAV)
+    candidate = VIBEVOICE_VOICES_DIR / f"{VIBEVOICE_DEFAULT_SPEAKER}.wav"
+    if not candidate.exists():
+        raise HTTPException(
+            status_code=500,
+            detail=f"Bundled speaker file not found: {candidate}",
+        )
+    return candidate
+
+
+def _format_text(text: str) -> str:
+    # VibeVoice expects "Speaker N: ..." per line. If the user did not provide a
+    # speaker prefix, prepend "Speaker 1:" so single-speaker TTS still works.
+    stripped = text.lstrip()
+    if stripped.lower().startswith("speaker "):
+        return text
+    return f"Speaker 1: {text}"
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, exc: Exception):
+    logger.exception("Unhandled exception while serving request")
+    return JSONResponse(
+        status_code=500,
+        content={"error": type(exc).__name__, "detail": str(exc)},
+    )
+
+
+@app.get("/")
+def root():
+    return {
+        "ok": True,
+        "engine": "VibeVoice",
+        "model": OPENAI_MODEL_ID,
+        "hf_model": VIBEVOICE_HF_MODEL,
+        "default_speaker": VIBEVOICE_DEFAULT_SPEAKER,
+        "default_voice": VIBEVOICE_DEFAULT_VOICE,
+    }
+
+
+@app.get("/v1/models")
+def list_models():
+    return {
+        "object": "list",
+        "data": [{"id": OPENAI_MODEL_ID, "object": "model", "owned_by": "microsoft"}],
+    }
+
+
+@app.get("/v1/voices")
+def list_voices():
+    voices = [{"id": "default", "object": "voice", "speaker": VIBEVOICE_DEFAULT_SPEAKER}]
+    if VIBEVOICE_PROMPT_WAV:
+        voices.append({"id": "clone", "object": "voice"})
+    return {"object": "list", "data": voices}
+
+
+@app.post("/v1/audio/speech")
+async def audio_speech(payload: AudioSpeechRequest):
+    if payload.response_format.lower() != "wav":
+        raise HTTPException(status_code=400, detail="This wrapper currently supports only wav.")
+
+    voice = payload.voice or VIBEVOICE_DEFAULT_VOICE
+    if voice not in {"default", "clone"}:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown voice '{voice}'. Use 'default' or 'clone'.",
+        )
+
+    processor, model = get_model()
+    speaker_path = _resolve_speaker_path(voice)
+
+    text = _format_text(payload.input)
+    inputs = processor(
+        text=[text],
+        voice_samples=[[str(speaker_path)]],
+        padding=True,
+        return_tensors="pt",
+    )
+
+    outputs = model.generate(
+        **inputs,
+        max_new_tokens=None,
+        cfg_scale=VIBEVOICE_CFG_SCALE,
+        tokenizer=processor.tokenizer,
+        generation_config={"do_sample": False},
+    )
+
+    if not getattr(outputs, "speech_outputs", None):
+        raise HTTPException(status_code=500, detail="No audio was generated.")
+
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+        tmp_path = tmp.name
+
+    try:
+        processor.save_audio(outputs.speech_outputs[0], tmp_path)
+        audio_bytes = Path(tmp_path).read_bytes()
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+
+    if not audio_bytes:
+        raise HTTPException(status_code=500, detail="No audio was generated.")
+
+    return Response(
+        content=audio_bytes,
+        media_type="audio/wav",
+        headers={
+            "Content-Length": str(len(audio_bytes)),
+            "x-openai-model": payload.model,
+            "x-openai-voice": voice,
+        },
+    )

--- a/src/apps/zonos_app.py
+++ b/src/apps/zonos_app.py
@@ -8,6 +8,17 @@ from pathlib import Path
 import soundfile as sf
 import torch
 import torchaudio
+
+# Force the global default device to CPU. Zonos.from_pretrained(..., device="cuda")
+# flips the default device to cuda during model loading, after which the
+# lazily-built `torchaudio.transforms.MelSpectrogram` filterbank inside
+# `SpeakerEmbeddingLDA` ends up with some tensors on cuda and `torch.zeros(1)`
+# (no explicit device) on cpu, raising "Expected all tensors to be on the same
+# device" during the first /v1/audio/speech call. Pinning the default to CPU
+# at module init keeps the filterbank consistent; we still move the model and
+# speaker embedding to cuda explicitly below.
+torch.set_default_device("cpu")
+
 from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse

--- a/src/apps/zonos_app.py
+++ b/src/apps/zonos_app.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+import soundfile as sf
+import torch
+import torchaudio
+from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+from zonos.conditioning import make_cond_dict
+from zonos.model import Zonos
+
+logger = logging.getLogger("uvicorn.error")
+
+OPENAI_MODEL_ID = os.environ.get("OPENAI_MODEL_ID", "zonos")
+ZONOS_HF_MODEL = os.environ.get("ZONOS_HF_MODEL", "Zyphra/Zonos-v0.1-transformer")
+ZONOS_LANGUAGE = os.environ.get("ZONOS_LANGUAGE", "ja")
+ZONOS_PROMPT_WAV = os.environ.get("ZONOS_PROMPT_WAV", "")
+ZONOS_DEFAULT_PROMPT_WAV = os.environ.get("ZONOS_DEFAULT_PROMPT_WAV", "")
+ZONOS_DEFAULT_VOICE = os.environ.get("ZONOS_DEFAULT_VOICE", "default")
+
+# Languages natively supported by the Zonos v0.1 release.
+SUPPORTED_LANGUAGES = ["en", "ja", "zh", "fr", "de"]
+
+app = FastAPI(title="Zonos OpenAI Compatible TTS")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[],
+    allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
+    allow_credentials=False,
+    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_headers=["*"],
+    expose_headers=["x-openai-model", "x-openai-voice"],
+)
+
+
+class AudioSpeechRequest(BaseModel):
+    model: str = OPENAI_MODEL_ID
+    input: str
+    voice: str | None = None
+    response_format: str = "wav"
+    speed: float = 1.0
+
+
+_model: Zonos | None = None
+_speaker_cache: dict[str, torch.Tensor] = {}
+
+
+def _device() -> str:
+    return "cuda" if torch.cuda.is_available() else "cpu"
+
+
+def get_model() -> Zonos:
+    global _model
+    if _model is None:
+        device = _device()
+        logger.info("Loading Zonos model %s on %s", ZONOS_HF_MODEL, device)
+        _model = Zonos.from_pretrained(ZONOS_HF_MODEL, device=device)
+        logger.info("Zonos model loaded")
+    return _model
+
+
+def get_speaker(model: Zonos, voice: str) -> torch.Tensor:
+    if voice in _speaker_cache:
+        return _speaker_cache[voice]
+    if voice == "clone":
+        wav_path = ZONOS_PROMPT_WAV
+    else:
+        wav_path = ZONOS_DEFAULT_PROMPT_WAV
+    if not wav_path or not Path(wav_path).exists():
+        raise HTTPException(
+            status_code=500,
+            detail=f"Reference audio not found for voice '{voice}': {wav_path}",
+        )
+    logger.info("Encoding speaker embedding for voice '%s' from %s", voice, wav_path)
+    wav, sampling_rate = torchaudio.load(wav_path)
+    speaker = model.make_speaker_embedding(wav, sampling_rate)
+    _speaker_cache[voice] = speaker
+    return speaker
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, exc: Exception):
+    logger.exception("Unhandled exception while serving request")
+    return JSONResponse(
+        status_code=500,
+        content={"error": type(exc).__name__, "detail": str(exc)},
+    )
+
+
+@app.get("/")
+def root():
+    return {
+        "ok": True,
+        "engine": "Zonos",
+        "model": OPENAI_MODEL_ID,
+        "hf_model": ZONOS_HF_MODEL,
+        "language": ZONOS_LANGUAGE,
+        "default_voice": ZONOS_DEFAULT_VOICE,
+    }
+
+
+@app.get("/v1/models")
+def list_models():
+    return {
+        "object": "list",
+        "data": [{"id": OPENAI_MODEL_ID, "object": "model", "owned_by": "zyphra"}],
+    }
+
+
+@app.get("/v1/voices")
+def list_voices():
+    voices = [{"id": "default", "object": "voice", "language": ZONOS_LANGUAGE}]
+    if ZONOS_PROMPT_WAV:
+        voices.append({"id": "clone", "object": "voice", "language": ZONOS_LANGUAGE})
+    return {"object": "list", "data": voices}
+
+
+@app.post("/v1/audio/speech")
+async def audio_speech(payload: AudioSpeechRequest):
+    if payload.response_format.lower() != "wav":
+        raise HTTPException(status_code=400, detail="This wrapper currently supports only wav.")
+
+    if ZONOS_LANGUAGE not in SUPPORTED_LANGUAGES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported language '{ZONOS_LANGUAGE}'. Supported: {SUPPORTED_LANGUAGES}",
+        )
+
+    voice = payload.voice or ZONOS_DEFAULT_VOICE
+    if voice not in {"default", "clone"}:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown voice '{voice}'. Use 'default' or 'clone'.",
+        )
+    if voice == "clone" and not ZONOS_PROMPT_WAV:
+        raise HTTPException(
+            status_code=400,
+            detail="voice='clone' requires --zonos-prompt-wav at startup.",
+        )
+
+    model = get_model()
+    speaker = get_speaker(model, voice)
+    cond_dict = make_cond_dict(text=payload.input, speaker=speaker, language=ZONOS_LANGUAGE)
+    conditioning = model.prepare_conditioning(cond_dict)
+    codes = model.generate(conditioning)
+    wavs = model.autoencoder.decode(codes).cpu()
+
+    audio = wavs[0]
+    if audio.ndim == 2:
+        audio = audio[0]
+    sample_rate = int(model.autoencoder.sampling_rate)
+
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+        tmp_path = tmp.name
+
+    try:
+        sf.write(tmp_path, audio.numpy(), sample_rate)
+        audio_bytes = Path(tmp_path).read_bytes()
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+
+    if not audio_bytes:
+        raise HTTPException(status_code=500, detail="No audio was generated.")
+
+    return Response(
+        content=audio_bytes,
+        media_type="audio/wav",
+        headers={
+            "Content-Length": str(len(audio_bytes)),
+            "x-openai-model": payload.model,
+            "x-openai-voice": voice,
+        },
+    )

--- a/src/config.py
+++ b/src/config.py
@@ -86,6 +86,9 @@ class Settings:
     sarashina_prompt_wav: str = ""
     sarashina_prompt_text: str = ""
     sarashina_default_voice: str = "default"
+    chatterbox_language: str = "ja"
+    chatterbox_prompt_wav: str = ""
+    chatterbox_default_voice: str = "default"
     root_dir: Path = Path("/content/openai-compatible-local-tts")
     repo_dir: Path = field(default_factory=default_repo_dir)
     app_port: int = 8000

--- a/src/config.py
+++ b/src/config.py
@@ -107,6 +107,12 @@ class Settings:
     openvoice_language: str = "JP"
     openvoice_prompt_wav: str = ""
     openvoice_default_voice: str = "default"
+    vibevoice_hf_model: str = "microsoft/VibeVoice-1.5B"
+    vibevoice_default_speaker: str = "en-Alice_woman"
+    vibevoice_prompt_wav: str = ""
+    vibevoice_default_voice: str = "default"
+    vibevoice_ddpm_steps: int = 10
+    vibevoice_cfg_scale: float = 1.3
     root_dir: Path = Path("/content/openai-compatible-local-tts")
     repo_dir: Path = field(default_factory=default_repo_dir)
     app_port: int = 8000

--- a/src/config.py
+++ b/src/config.py
@@ -99,6 +99,11 @@ class Settings:
     outetts_prompt_wav: str = ""
     outetts_prompt_text: str = ""
     outetts_default_voice: str = "default"
+    dia_hf_model: str = "nari-labs/Dia-1.6B-0626"
+    dia_compute_dtype: str = "float16"
+    dia_prompt_wav: str = ""
+    dia_prompt_text: str = ""
+    dia_default_voice: str = "default"
     root_dir: Path = Path("/content/openai-compatible-local-tts")
     repo_dir: Path = field(default_factory=default_repo_dir)
     app_port: int = 8000

--- a/src/config.py
+++ b/src/config.py
@@ -93,6 +93,12 @@ class Settings:
     zonos_language: str = "ja"
     zonos_prompt_wav: str = ""
     zonos_default_voice: str = "default"
+    outetts_model_size: str = "0.6B"
+    outetts_backend: str = "HF"
+    outetts_default_speaker: str = "EN-FEMALE-1-NEUTRAL"
+    outetts_prompt_wav: str = ""
+    outetts_prompt_text: str = ""
+    outetts_default_voice: str = "default"
     root_dir: Path = Path("/content/openai-compatible-local-tts")
     repo_dir: Path = field(default_factory=default_repo_dir)
     app_port: int = 8000

--- a/src/config.py
+++ b/src/config.py
@@ -89,6 +89,10 @@ class Settings:
     chatterbox_language: str = "ja"
     chatterbox_prompt_wav: str = ""
     chatterbox_default_voice: str = "default"
+    zonos_hf_model: str = "Zyphra/Zonos-v0.1-transformer"
+    zonos_language: str = "ja"
+    zonos_prompt_wav: str = ""
+    zonos_default_voice: str = "default"
     root_dir: Path = Path("/content/openai-compatible-local-tts")
     repo_dir: Path = field(default_factory=default_repo_dir)
     app_port: int = 8000

--- a/src/config.py
+++ b/src/config.py
@@ -104,6 +104,9 @@ class Settings:
     dia_prompt_wav: str = ""
     dia_prompt_text: str = ""
     dia_default_voice: str = "default"
+    openvoice_language: str = "JP"
+    openvoice_prompt_wav: str = ""
+    openvoice_default_voice: str = "default"
     root_dir: Path = Path("/content/openai-compatible-local-tts")
     repo_dir: Path = field(default_factory=default_repo_dir)
     app_port: int = 8000

--- a/src/installers/__init__.py
+++ b/src/installers/__init__.py
@@ -8,6 +8,7 @@ from .kokoro import install as install_kokoro
 from .melo import install as install_melo
 from .moss_tts_nano import install as install_moss_tts_nano
 from .neutts import install as install_neutts
+from .openvoice_v2 import install as install_openvoice_v2
 from .outetts import install as install_outetts
 from .piper import install as install_piper
 from .piper_plus import install as install_piper_plus
@@ -29,6 +30,7 @@ INSTALLERS = {
     "MeloTTS": install_melo,
     "MOSS-TTS-Nano": install_moss_tts_nano,
     "NeuTTS": install_neutts,
+    "OpenVoice-V2": install_openvoice_v2,
     "OuteTTS": install_outetts,
     "Style-Bert-VITS2": install_style_bert,
     "Piper": install_piper,

--- a/src/installers/__init__.py
+++ b/src/installers/__init__.py
@@ -14,6 +14,7 @@ from .piper import install as install_piper
 from .piper_plus import install as install_piper_plus
 from .sarashina_tts import install as install_sarashina_tts
 from .style_bert import install as install_style_bert
+from .vibevoice import install as install_vibevoice
 from .voxcpm import install as install_voxcpm
 from .tiny_tts import install as install_tiny_tts
 from .voxtral import install as install_voxtral
@@ -38,6 +39,7 @@ INSTALLERS = {
     "Qwen3-TTS": install_qwen3_tts,
     "Sarashina-TTS": install_sarashina_tts,
     "TinyTTS": install_tiny_tts,
+    "VibeVoice": install_vibevoice,
     "VoxCPM2": install_voxcpm,
     "Voxtral-TTS": install_voxtral,
     "Zonos": install_zonos,

--- a/src/installers/__init__.py
+++ b/src/installers/__init__.py
@@ -7,6 +7,7 @@ from .kokoro import install as install_kokoro
 from .melo import install as install_melo
 from .moss_tts_nano import install as install_moss_tts_nano
 from .neutts import install as install_neutts
+from .outetts import install as install_outetts
 from .piper import install as install_piper
 from .piper_plus import install as install_piper_plus
 from .sarashina_tts import install as install_sarashina_tts
@@ -26,6 +27,7 @@ INSTALLERS = {
     "MeloTTS": install_melo,
     "MOSS-TTS-Nano": install_moss_tts_nano,
     "NeuTTS": install_neutts,
+    "OuteTTS": install_outetts,
     "Style-Bert-VITS2": install_style_bert,
     "Piper": install_piper,
     "Piper-Plus": install_piper_plus,

--- a/src/installers/__init__.py
+++ b/src/installers/__init__.py
@@ -1,3 +1,4 @@
+from .chatterbox import install as install_chatterbox
 from .f5tts import install as install_f5tts
 from .fish_speech import install as install_fish_speech
 from .irodori import install as install_irodori
@@ -16,6 +17,7 @@ from .voxtral import install as install_voxtral
 
 
 INSTALLERS = {
+    "Chatterbox": install_chatterbox,
     "F5-TTS": install_f5tts,
     "Fish-Speech": install_fish_speech,
     "Irodori-TTS": install_irodori,

--- a/src/installers/__init__.py
+++ b/src/installers/__init__.py
@@ -14,6 +14,7 @@ from .style_bert import install as install_style_bert
 from .voxcpm import install as install_voxcpm
 from .tiny_tts import install as install_tiny_tts
 from .voxtral import install as install_voxtral
+from .zonos import install as install_zonos
 
 
 INSTALLERS = {
@@ -33,4 +34,5 @@ INSTALLERS = {
     "TinyTTS": install_tiny_tts,
     "VoxCPM2": install_voxcpm,
     "Voxtral-TTS": install_voxtral,
+    "Zonos": install_zonos,
 }

--- a/src/installers/__init__.py
+++ b/src/installers/__init__.py
@@ -1,4 +1,5 @@
 from .chatterbox import install as install_chatterbox
+from .dia import install as install_dia
 from .f5tts import install as install_f5tts
 from .fish_speech import install as install_fish_speech
 from .irodori import install as install_irodori
@@ -20,6 +21,7 @@ from .zonos import install as install_zonos
 
 INSTALLERS = {
     "Chatterbox": install_chatterbox,
+    "Dia": install_dia,
     "F5-TTS": install_f5tts,
     "Fish-Speech": install_fish_speech,
     "Irodori-TTS": install_irodori,

--- a/src/installers/chatterbox.py
+++ b/src/installers/chatterbox.py
@@ -12,6 +12,12 @@ def install(settings: Settings) -> dict:
 
     python_bin = ensure_venv(engine_dir)
     # chatterbox-tts pulls in torch, torchaudio, transformers, librosa, etc.
+    # The transitive dependency `resemble-perth==1.0.1` imports `pkg_resources`
+    # at module load time. setuptools >= 81 dropped `pkg_resources`, so on a
+    # default uv venv (which gets the latest setuptools) perth's
+    # `PerthImplicitWatermarker` silently resolves to None and synthesis fails
+    # with `TypeError: 'NoneType' object is not callable`. Pin setuptools<81
+    # to keep `pkg_resources` available.
     uv_pip_install(
         python_bin,
         [
@@ -19,6 +25,7 @@ def install(settings: Settings) -> dict:
             "uvicorn",
             "soundfile",
             "numpy",
+            "setuptools<81",
             "chatterbox-tts",
         ],
     )

--- a/src/installers/chatterbox.py
+++ b/src/installers/chatterbox.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import os
+
+from src.config import Settings
+from src.runtime import ensure_venv, popen, uv_pip_install, write_text
+
+
+def install(settings: Settings) -> dict:
+    engine_dir = settings.engines_dir / "chatterbox"
+    engine_dir.mkdir(parents=True, exist_ok=True)
+
+    python_bin = ensure_venv(engine_dir)
+    # chatterbox-tts pulls in torch, torchaudio, transformers, librosa, etc.
+    uv_pip_install(
+        python_bin,
+        [
+            "fastapi",
+            "uvicorn",
+            "soundfile",
+            "numpy",
+            "chatterbox-tts",
+        ],
+    )
+
+    write_text(engine_dir / "app.py", settings.read_repo_text("src/apps/chatterbox_app.py"))
+
+    env = {
+        **os.environ,
+        "PYTHONUNBUFFERED": "1",
+        "OPENAI_MODEL_ID": settings.openai_model_id or "chatterbox",
+        "CHATTERBOX_LANGUAGE": settings.chatterbox_language,
+        "CHATTERBOX_PROMPT_WAV": settings.chatterbox_prompt_wav,
+        "CHATTERBOX_DEFAULT_VOICE": settings.chatterbox_default_voice,
+    }
+    proc = popen(
+        [
+            str(engine_dir / ".venv" / "bin" / "uvicorn"),
+            "app:app",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            str(settings.app_port),
+            "--log-level",
+            "info",
+        ],
+        cwd=str(engine_dir),
+        env=env,
+        log_path=settings.log_dir / "chatterbox-uvicorn.log",
+    )
+    return {
+        "proc": proc,
+        "app_dir": engine_dir,
+        "log_path": settings.log_dir / "chatterbox-uvicorn.log",
+    }

--- a/src/installers/dia.py
+++ b/src/installers/dia.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import os
+
+from src.config import Settings
+from src.runtime import ensure_git_clone, ensure_venv, popen, uv_pip_install, write_text
+
+
+DIA_REPO_URL = "https://github.com/nari-labs/dia.git"
+
+
+def install(settings: Settings) -> dict:
+    engine_dir = settings.engines_dir / "dia"
+    engine_dir.mkdir(parents=True, exist_ok=True)
+
+    repo_dir = engine_dir / "dia-repo"
+    ensure_git_clone(DIA_REPO_URL, repo_dir)
+
+    python_bin = ensure_venv(engine_dir)
+    uv_pip_install(python_bin, ["-e", str(repo_dir)])
+    uv_pip_install(python_bin, ["fastapi", "uvicorn", "soundfile", "numpy"])
+
+    write_text(engine_dir / "app.py", settings.read_repo_text("src/apps/dia_app.py"))
+
+    env = {
+        **os.environ,
+        "PYTHONUNBUFFERED": "1",
+        "OPENAI_MODEL_ID": settings.openai_model_id or "dia",
+        "DIA_HF_MODEL": settings.dia_hf_model,
+        "DIA_COMPUTE_DTYPE": settings.dia_compute_dtype,
+        "DIA_PROMPT_WAV": settings.dia_prompt_wav,
+        "DIA_PROMPT_TEXT": settings.dia_prompt_text,
+        "DIA_DEFAULT_VOICE": settings.dia_default_voice,
+    }
+    proc = popen(
+        [
+            str(engine_dir / ".venv" / "bin" / "uvicorn"),
+            "app:app",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            str(settings.app_port),
+            "--log-level",
+            "info",
+        ],
+        cwd=str(engine_dir),
+        env=env,
+        log_path=settings.log_dir / "dia-uvicorn.log",
+    )
+    return {
+        "proc": proc,
+        "app_dir": engine_dir,
+        "log_path": settings.log_dir / "dia-uvicorn.log",
+    }

--- a/src/installers/openvoice_v2.py
+++ b/src/installers/openvoice_v2.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import os
+
+from src.config import Settings
+from src.runtime import ensure_git_clone, ensure_venv, popen, run, uv_pip_install, write_text
+
+
+OPENVOICE_REPO_URL = "https://github.com/myshell-ai/OpenVoice.git"
+MELO_REPO_URL = "https://github.com/myshell-ai/MeloTTS.git"
+OPENVOICE_V2_CKPT_URL = (
+    "https://myshell-public-repo-host.s3.amazonaws.com/openvoice/checkpoints_v2_0417.zip"
+)
+
+
+def install(settings: Settings) -> dict:
+    engine_dir = settings.engines_dir / "openvoice-v2"
+    engine_dir.mkdir(parents=True, exist_ok=True)
+
+    repo_dir = engine_dir / "OpenVoice"
+    ensure_git_clone(OPENVOICE_REPO_URL, repo_dir)
+
+    python_bin = ensure_venv(engine_dir)
+    # OpenVoice itself.
+    uv_pip_install(python_bin, ["-e", str(repo_dir)])
+    # MeloTTS provides the base multilingual TTS that V2 layers tone color over.
+    # NOTE: this dependency is what makes the standalone MeloTTS engine "Not
+    # working" today on Colab (Rust toolchain required for tokenizers); the
+    # same risk applies here.
+    uv_pip_install(python_bin, [f"git+{MELO_REPO_URL}"])
+    run([str(python_bin), "-m", "unidic", "download"], check=False)
+    uv_pip_install(python_bin, ["fastapi", "uvicorn", "soundfile", "numpy"])
+
+    # Download and unzip OpenVoice V2 checkpoints (~600MB). Idempotent.
+    ckpt_zip = engine_dir / "checkpoints_v2.zip"
+    ckpt_dir = engine_dir / "checkpoints_v2"
+    if not ckpt_dir.exists():
+        run(["wget", "-q", "-O", str(ckpt_zip), OPENVOICE_V2_CKPT_URL])
+        run(["unzip", "-q", "-o", str(ckpt_zip), "-d", str(engine_dir)])
+
+    write_text(engine_dir / "app.py", settings.read_repo_text("src/apps/openvoice_v2_app.py"))
+
+    env = {
+        **os.environ,
+        "PYTHONUNBUFFERED": "1",
+        "OPENAI_MODEL_ID": settings.openai_model_id or "openvoice-v2",
+        "OPENVOICE_LANGUAGE": settings.openvoice_language,
+        "OPENVOICE_CKPT_DIR": str(ckpt_dir),
+        "OPENVOICE_REPO_DIR": str(repo_dir),
+        "OPENVOICE_PROMPT_WAV": settings.openvoice_prompt_wav,
+        "OPENVOICE_DEFAULT_VOICE": settings.openvoice_default_voice,
+    }
+    proc = popen(
+        [
+            str(engine_dir / ".venv" / "bin" / "uvicorn"),
+            "app:app",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            str(settings.app_port),
+            "--log-level",
+            "info",
+        ],
+        cwd=str(engine_dir),
+        env=env,
+        log_path=settings.log_dir / "openvoice-v2-uvicorn.log",
+    )
+    return {
+        "proc": proc,
+        "app_dir": engine_dir,
+        "log_path": settings.log_dir / "openvoice-v2-uvicorn.log",
+    }

--- a/src/installers/outetts.py
+++ b/src/installers/outetts.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import os
+
+from src.config import Settings
+from src.runtime import ensure_venv, popen, uv_pip_install, write_text
+
+
+def install(settings: Settings) -> dict:
+    engine_dir = settings.engines_dir / "outetts"
+    engine_dir.mkdir(parents=True, exist_ok=True)
+
+    python_bin = ensure_venv(engine_dir)
+    uv_pip_install(
+        python_bin,
+        [
+            "fastapi",
+            "uvicorn",
+            "soundfile",
+            "numpy",
+            "outetts",
+        ],
+    )
+
+    write_text(engine_dir / "app.py", settings.read_repo_text("src/apps/outetts_app.py"))
+
+    env = {
+        **os.environ,
+        "PYTHONUNBUFFERED": "1",
+        "OPENAI_MODEL_ID": settings.openai_model_id or "outetts",
+        "OUTETTS_MODEL_SIZE": settings.outetts_model_size,
+        "OUTETTS_BACKEND": settings.outetts_backend,
+        "OUTETTS_DEFAULT_SPEAKER": settings.outetts_default_speaker,
+        "OUTETTS_PROMPT_WAV": settings.outetts_prompt_wav,
+        "OUTETTS_PROMPT_TEXT": settings.outetts_prompt_text,
+        "OUTETTS_DEFAULT_VOICE": settings.outetts_default_voice,
+    }
+    proc = popen(
+        [
+            str(engine_dir / ".venv" / "bin" / "uvicorn"),
+            "app:app",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            str(settings.app_port),
+            "--log-level",
+            "info",
+        ],
+        cwd=str(engine_dir),
+        env=env,
+        log_path=settings.log_dir / "outetts-uvicorn.log",
+    )
+    return {
+        "proc": proc,
+        "app_dir": engine_dir,
+        "log_path": settings.log_dir / "outetts-uvicorn.log",
+    }

--- a/src/installers/outetts.py
+++ b/src/installers/outetts.py
@@ -11,6 +11,11 @@ def install(settings: Settings) -> dict:
     engine_dir.mkdir(parents=True, exist_ok=True)
 
     python_bin = ensure_venv(engine_dir)
+    # `outetts.Interface.generate(...).save(path)` writes the wav via
+    # `torchaudio.save()`. From torchaudio 2.11 onward that delegates to the
+    # separate `torchcodec` package, which is not pulled in by either outetts
+    # or torchaudio's metadata. Without it, the first /v1/audio/speech call
+    # raises `ImportError: TorchCodec is required for save_with_torchcodec`.
     uv_pip_install(
         python_bin,
         [
@@ -18,6 +23,7 @@ def install(settings: Settings) -> dict:
             "uvicorn",
             "soundfile",
             "numpy",
+            "torchcodec",
             "outetts",
         ],
     )

--- a/src/installers/vibevoice.py
+++ b/src/installers/vibevoice.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import os
+
+from src.config import Settings
+from src.runtime import ensure_git_clone, ensure_venv, popen, uv_pip_install, write_text
+
+
+VIBEVOICE_REPO_URL = "https://github.com/microsoft/VibeVoice.git"
+
+
+def install(settings: Settings) -> dict:
+    engine_dir = settings.engines_dir / "vibevoice"
+    engine_dir.mkdir(parents=True, exist_ok=True)
+
+    repo_dir = engine_dir / "VibeVoice"
+    ensure_git_clone(VIBEVOICE_REPO_URL, repo_dir)
+
+    python_bin = ensure_venv(engine_dir)
+    # The vibevoice package is installed editable from the cloned repo so the
+    # bundled `demo/voices/*.wav` reference samples land alongside the code.
+    uv_pip_install(python_bin, ["-e", str(repo_dir)])
+    uv_pip_install(python_bin, ["fastapi", "uvicorn", "soundfile", "numpy"])
+
+    write_text(engine_dir / "app.py", settings.read_repo_text("src/apps/vibevoice_app.py"))
+
+    env = {
+        **os.environ,
+        "PYTHONUNBUFFERED": "1",
+        "OPENAI_MODEL_ID": settings.openai_model_id or "vibevoice",
+        "VIBEVOICE_HF_MODEL": settings.vibevoice_hf_model,
+        "VIBEVOICE_VOICES_DIR": str(repo_dir / "demo" / "voices"),
+        "VIBEVOICE_DEFAULT_SPEAKER": settings.vibevoice_default_speaker,
+        "VIBEVOICE_PROMPT_WAV": settings.vibevoice_prompt_wav,
+        "VIBEVOICE_DEFAULT_VOICE": settings.vibevoice_default_voice,
+        "VIBEVOICE_DDPM_STEPS": str(settings.vibevoice_ddpm_steps),
+        "VIBEVOICE_CFG_SCALE": str(settings.vibevoice_cfg_scale),
+    }
+    proc = popen(
+        [
+            str(engine_dir / ".venv" / "bin" / "uvicorn"),
+            "app:app",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            str(settings.app_port),
+            "--log-level",
+            "info",
+        ],
+        cwd=str(engine_dir),
+        env=env,
+        log_path=settings.log_dir / "vibevoice-uvicorn.log",
+    )
+    return {
+        "proc": proc,
+        "app_dir": engine_dir,
+        "log_path": settings.log_dir / "vibevoice-uvicorn.log",
+    }

--- a/src/installers/zonos.py
+++ b/src/installers/zonos.py
@@ -24,6 +24,11 @@ def install(settings: Settings) -> dict:
     # additionally needs mamba-ssm + causal_conv1d, which require a 30xx-series GPU
     # or newer; we stick with the transformer to keep T4 / L4 compatibility.
     uv_pip_install(python_bin, ["-e", str(repo_dir)])
+    # Pin torch / torchaudio to 2.6 -- newer torchaudio (2.11) requires the
+    # separate `torchcodec` package for `torchaudio.load`, and Zonos does not
+    # depend on either explicitly, so uv resolves to whatever happens to be
+    # latest. 2.6 ships its own audio backend and avoids the torchcodec hop.
+    uv_pip_install(python_bin, ["torch==2.6.0", "torchaudio==2.6.0"])
     uv_pip_install(python_bin, ["fastapi", "uvicorn", "soundfile", "numpy"])
 
     write_text(engine_dir / "app.py", settings.read_repo_text("src/apps/zonos_app.py"))

--- a/src/installers/zonos.py
+++ b/src/installers/zonos.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import os
+
+from src.config import Settings
+from src.runtime import ensure_git_clone, ensure_venv, popen, run, uv_pip_install, write_text
+
+
+ZONOS_REPO_URL = "https://github.com/Zyphra/Zonos.git"
+
+
+def install(settings: Settings) -> dict:
+    engine_dir = settings.engines_dir / "zonos"
+    engine_dir.mkdir(parents=True, exist_ok=True)
+
+    # Zonos requires espeak-ng for phonemization at the system level.
+    run(["bash", "-lc", "apt-get update && apt-get install -y espeak-ng"], check=False)
+
+    repo_dir = engine_dir / "Zonos"
+    ensure_git_clone(ZONOS_REPO_URL, repo_dir)
+
+    python_bin = ensure_venv(engine_dir)
+    # Install the upstream Zonos package (transformer backbone). The hybrid backbone
+    # additionally needs mamba-ssm + causal_conv1d, which require a 30xx-series GPU
+    # or newer; we stick with the transformer to keep T4 / L4 compatibility.
+    uv_pip_install(python_bin, ["-e", str(repo_dir)])
+    uv_pip_install(python_bin, ["fastapi", "uvicorn", "soundfile", "numpy"])
+
+    write_text(engine_dir / "app.py", settings.read_repo_text("src/apps/zonos_app.py"))
+
+    env = {
+        **os.environ,
+        "PYTHONUNBUFFERED": "1",
+        "OPENAI_MODEL_ID": settings.openai_model_id or "zonos",
+        "ZONOS_HF_MODEL": settings.zonos_hf_model,
+        "ZONOS_LANGUAGE": settings.zonos_language,
+        "ZONOS_PROMPT_WAV": settings.zonos_prompt_wav,
+        "ZONOS_DEFAULT_PROMPT_WAV": str(repo_dir / "assets" / "exampleaudio.mp3"),
+        "ZONOS_DEFAULT_VOICE": settings.zonos_default_voice,
+    }
+    proc = popen(
+        [
+            str(engine_dir / ".venv" / "bin" / "uvicorn"),
+            "app:app",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            str(settings.app_port),
+            "--log-level",
+            "info",
+        ],
+        cwd=str(engine_dir),
+        env=env,
+        log_path=settings.log_dir / "zonos-uvicorn.log",
+    )
+    return {
+        "proc": proc,
+        "app_dir": engine_dir,
+        "log_path": settings.log_dir / "zonos-uvicorn.log",
+    }

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -42,6 +42,8 @@ def resolve_selected_voice(settings: Settings) -> str:
         return settings.dia_default_voice
     if settings.engine == "OpenVoice-V2":
         return settings.openvoice_default_voice
+    if settings.engine == "VibeVoice":
+        return settings.vibevoice_default_voice
     return ""
 
 
@@ -189,6 +191,20 @@ def print_engine_voice_hints(settings: Settings):
         print("対応言語: EN / ES / FR / ZH / JP / KR")
         print("注意: ベース TTS は MeloTTS のため、本リポの MeloTTS 単体エンジンと同じ依存解決問題（tokenizers Rust ビルド失敗）に当たる可能性があります。")
         print("ライセンス: コードと重みとも MIT（2024-04 以降、商用 OK）")
+    elif settings.engine == "VibeVoice":
+        print("VibeVoice は Microsoft の長尺マルチスピーカー TTS です（最大 90 分・4 話者の一括生成）。")
+        print(f"モデル: {settings.vibevoice_hf_model}")
+        print(f"デフォルト speaker: {settings.vibevoice_default_speaker}（demo/voices/<speaker>.wav）")
+        print(f"デフォルト voice: {settings.vibevoice_default_voice}")
+        print(f"DDPM steps: {settings.vibevoice_ddpm_steps} / cfg_scale: {settings.vibevoice_cfg_scale}")
+        print("voice 候補: default（VIBEVOICE_DEFAULT_SPEAKER 名で demo/voices から参照音声を選択）")
+        if settings.vibevoice_prompt_wav:
+            print(f"             clone（参照音声: {settings.vibevoice_prompt_wav}）")
+        else:
+            print("             clone は --vibevoice-prompt-wav を指定すると有効になります")
+        print("対応言語: 英語 / 中国語のみ（モデル規約上、それ以外の言語は禁止）")
+        print("注意: ライセンスは MIT ですが、Microsoft 公式に「research purpose only」と明記されており、")
+        print("      なりすまし・ディスインフォ・実時間音声変換などは禁止です。商用 / 実運用での利用は推奨されていません。")
     else:
         print("Irodori-TTS は現状 voice 切り替えを持たない想定です。")
 

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -155,7 +155,12 @@ def print_engine_voice_hints(settings: Settings):
             print(f"             clone（参照音声: {settings.outetts_prompt_wav}）")
         else:
             print("             clone は --outetts-prompt-wav を指定すると有効になります（必要なら --outetts-prompt-text も併用）")
-        print("注意: 日本語を話させる場合は日本語話者プロファイルの作成（clone）を推奨します。CPU/GPU 両対応。ライセンス: Apache-2.0")
+        print("注意: 日本語を話させる場合は日本語話者プロファイルの作成（clone）を推奨します。CPU/GPU 両対応。")
+        if settings.outetts_model_size.upper() == "1B":
+            print("ライセンス警告: 1B (Llama-OuteTTS-1.0-1B) の重みは CC-BY-NC-SA-4.0 + Llama 3.2 Community License で、商用利用は不可です。")
+            print("                商用利用したい場合は 0.6B (OuteTTS-1.0-0.6B, Apache-2.0) を選択してください。")
+        else:
+            print("ライセンス: 0.6B はコード / 重みとも Apache-2.0（商用 OK）。1B に切り替えると重みは CC-BY-NC-SA-4.0 で非商用となります。")
     else:
         print("Irodori-TTS は現状 voice 切り替えを持たない想定です。")
 

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -34,6 +34,8 @@ def resolve_selected_voice(settings: Settings) -> str:
         return settings.sarashina_default_voice
     if settings.engine == "Chatterbox":
         return settings.chatterbox_default_voice
+    if settings.engine == "Zonos":
+        return settings.zonos_default_voice
     return ""
 
 
@@ -129,6 +131,18 @@ def print_engine_voice_hints(settings: Settings):
             print("             clone は --chatterbox-prompt-wav を指定すると有効になります")
         print("対応言語: ar, da, de, el, en, es, fi, fr, he, hi, it, ja, ko, ms, nl, no, pl, pt, ru, sv, sw, tr, zh")
         print("注意: GPU 推奨（VRAM ~2-4GB）。ライセンス: MIT（コードと重み）")
+    elif settings.engine == "Zonos":
+        print("Zonos は Zyphra の多言語 TTS です（5言語対応・日本語含む、ゼロショット voice cloning 対応）。")
+        print(f"モデル: {settings.zonos_hf_model}")
+        print(f"language: {settings.zonos_language}")
+        print(f"デフォルト voice: {settings.zonos_default_voice}")
+        print("voice 候補: default（同梱の参照音声 assets/exampleaudio.mp3 を使用）")
+        if settings.zonos_prompt_wav:
+            print(f"             clone（参照音声: {settings.zonos_prompt_wav}）")
+        else:
+            print("             clone は --zonos-prompt-wav を指定すると有効になります")
+        print("対応言語: en, ja, zh, fr, de（espeak-ng で音素化）")
+        print("注意: GPU 推奨（VRAM 6GB+）。ライセンス: Apache-2.0（コードと重み）")
     else:
         print("Irodori-TTS は現状 voice 切り替えを持たない想定です。")
 

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -40,6 +40,8 @@ def resolve_selected_voice(settings: Settings) -> str:
         return settings.outetts_default_voice
     if settings.engine == "Dia":
         return settings.dia_default_voice
+    if settings.engine == "OpenVoice-V2":
+        return settings.openvoice_default_voice
     return ""
 
 
@@ -175,6 +177,18 @@ def print_engine_voice_hints(settings: Settings):
             print("             clone は --dia-prompt-wav と --dia-prompt-text の両方を指定すると有効になります")
         print("対応言語: 英語のみ。日本語テキストは正しく発音されません。")
         print("注意: GPU 推奨（bf16/float16 で VRAM ~4.4GB / float32 で ~7.9GB）。ライセンス: Apache 2.0（コードと重み）")
+    elif settings.engine == "OpenVoice-V2":
+        print("OpenVoice V2 は MyShell の voice cloning TTS です（MeloTTS をベースに ToneColorConverter で声色変換）。")
+        print(f"language: {settings.openvoice_language}")
+        print(f"デフォルト voice: {settings.openvoice_default_voice}")
+        print("voice 候補: default（OpenVoice 同梱の resources/example_reference.mp3 を参照音声として使用）")
+        if settings.openvoice_prompt_wav:
+            print(f"             clone（参照音声: {settings.openvoice_prompt_wav}）")
+        else:
+            print("             clone は --openvoice-prompt-wav を指定すると有効になります")
+        print("対応言語: EN / ES / FR / ZH / JP / KR")
+        print("注意: ベース TTS は MeloTTS のため、本リポの MeloTTS 単体エンジンと同じ依存解決問題（tokenizers Rust ビルド失敗）に当たる可能性があります。")
+        print("ライセンス: コードと重みとも MIT（2024-04 以降、商用 OK）")
     else:
         print("Irodori-TTS は現状 voice 切り替えを持たない想定です。")
 

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -38,6 +38,8 @@ def resolve_selected_voice(settings: Settings) -> str:
         return settings.zonos_default_voice
     if settings.engine == "OuteTTS":
         return settings.outetts_default_voice
+    if settings.engine == "Dia":
+        return settings.dia_default_voice
     return ""
 
 
@@ -161,6 +163,18 @@ def print_engine_voice_hints(settings: Settings):
             print("                商用利用したい場合は 0.6B (OuteTTS-1.0-0.6B, Apache-2.0) を選択してください。")
         else:
             print("ライセンス: 0.6B はコード / 重みとも Apache-2.0（商用 OK）。1B に切り替えると重みは CC-BY-NC-SA-4.0 で非商用となります。")
+    elif settings.engine == "Dia":
+        print("Dia は Nari Labs の対話 TTS です（[S1]/[S2] 話者タグでマルチスピーカー一括生成、英語のみ）。")
+        print(f"モデル: {settings.dia_hf_model}")
+        print(f"compute_dtype: {settings.dia_compute_dtype}")
+        print(f"デフォルト voice: {settings.dia_default_voice}")
+        print("voice 候補: default（プロンプトなし。入力に [S1]/[S2] タグが無い場合は先頭に [S1] を自動挿入）")
+        if settings.dia_prompt_wav and settings.dia_prompt_text:
+            print(f"             clone（参照音声: {settings.dia_prompt_wav}, 書き起こし: {settings.dia_prompt_text}）")
+        else:
+            print("             clone は --dia-prompt-wav と --dia-prompt-text の両方を指定すると有効になります")
+        print("対応言語: 英語のみ。日本語テキストは正しく発音されません。")
+        print("注意: GPU 推奨（bf16/float16 で VRAM ~4.4GB / float32 で ~7.9GB）。ライセンス: Apache 2.0（コードと重み）")
     else:
         print("Irodori-TTS は現状 voice 切り替えを持たない想定です。")
 

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -32,6 +32,8 @@ def resolve_selected_voice(settings: Settings) -> str:
         return settings.neutts_default_voice
     if settings.engine == "Sarashina-TTS":
         return settings.sarashina_default_voice
+    if settings.engine == "Chatterbox":
+        return settings.chatterbox_default_voice
     return ""
 
 
@@ -116,6 +118,17 @@ def print_engine_voice_hints(settings: Settings):
         print("TinyTTS は超軽量（~3.4MB）の英語専用 TTS です（CPU 動作、GPU 不要）。")
         print("voice パラメータは現在 'default' のみ対応です。")
         print("注意: 英語のみ対応。日本語テキストは正しく発音されません。ライセンス: Apache-2.0")
+    elif settings.engine == "Chatterbox":
+        print("Chatterbox は Resemble AI の多言語 TTS です（23言語対応、ゼロショット voice cloning 対応）。")
+        print(f"language: {settings.chatterbox_language}")
+        print(f"デフォルト voice: {settings.chatterbox_default_voice}")
+        print("voice 候補: default（プロンプトなしの plain TTS）")
+        if settings.chatterbox_prompt_wav:
+            print(f"             clone（参照音声: {settings.chatterbox_prompt_wav}）")
+        else:
+            print("             clone は --chatterbox-prompt-wav を指定すると有効になります")
+        print("対応言語: ar, da, de, el, en, es, fi, fr, he, hi, it, ja, ko, ms, nl, no, pl, pt, ru, sv, sw, tr, zh")
+        print("注意: GPU 推奨（VRAM ~2-4GB）。ライセンス: MIT（コードと重み）")
     else:
         print("Irodori-TTS は現状 voice 切り替えを持たない想定です。")
 

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -36,6 +36,8 @@ def resolve_selected_voice(settings: Settings) -> str:
         return settings.chatterbox_default_voice
     if settings.engine == "Zonos":
         return settings.zonos_default_voice
+    if settings.engine == "OuteTTS":
+        return settings.outetts_default_voice
     return ""
 
 
@@ -143,6 +145,17 @@ def print_engine_voice_hints(settings: Settings):
             print("             clone は --zonos-prompt-wav を指定すると有効になります")
         print("対応言語: en, ja, zh, fr, de（espeak-ng で音素化）")
         print("注意: GPU 推奨（VRAM 6GB+）。ライセンス: Apache-2.0（コードと重み）")
+    elif settings.engine == "OuteTTS":
+        print("OuteTTS は OuteAI の軽量多言語 TTS です（日本語含む多言語対応、voice cloning 対応）。")
+        print(f"モデルサイズ: {settings.outetts_model_size} / backend: {settings.outetts_backend}")
+        print(f"デフォルト speaker: {settings.outetts_default_speaker}")
+        print(f"デフォルト voice: {settings.outetts_default_voice}")
+        print("voice 候補: default（OUTETTS_DEFAULT_SPEAKER に該当する内蔵プロファイルを使用）")
+        if settings.outetts_prompt_wav:
+            print(f"             clone（参照音声: {settings.outetts_prompt_wav}）")
+        else:
+            print("             clone は --outetts-prompt-wav を指定すると有効になります（必要なら --outetts-prompt-text も併用）")
+        print("注意: 日本語を話させる場合は日本語話者プロファイルの作成（clone）を推奨します。CPU/GPU 両対応。ライセンス: Apache-2.0")
     else:
         print("Irodori-TTS は現状 voice 切り替えを持たない想定です。")
 


### PR DESCRIPTION
## Summary

Add six new TTS engines to the Colab launcher, plus a `CLAUDE.md` that
documents the standing operational rules for adding engines (license
verification, README sync, push, Colab MCP verification).

Each engine follows the existing layout (`src/installers/<name>.py`,
`src/apps/<name>_app.py`, registry in `src/installers/__init__.py`,
tunables in `src/config.py`, CLI flags in `colab/bootstrap.py`, hint +
voice resolution in `src/launcher.py`, form params + cmd args in
`multi_tts_openai_colab.py`, plus README.md / README.ja.md updates).
Verified end-to-end on a Colab L4 GPU runtime.

### Verified working

| Engine | License (code / weights) | Notes |
|---|---|---|
| **Chatterbox** (Resemble AI) | MIT / MIT | 23 languages incl. JP, zero-shot voice cloning. |
| **Zonos** (Zyphra) | Apache 2.0 / Apache 2.0 | EN/JA/ZH/FR/DE, zero-shot voice cloning. Auto-installs ` espeak-ng`. |
| **OuteTTS** (OuteAI) | Apache 2.0 (code) / **Apache 2.0 for 0.6B**, **CC-BY-NC-SA-4.0 + Llama 3.2 Community License for 1B** | The default size is 0.6B (commercial-friendly); the 1B variant is non-commercial. README and the launcher hint surface the distinction. |
| **Dia** (Nari Labs) | Apache 2.0 / Apache 2.0 | English-only `[S1]`/`[S2]` multi-speaker dialogue TTS. |

### Documented as currently not working (kept in tree, marked in README)

| Engine | Reason |
|---|---|
| **VibeVoice** (Microsoft) | Upstream is mid-migration: `.wav` reference speakers in `demo/voices/` were replaced by `.pt` prompt caches under `demo/voices/streaming_model/`, and the recommended path moved to `processor.process_input_with_cached_prompt(...)`. The wrapper handles the class rename + DDPM-step API change but has no working `.wav` defaults to point at. License is MIT but research-only. |
| **OpenVoice V2** (MyShell) | OpenVoice's `pyproject.toml` hard-pins `faster-whisper==0.9.0`, which transitively pins `av>=10.dev0,<11.dev0`. `av` 10.x has no Python 3.13 wheels and no longer compiles under Cython 3.x. Pre-installing `faster-whisper>=1.0` doesn't help because uv respects the pin. |

### Notable fixes uncovered during verification

- **Chatterbox**: `setuptools >= 81` removes `pkg_resources`, which breaks `resemble-perth==1.0.1` at import time. Pinned `setuptools<81` in the install spec.
- **Zonos**: torch/torchaudio 2.11 routes `torchaudio.load()` through the separate `torchcodec` package (not declared by Zonos). Pin `torch==2.6 / torchaudio==2.6`. Additionally, `Zonos.from_pretrained(..., device='cuda')` flips the global default device to CUDA, which makes torchaudio's lazily-built `MelSpectrogram` filterbank crash on a device mismatch — force the default back to CPU at module init in the wrapper.
- **OuteTTS**: `outetts.Interface.generate(...).save(path)` writes via `torchaudio.save()`, which from torchaudio 2.11 routes through `torchcodec`. Add `torchcodec` to the install spec.
- **Dia**: Without explicit `cfg_scale` / `temperature` / `top_p` / `cfg_filter_top_k`, Dia returns a 30-second WAV with `max_abs ≈ 0.01` (≈ -40 dB) — i.e. valid bytes but inaudible. Match the upstream `generate.py` defaults.
- **VibeVoice**: `VibeVoiceForConditionalGenerationInference` was renamed to `VibeVoiceForConditionalGeneration`, and `model.set_ddpm_inference_steps(...)` was removed in favour of `model.model.noise_scheduler.set_timesteps(...)`. Both handled. (Synthesis still blocked by the `.pt` migration above.)
- **OuteTTS license correction**: an earlier commit on this branch incorrectly described the 1B weights as Apache 2.0; corrected to CC-BY-NC-SA-4.0 + Llama 3.2 Community License before the next engine landed.

### Other repo-wide changes

- New **`CLAUDE.md`** documenting the mandatory procedure when adding or modifying an engine: verify license, follow the file layout, sync the embedded Colab cells in both READMEs, commit per engine in English, push, and verify on Colab via the Colab MCP. Local engine runs are explicitly forbidden — nothing in this repo is exercised on the developer machine.
- Synced the embedded Colab cells in `README.md` / `README.ja.md` with `multi_tts_openai_colab.py` (both were stale on the JA side; EN was missing every engine added since Chatterbox).
- Filled in the missing `NeuTTS` row in the README.ja.md supported-engines table (it was already in EN).

## Test plan

- [x] Chatterbox: HTTP 200 + 167 KB RIFF WAV (Japanese, default voice) on L4 in ~34 s.
- [x] Zonos: HTTP 200 + 531 KB RIFF WAV. Verified cleanly on a CPU-only Colab runtime as well, confirming the auto CPU fallback works (the wrapper checks `torch.cuda.is_available()`).
- [x] OuteTTS: HTTP 200 + 338 KB RIFF WAV (English, EN-FEMALE-1-NEUTRAL) on L4 in ~42 s.
- [x] Dia: HTTP 200 + audible WAV at proper amplitude after the cfg_scale fix.
- [x] VibeVoice: model loads on L4 but synthesis blocked at the `.pt` reference issue (documented).
- [x] OpenVoice V2: install fails at `av==10` build (documented); does not regress anything else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)