### PR TITLE
Add Supertonic TTS engine (CPU-only ONNX, 31 languages)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -19,6 +19,7 @@ Google Colab 上で選択したローカル TTS を一時的に OpenAI 互換 `/
 | MOSS-TTS-Nano | 動作（出力が約2秒で切れる） | 日本語 / 英語 / 中国語 他 20言語 |
 | NeuTTS | 動作OK (CPU可・voice cloning) | 英語 / スペイン語 / ドイツ語 / フランス語 |
 | TinyTTS | 動作OK | 英語 |
+| Supertonic | Colab 動作確認待ち (CPU可・ONNX・~99M params) | 英語 / 日本語 / 韓国語 他 31言語 |
 | Voxtral-TTS | 動作OK (GPU必須・VRAM 16GB+) | 英語 / フランス語 / スペイン語 他 9言語 |
 | Sarashina-TTS | 動作OK (GPU必須・VRAM ~6GB) | 日本語 / 英語 |
 | F5-TTS | 動作OK (GPU必須) | 英語 / 中国語（日本語は別モデル） |
@@ -76,7 +77,7 @@ REPO_URL = "https://github.com/shinshin86/local-tts-on-google-colab.git"  #@para
 REPO_REF = "main"  #@param {type:"string"}
 WORKDIR = "/content/local-tts-on-google-colab"  #@param {type:"string"}
 
-ENGINE = "Kokoro"  #@param ["Bark", "ChatTTS", "Chatterbox", "CosyVoice2", "CSM-1B", "Dia", "F5-TTS", "Fish-Speech", "GPT-SoVITS", "Higgs-Audio-v2", "Irodori-TTS", "Kokoro", "Kyutai-TTS", "MaskGCT", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "OpenVoice-V2", "Orpheus-TTS", "OuteTTS", "Piper", "Piper-Plus", "Pocket-TTS", "Qwen3-TTS", "Sarashina-TTS", "Spark-TTS", "Style-Bert-VITS2", "StyleTTS2", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos"]
+ENGINE = "Kokoro"  #@param ["Bark", "ChatTTS", "Chatterbox", "CosyVoice2", "CSM-1B", "Dia", "F5-TTS", "Fish-Speech", "GPT-SoVITS", "Higgs-Audio-v2", "Irodori-TTS", "Kokoro", "Kyutai-TTS", "MaskGCT", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "OpenVoice-V2", "Orpheus-TTS", "OuteTTS", "Piper", "Piper-Plus", "Pocket-TTS", "Qwen3-TTS", "Sarashina-TTS", "Spark-TTS", "Style-Bert-VITS2", "StyleTTS2", "Supertonic", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos"]
 EXPOSE_PUBLIC_URL = True  #@param {type:"boolean"}
 TEST_TEXT = "こんにちは。これは OpenAI 互換 TTS の動作確認です。"  #@param {type:"string"}
 TEST_SPEED = 1.0  #@param {type:"number"}
@@ -321,6 +322,15 @@ HIGGS_PROMPT_WAV = ""  #@param {type:"string"}
 HIGGS_PROMPT_TEXT = ""  #@param {type:"string"}
 HIGGS_MAX_NEW_TOKENS = 1024  #@param {type:"integer"}
 HIGGS_TEMPERATURE = 0.7  #@param {type:"number"}
+
+#@markdown ---
+#@markdown Supertonic (CPU OK, 31 languages incl JP/KO/EN, ONNX)
+#@markdown - Code: MIT. Weights: OpenRAIL-M (commercial OK, use-based ethical restrictions).
+#@markdown - Voice presets only (no voice cloning). Language is auto-detected for CJK text.
+SUPERTONIC_MODEL = "supertonic-3"  #@param ["supertonic-3", "supertonic-2", "supertonic"]
+SUPERTONIC_DEFAULT_VOICE = "M1"  #@param ["M1", "M2", "M3", "M4", "M5", "F1", "F2", "F3", "F4", "F5"]
+SUPERTONIC_DEFAULT_LANG = "en"  #@param ["en", "ja", "ko", "ar", "bg", "cs", "da", "de", "el", "es", "et", "fi", "fr", "hi", "hr", "hu", "id", "it", "lt", "lv", "nl", "pl", "pt", "ro", "ru", "sk", "sl", "sv", "tr", "uk", "vi", "na"]
+SUPERTONIC_TOTAL_STEPS = 5  #@param {type:"integer"}
 
 import shlex
 import subprocess
@@ -608,6 +618,14 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         str(HIGGS_MAX_NEW_TOKENS),
         "--higgs-temperature",
         str(HIGGS_TEMPERATURE),
+        "--supertonic-model",
+        SUPERTONIC_MODEL,
+        "--supertonic-default-voice",
+        SUPERTONIC_DEFAULT_VOICE,
+        "--supertonic-default-lang",
+        SUPERTONIC_DEFAULT_LANG,
+        "--supertonic-total-steps",
+        str(SUPERTONIC_TOTAL_STEPS),
     ]
     if SARASHINA_USE_VLLM:
         cmd.append("--sarashina-use-vllm")
@@ -720,6 +738,24 @@ main()
 ### TinyTTS
 
 [ecyht2/tiny-tts](https://github.com/ecyht2/tiny-tts) を使った超軽量の英語 TTS です。モデルはわずか 1.6M パラメータ（約 3.4MB）で、GPU 不要・CPU のみで 53 倍速のリアルタイム合成が可能です。音声は 44.1kHz で出力されます。voice の切り替え機能はありません。ライセンス: Apache 2.0。
+
+### Supertonic
+
+Supertone Inc. の [supertone-inc/supertonic](https://github.com/supertone-inc/supertonic) を使った超軽量オンデバイス TTS です。`supertonic-3` モデル（約 99M params、ONNX アセット約 305MB）は英語・日本語・韓国語を含む 31 言語に対応し、未対応テキスト向けに `na` フォールバックも持ちます。ONNX Runtime で完全に CPU 動作（GPU 不要）。本ラッパーは初回リクエストでモデルをロードし、voice style はリクエスト間でキャッシュします。
+
+`voice` パラメータは内蔵 10 プリセットを公開します:
+
+| voice | 説明 |
+|---|---|
+| `M1` – `M5` | 男性プリセット（M1: 明るく前向き / M2: 落ち着いた低音 / M3: 信頼感のあるビジネス / M4: 柔らかく親しみやすい / M5: 暖かみのあるナレーション） |
+| `F1` – `F5` | 女性プリセット（F1: 落ち着き / F2: 明るく若々しい / F3: アナウンサー調 / F4: 自信のあるビジネス / F5: 優しいウェルネス） |
+| `default` | `--supertonic-default-voice` のエイリアス（既定は `M1`） |
+
+公式 Python SDK は voice cloning に対応していません（クローン音声は Supertone の Voice Builder サービスで作成する想定）。`voice=clone` を指定すると明示的に 4xx を返します。
+
+Supertonic-3 は合成時に言語ヒントが必要ですが、OpenAI 互換の `/v1/audio/speech` には `language` フィールドが無いため、本ラッパーは JSON body に拡張フィールド `language` を受け付けます。`language` が省略された場合は入力テキストのスクリプトから簡易判定（ひらがな・カタカナ・CJK → `ja`、ハングル → `ko`）し、それ以外は `--supertonic-default-lang`（既定 `en`）にフォールバックします。言語が分からないテキストは `"na"` を指定してください。
+
+ライセンス: **コードは MIT**（https://github.com/supertone-inc/supertonic）、**重みは OpenRAIL-M**（https://huggingface.co/Supertone/supertonic-3）。商用利用 OK。なりすまし・ディープフェイク・誹謗中傷など、OpenRAIL-M の use-based ethical restrictions は適用されます（詳細はライセンス本文を参照）。
 
 ### Voxtral-TTS
 
@@ -1033,6 +1069,7 @@ GPT-SoVITS は本質的に few-shot cloning モデルで、内蔵の「default s
 | MOSS-TTS-Nano | Apache 2.0 | Apache 2.0 | OK | 100M パラメータ、CPU 動作可 |
 | NeuTTS | Apache 2.0 | Apache 2.0 (Air) / NeuTTS Open License 1.0 (Nano) | OK (Air) / 規約要確認 (Nano) | ボイスクローン。英 / 西 / 独 / 仏 |
 | TinyTTS | Apache 2.0 | Apache 2.0 | OK | |
+| Supertonic | MIT | OpenRAIL-M | OK | 31言語（日 / 韓 / 英含む）。CPU 動作（ONNX）。なりすまし・ディープフェイク等の use-based ethical restrictions あり |
 | Voxtral-TTS | — | CC BY-NC 4.0 | 不可 | vLLM + vllm-omni 経由。音声データセットのライセンス制約により非商用 |
 | Sarashina-TTS | — | Sarashina Model NonCommercial License | 不可 | 日本語 / 英語。ゼロショット音声クローン対応。出力には SilentCipher のウォーターマークが付与される（除去禁止） |
 | F5-TTS | MIT | CC-BY-NC | 不可（モデル） | モデル重みは Emilia データセットの制約により非商用 |
@@ -1092,6 +1129,8 @@ GPT-SoVITS は本質的に few-shot cloning モデルで、内蔵の「default s
   https://github.com/OpenBMB/VoxCPM
 - TinyTTS
   https://github.com/ecyht2/tiny-tts
+- Supertonic
+  https://github.com/supertone-inc/supertonic
 - MOSS-TTS-Nano
   https://github.com/OpenMOSS/MOSS-TTS-Nano
 - NeuTTS

--- a/README.ja.md
+++ b/README.ja.md
@@ -19,7 +19,7 @@ Google Colab 上で選択したローカル TTS を一時的に OpenAI 互換 `/
 | MOSS-TTS-Nano | 動作（出力が約2秒で切れる） | 日本語 / 英語 / 中国語 他 20言語 |
 | NeuTTS | 動作OK (CPU可・voice cloning) | 英語 / スペイン語 / ドイツ語 / フランス語 |
 | TinyTTS | 動作OK | 英語 |
-| Supertonic | Colab 動作確認待ち (CPU可・ONNX・~99M params) | 英語 / 日本語 / 韓国語 他 31言語 |
+| Supertonic | 動作OK (CPU可・ONNX・~99M params) | 英語 / 日本語 / 韓国語 他 31言語 |
 | Voxtral-TTS | 動作OK (GPU必須・VRAM 16GB+) | 英語 / フランス語 / スペイン語 他 9言語 |
 | Sarashina-TTS | 動作OK (GPU必須・VRAM ~6GB) | 日本語 / 英語 |
 | F5-TTS | 動作OK (GPU必須) | 英語 / 中国語（日本語は別モデル） |

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Supported engines:
 | MOSS-TTS-Nano | Works (output truncated to ~2s) | Japanese / English / Chinese and 20 languages |
 | NeuTTS | Works (CPU OK, voice cloning) | English / Spanish / German / French |
 | TinyTTS | Works | English |
-| Supertonic | Pending Colab verification (CPU OK, ONNX, ~99M params) | English / Japanese / Korean and 31 languages |
+| Supertonic | Works (CPU OK, ONNX, ~99M params) | English / Japanese / Korean and 31 languages |
 | Voxtral-TTS | Works (GPU required, VRAM 16GB+) | English / French / Spanish and 9 languages |
 | Orpheus-TTS | Not working (HF-gated weights, requires Llama 3.2 license acceptance + `HF_TOKEN`) | English (Llama-3.2-3B base, vLLM) |
 | CosyVoice2 | Works (GPU recommended, Python 3.10 venv) | Japanese / English / Chinese / Korean / German and 9 languages |

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Supported engines:
 | MOSS-TTS-Nano | Works (output truncated to ~2s) | Japanese / English / Chinese and 20 languages |
 | NeuTTS | Works (CPU OK, voice cloning) | English / Spanish / German / French |
 | TinyTTS | Works | English |
+| Supertonic | Pending Colab verification (CPU OK, ONNX, ~99M params) | English / Japanese / Korean and 31 languages |
 | Voxtral-TTS | Works (GPU required, VRAM 16GB+) | English / French / Spanish and 9 languages |
 | Orpheus-TTS | Not working (HF-gated weights, requires Llama 3.2 license acceptance + `HF_TOKEN`) | English (Llama-3.2-3B base, vLLM) |
 | CosyVoice2 | Works (GPU recommended, Python 3.10 venv) | Japanese / English / Chinese / Korean / German and 9 languages |
@@ -76,7 +77,7 @@ REPO_URL = "https://github.com/shinshin86/local-tts-on-google-colab.git"  #@para
 REPO_REF = "main"  #@param {type:"string"}
 WORKDIR = "/content/local-tts-on-google-colab"  #@param {type:"string"}
 
-ENGINE = "Kokoro"  #@param ["Bark", "ChatTTS", "Chatterbox", "CosyVoice2", "CSM-1B", "Dia", "F5-TTS", "Fish-Speech", "GPT-SoVITS", "Higgs-Audio-v2", "Irodori-TTS", "Kokoro", "Kyutai-TTS", "MaskGCT", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "OpenVoice-V2", "Orpheus-TTS", "OuteTTS", "Piper", "Piper-Plus", "Pocket-TTS", "Qwen3-TTS", "Sarashina-TTS", "Spark-TTS", "Style-Bert-VITS2", "StyleTTS2", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos"]
+ENGINE = "Kokoro"  #@param ["Bark", "ChatTTS", "Chatterbox", "CosyVoice2", "CSM-1B", "Dia", "F5-TTS", "Fish-Speech", "GPT-SoVITS", "Higgs-Audio-v2", "Irodori-TTS", "Kokoro", "Kyutai-TTS", "MaskGCT", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "OpenVoice-V2", "Orpheus-TTS", "OuteTTS", "Piper", "Piper-Plus", "Pocket-TTS", "Qwen3-TTS", "Sarashina-TTS", "Spark-TTS", "Style-Bert-VITS2", "StyleTTS2", "Supertonic", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos"]
 EXPOSE_PUBLIC_URL = True  #@param {type:"boolean"}
 TEST_TEXT = "こんにちは。これは OpenAI 互換 TTS の動作確認です。"  #@param {type:"string"}
 TEST_SPEED = 1.0  #@param {type:"number"}
@@ -321,6 +322,15 @@ HIGGS_PROMPT_WAV = ""  #@param {type:"string"}
 HIGGS_PROMPT_TEXT = ""  #@param {type:"string"}
 HIGGS_MAX_NEW_TOKENS = 1024  #@param {type:"integer"}
 HIGGS_TEMPERATURE = 0.7  #@param {type:"number"}
+
+#@markdown ---
+#@markdown Supertonic (CPU OK, 31 languages incl JP/KO/EN, ONNX)
+#@markdown - Code: MIT. Weights: OpenRAIL-M (commercial OK, use-based ethical restrictions).
+#@markdown - Voice presets only (no voice cloning). Language is auto-detected for CJK text.
+SUPERTONIC_MODEL = "supertonic-3"  #@param ["supertonic-3", "supertonic-2", "supertonic"]
+SUPERTONIC_DEFAULT_VOICE = "M1"  #@param ["M1", "M2", "M3", "M4", "M5", "F1", "F2", "F3", "F4", "F5"]
+SUPERTONIC_DEFAULT_LANG = "en"  #@param ["en", "ja", "ko", "ar", "bg", "cs", "da", "de", "el", "es", "et", "fi", "fr", "hi", "hr", "hu", "id", "it", "lt", "lv", "nl", "pl", "pt", "ro", "ru", "sk", "sl", "sv", "tr", "uk", "vi", "na"]
+SUPERTONIC_TOTAL_STEPS = 5  #@param {type:"integer"}
 
 import shlex
 import subprocess
@@ -608,6 +618,14 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         str(HIGGS_MAX_NEW_TOKENS),
         "--higgs-temperature",
         str(HIGGS_TEMPERATURE),
+        "--supertonic-model",
+        SUPERTONIC_MODEL,
+        "--supertonic-default-voice",
+        SUPERTONIC_DEFAULT_VOICE,
+        "--supertonic-default-lang",
+        SUPERTONIC_DEFAULT_LANG,
+        "--supertonic-total-steps",
+        str(SUPERTONIC_TOTAL_STEPS),
     ]
     if SARASHINA_USE_VLLM:
         cmd.append("--sarashina-use-vllm")
@@ -720,6 +738,24 @@ Default backbone: `neuphonic/neutts-air` (~360M params, English only, Apache 2.0
 ### TinyTTS
 
 An ultra-lightweight English TTS using [ecyht2/tiny-tts](https://github.com/ecyht2/tiny-tts). The model has only 1.6M parameters (~3.4 MB), no GPU required, and can synthesize speech at 53× real-time on CPU alone. Audio is output at 44.1 kHz. There is no voice switching. License: Apache 2.0.
+
+### Supertonic
+
+An ultra-lightweight on-device TTS using [supertone-inc/supertonic](https://github.com/supertone-inc/supertonic) by Supertone Inc. The `supertonic-3` model (~99M params, ~305MB ONNX assets) supports 31 languages including English, Japanese, and Korean, plus a `na` fallback for unknown text. Runs entirely on CPU via ONNX Runtime (no GPU required). The wrapper loads the model on first request and caches voice styles between requests.
+
+The `voice` parameter exposes the 10 built-in presets:
+
+| voice | description |
+|---|---|
+| `M1` – `M5` | Male presets (M1: upbeat / M2: deep / M3: authoritative / M4: gentle / M5: warm storyteller) |
+| `F1` – `F5` | Female presets (F1: calm / F2: cheerful / F3: announcer / F4: confident / F5: gentle) |
+| `default` | Alias for `--supertonic-default-voice` (defaults to `M1`) |
+
+Voice cloning is **not** supported by the public Python SDK — cloned voices are produced through Supertone's separate Voice Builder service. Requesting `voice=clone` returns a 4xx with a clear message.
+
+Supertonic-3 needs a language hint at synthesis time. OpenAI's `/v1/audio/speech` schema has no `language` field, so the wrapper accepts an extra `language` field in the JSON body. When `language` is omitted, the wrapper auto-detects the script (Hiragana/Katakana/CJK → `ja`, Hangul → `ko`) and otherwise falls back to `--supertonic-default-lang` (`en`). Use `"na"` for text whose language is unknown.
+
+License: **code MIT** (https://github.com/supertone-inc/supertonic), **weights OpenRAIL-M** (https://huggingface.co/Supertone/supertonic-3). Commercial use is permitted; use-based ethical restrictions apply (no impersonation, deepfakes, defamation, etc. — see the OpenRAIL-M license text for the full list).
 
 ### Voxtral-TTS
 
@@ -1033,6 +1069,7 @@ The license for each engine is as follows. When using them, always check each pr
 | MOSS-TTS-Nano | Apache 2.0 | Apache 2.0 | OK | 100M params, CPU OK |
 | NeuTTS | Apache 2.0 | Apache 2.0 (Air) / NeuTTS Open License 1.0 (Nano) | OK (Air) / Check terms (Nano) | Voice cloning. EN / ES / DE / FR |
 | TinyTTS | Apache 2.0 | Apache 2.0 | OK | |
+| Supertonic | MIT | OpenRAIL-M | OK | 31 languages incl JP/KO/EN. CPU OK (ONNX). Use-based ethical restrictions (no impersonation/deepfakes) |
 | Voxtral-TTS | — | CC BY-NC 4.0 | Not allowed | Via vLLM + vllm-omni. Non-commercial due to voice dataset license constraints |
 | Orpheus-TTS | Apache 2.0 | Apache 2.0 + Llama 3.2 Community License | Caution | Llama-3.2-3B-Instruct base; Llama Community License applies in practice. EN only. **Currently not working: weights are HF-gated and require Llama 3.2 license acceptance + `HF_TOKEN`** |
 | CosyVoice2 | Apache 2.0 | Apache 2.0 | OK | Multilingual incl JP. Zero-shot voice cloning. Requires Python 3.10 venv |
@@ -1092,6 +1129,8 @@ This repository itself is intended for short-term operational verification and t
   https://github.com/OpenBMB/VoxCPM
 - TinyTTS
   https://github.com/ecyht2/tiny-tts
+- Supertonic
+  https://github.com/supertone-inc/supertonic
 - MOSS-TTS-Nano
   https://github.com/OpenMOSS/MOSS-TTS-Nano
 - NeuTTS

--- a/colab/bootstrap.py
+++ b/colab/bootstrap.py
@@ -153,6 +153,10 @@ def parse_args():
     parser.add_argument("--higgs-prompt-text", default="")
     parser.add_argument("--higgs-max-new-tokens", type=int, default=1024)
     parser.add_argument("--higgs-temperature", type=float, default=0.7)
+    parser.add_argument("--supertonic-model", default="supertonic-3")
+    parser.add_argument("--supertonic-default-voice", default="M1")
+    parser.add_argument("--supertonic-default-lang", default="en")
+    parser.add_argument("--supertonic-total-steps", type=int, default=5)
     parser.add_argument("--root-dir", default="/content/openai-compatible-local-tts")
     return parser.parse_args()
 
@@ -292,6 +296,10 @@ def main():
         higgs_prompt_text=args.higgs_prompt_text,
         higgs_max_new_tokens=args.higgs_max_new_tokens,
         higgs_temperature=args.higgs_temperature,
+        supertonic_model=args.supertonic_model,
+        supertonic_default_voice=args.supertonic_default_voice,
+        supertonic_default_lang=args.supertonic_default_lang,
+        supertonic_total_steps=args.supertonic_total_steps,
         root_dir=Path(args.root_dir),
         repo_dir=REPO_DIR,
     )

--- a/multi_tts_openai_colab.py
+++ b/multi_tts_openai_colab.py
@@ -11,7 +11,7 @@ REPO_URL = "https://github.com/shinshin86/local-tts-on-google-colab.git"  #@para
 REPO_REF = "main"  #@param {type:"string"}
 WORKDIR = "/content/local-tts-on-google-colab"  #@param {type:"string"}
 
-ENGINE = "Kokoro"  #@param ["Bark", "ChatTTS", "Chatterbox", "CosyVoice2", "CSM-1B", "Dia", "F5-TTS", "Fish-Speech", "GPT-SoVITS", "Higgs-Audio-v2", "Irodori-TTS", "Kokoro", "Kyutai-TTS", "MaskGCT", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "OpenVoice-V2", "Orpheus-TTS", "OuteTTS", "Piper", "Piper-Plus", "Pocket-TTS", "Qwen3-TTS", "Sarashina-TTS", "Spark-TTS", "Style-Bert-VITS2", "StyleTTS2", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos"]
+ENGINE = "Kokoro"  #@param ["Bark", "ChatTTS", "Chatterbox", "CosyVoice2", "CSM-1B", "Dia", "F5-TTS", "Fish-Speech", "GPT-SoVITS", "Higgs-Audio-v2", "Irodori-TTS", "Kokoro", "Kyutai-TTS", "MaskGCT", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "OpenVoice-V2", "Orpheus-TTS", "OuteTTS", "Piper", "Piper-Plus", "Pocket-TTS", "Qwen3-TTS", "Sarashina-TTS", "Spark-TTS", "Style-Bert-VITS2", "StyleTTS2", "Supertonic", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos"]
 EXPOSE_PUBLIC_URL = True  #@param {type:"boolean"}
 TEST_TEXT = "こんにちは。これは OpenAI 互換 TTS の動作確認です。"  #@param {type:"string"}
 TEST_SPEED = 1.0  #@param {type:"number"}
@@ -256,6 +256,15 @@ HIGGS_PROMPT_WAV = ""  #@param {type:"string"}
 HIGGS_PROMPT_TEXT = ""  #@param {type:"string"}
 HIGGS_MAX_NEW_TOKENS = 1024  #@param {type:"integer"}
 HIGGS_TEMPERATURE = 0.7  #@param {type:"number"}
+
+#@markdown ---
+#@markdown Supertonic (CPU OK, 31 languages incl JP/KO/EN, ONNX)
+#@markdown - Code: MIT. Weights: OpenRAIL-M (commercial OK, use-based ethical restrictions).
+#@markdown - Voice presets only (no voice cloning). Language is auto-detected for CJK text.
+SUPERTONIC_MODEL = "supertonic-3"  #@param ["supertonic-3", "supertonic-2", "supertonic"]
+SUPERTONIC_DEFAULT_VOICE = "M1"  #@param ["M1", "M2", "M3", "M4", "M5", "F1", "F2", "F3", "F4", "F5"]
+SUPERTONIC_DEFAULT_LANG = "en"  #@param ["en", "ja", "ko", "ar", "bg", "cs", "da", "de", "el", "es", "et", "fi", "fr", "hi", "hr", "hu", "id", "it", "lt", "lv", "nl", "pl", "pt", "ro", "ru", "sk", "sl", "sv", "tr", "uk", "vi", "na"]
+SUPERTONIC_TOTAL_STEPS = 5  #@param {type:"integer"}
 
 import shlex
 import subprocess
@@ -543,6 +552,14 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         str(HIGGS_MAX_NEW_TOKENS),
         "--higgs-temperature",
         str(HIGGS_TEMPERATURE),
+        "--supertonic-model",
+        SUPERTONIC_MODEL,
+        "--supertonic-default-voice",
+        SUPERTONIC_DEFAULT_VOICE,
+        "--supertonic-default-lang",
+        SUPERTONIC_DEFAULT_LANG,
+        "--supertonic-total-steps",
+        str(SUPERTONIC_TOTAL_STEPS),
     ]
     if SARASHINA_USE_VLLM:
         cmd.append("--sarashina-use-vllm")

--- a/src/apps/supertonic_app.py
+++ b/src/apps/supertonic_app.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+import soundfile as sf
+from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+from supertonic import TTS
+
+logger = logging.getLogger("uvicorn.error")
+
+OPENAI_MODEL_ID = os.environ.get("OPENAI_MODEL_ID", "supertonic-3")
+SUPERTONIC_MODEL = os.environ.get("SUPERTONIC_MODEL", "supertonic-3")
+DEFAULT_VOICE = os.environ.get("SUPERTONIC_DEFAULT_VOICE", "M1")
+DEFAULT_LANG = os.environ.get("SUPERTONIC_DEFAULT_LANG", "en")
+TOTAL_STEPS = int(os.environ.get("SUPERTONIC_TOTAL_STEPS", "5"))
+
+
+def detect_lang(text: str) -> str | None:
+    """Light-weight script detection for callers that don't pass `language`.
+
+    OpenAI's /v1/audio/speech schema has no language field, so this lets the
+    default smoke test (Japanese text, no language) work without forcing the
+    caller to send a non-standard parameter.
+    """
+    for ch in text:
+        code = ord(ch)
+        # Hangul syllables / Jamo
+        if 0xAC00 <= code <= 0xD7A3 or 0x1100 <= code <= 0x11FF or 0x3130 <= code <= 0x318F:
+            return "ko"
+        # Hiragana / Katakana
+        if 0x3040 <= code <= 0x309F or 0x30A0 <= code <= 0x30FF:
+            return "ja"
+        # CJK Unified Ideographs — ambiguous (ja/zh/ko), but the repo's default
+        # test text is Japanese so prefer ja.
+        if 0x4E00 <= code <= 0x9FFF:
+            return "ja"
+    return None
+
+# supertonic-3 voice presets shipped with the model. supertonic-py exposes the
+# authoritative list at runtime via tts.voice_style_names; we keep these here
+# only to drive the /v1/voices response when the model has not finished loading.
+VOICE_PRESETS = ["M1", "M2", "M3", "M4", "M5", "F1", "F2", "F3", "F4", "F5"]
+
+# supertonic-3 accepts 31 ISO codes plus a "na" fallback for unknown text.
+SUPPORTED_LANGS = {
+    "en", "ko", "ja", "ar", "bg", "cs", "da", "de", "el", "es", "et", "fi",
+    "fr", "hi", "hr", "hu", "id", "it", "lt", "lv", "nl", "pl", "pt", "ro",
+    "ru", "sk", "sl", "sv", "tr", "uk", "vi", "na",
+}
+
+app = FastAPI(title="Supertonic OpenAI Compatible TTS")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[],
+    allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
+    allow_credentials=False,
+    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_headers=["*"],
+    expose_headers=["x-openai-model", "x-openai-voice"],
+)
+
+
+class AudioSpeechRequest(BaseModel):
+    model: str = OPENAI_MODEL_ID
+    input: str
+    voice: str | None = None
+    response_format: str = "wav"
+    speed: float = 1.0
+    # Non-standard: Supertonic needs a language hint per request.
+    language: str | None = None
+
+
+_tts: TTS | None = None
+_styles: dict[str, object] = {}
+
+
+def get_tts() -> TTS:
+    global _tts
+    if _tts is None:
+        _tts = TTS(model=SUPERTONIC_MODEL, auto_download=True)
+    return _tts
+
+
+def get_voice_style(voice_name: str):
+    style = _styles.get(voice_name)
+    if style is None:
+        style = get_tts().get_voice_style(voice_name=voice_name)
+        _styles[voice_name] = style
+    return style
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, exc: Exception):
+    logger.exception("Unhandled exception while serving request")
+    return JSONResponse(
+        status_code=500,
+        content={"error": type(exc).__name__, "detail": str(exc)},
+    )
+
+
+@app.get("/")
+def root():
+    return {"ok": True, "engine": "Supertonic", "model": OPENAI_MODEL_ID}
+
+
+@app.get("/v1/models")
+def list_models():
+    return {
+        "object": "list",
+        "data": [{"id": OPENAI_MODEL_ID, "object": "model", "owned_by": "local"}],
+    }
+
+
+@app.get("/v1/voices")
+def list_voices():
+    # Prefer the authoritative list from the loaded model when available.
+    voices = VOICE_PRESETS
+    if _tts is not None and getattr(_tts, "voice_style_names", None):
+        voices = list(_tts.voice_style_names)
+    return {
+        "object": "list",
+        "data": [{"id": voice, "object": "voice"} for voice in voices],
+    }
+
+
+@app.post("/v1/audio/speech")
+async def audio_speech(payload: AudioSpeechRequest):
+    if payload.response_format.lower() != "wav":
+        raise HTTPException(status_code=400, detail="This wrapper currently supports only wav.")
+
+    voice = payload.voice or DEFAULT_VOICE
+    # Map "default" to the configured default voice; Supertonic itself uses
+    # preset names like M1/F1.
+    if voice == "default":
+        voice = DEFAULT_VOICE
+    if voice == "clone":
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Supertonic does not support runtime voice cloning. "
+                "Use a preset voice (M1-M5 / F1-F5)."
+            ),
+        )
+
+    lang = (payload.language or detect_lang(payload.input) or DEFAULT_LANG).lower()
+    if lang not in SUPPORTED_LANGS:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Unsupported language '{lang}'. Pass one of {sorted(SUPPORTED_LANGS)} "
+                "via the 'language' field, or use 'na' for unknown languages."
+            ),
+        )
+
+    tts = get_tts()
+    try:
+        style = get_voice_style(voice)
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Unknown voice '{voice}'. Available presets: "
+                f"{', '.join(tts.voice_style_names)}."
+            ),
+        ) from exc
+
+    wav, _duration = tts.synthesize(
+        payload.input,
+        voice_style=style,
+        total_steps=TOTAL_STEPS,
+        speed=float(payload.speed),
+        lang=lang,
+    )
+
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+        tmp_path = tmp.name
+
+    try:
+        # wav has shape (1, num_samples); soundfile expects (num_samples,).
+        sf.write(tmp_path, wav.squeeze(), tts.sample_rate)
+        audio_bytes = Path(tmp_path).read_bytes()
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+
+    return Response(
+        content=audio_bytes,
+        media_type="audio/wav",
+        headers={
+            "Content-Length": str(len(audio_bytes)),
+            "x-openai-model": payload.model,
+            "x-openai-voice": voice,
+        },
+    )

--- a/src/config.py
+++ b/src/config.py
@@ -172,6 +172,10 @@ class Settings:
     higgs_prompt_text: str = ""
     higgs_max_new_tokens: int = 1024
     higgs_temperature: float = 0.7
+    supertonic_model: str = "supertonic-3"
+    supertonic_default_voice: str = "M1"
+    supertonic_default_lang: str = "en"
+    supertonic_total_steps: int = 5
     root_dir: Path = Path("/content/openai-compatible-local-tts")
     repo_dir: Path = field(default_factory=default_repo_dir)
     app_port: int = 8000

--- a/src/installers/__init__.py
+++ b/src/installers/__init__.py
@@ -26,6 +26,7 @@ from .sarashina_tts import install as install_sarashina_tts
 from .spark_tts import install as install_spark_tts
 from .style_bert import install as install_style_bert
 from .styletts2 import install as install_styletts2
+from .supertonic import install as install_supertonic
 from .vibevoice import install as install_vibevoice
 from .voxcpm import install as install_voxcpm
 from .tiny_tts import install as install_tiny_tts
@@ -56,6 +57,7 @@ INSTALLERS = {
     "OuteTTS": install_outetts,
     "Style-Bert-VITS2": install_style_bert,
     "StyleTTS2": install_styletts2,
+    "Supertonic": install_supertonic,
     "Piper": install_piper,
     "Piper-Plus": install_piper_plus,
     "Pocket-TTS": install_pocket_tts,

--- a/src/installers/supertonic.py
+++ b/src/installers/supertonic.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import os
+
+from src.config import Settings
+from src.runtime import ensure_venv, popen, uv_pip_install, write_text
+
+
+def install(settings: Settings) -> dict:
+    engine_dir = settings.engines_dir / "supertonic-openai"
+    engine_dir.mkdir(parents=True, exist_ok=True)
+    python_bin = ensure_venv(engine_dir)
+    # Upstream supertonic-py pins numpy<2.0 (see requirements.txt).
+    uv_pip_install(
+        python_bin,
+        [
+            "fastapi",
+            "uvicorn",
+            "supertonic>=0.1.0",
+            "soundfile",
+            "numpy<2.0",
+        ],
+    )
+    write_text(engine_dir / "app.py", settings.read_repo_text("src/apps/supertonic_app.py"))
+    env = {
+        **os.environ,
+        "PYTHONUNBUFFERED": "1",
+        "OPENAI_MODEL_ID": settings.openai_model_id or "supertonic-3",
+        "SUPERTONIC_MODEL": settings.supertonic_model,
+        "SUPERTONIC_DEFAULT_VOICE": settings.supertonic_default_voice,
+        "SUPERTONIC_DEFAULT_LANG": settings.supertonic_default_lang,
+        "SUPERTONIC_TOTAL_STEPS": str(settings.supertonic_total_steps),
+    }
+    proc = popen(
+        [
+            str(engine_dir / ".venv" / "bin" / "uvicorn"),
+            "app:app",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            str(settings.app_port),
+            "--log-level",
+            "info",
+        ],
+        cwd=str(engine_dir),
+        env=env,
+        log_path=settings.log_dir / "supertonic-uvicorn.log",
+    )
+    return {"proc": proc, "app_dir": engine_dir, "log_path": settings.log_dir / "supertonic-uvicorn.log"}

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -68,6 +68,8 @@ def resolve_selected_voice(settings: Settings) -> str:
         return settings.gpt_sovits_default_voice
     if settings.engine == "Higgs-Audio-v2":
         return settings.higgs_default_voice
+    if settings.engine == "Supertonic":
+        return settings.supertonic_default_voice
     return ""
 
 
@@ -387,6 +389,18 @@ def print_engine_voice_hints(settings: Settings):
         print("対応言語: 英語 / 中国語のみ（モデル規約上、それ以外の言語は禁止）")
         print("注意: ライセンスは MIT ですが、Microsoft 公式に「research purpose only」と明記されており、")
         print("      なりすまし・ディスインフォ・実時間音声変換などは禁止です。商用 / 実運用での利用は推奨されていません。")
+    elif settings.engine == "Supertonic":
+        print("Supertonic は Supertone Inc. の超軽量オンデバイス TTS です（ONNX、~99M params、CPU 動作可）。")
+        print(f"モデル: {settings.supertonic_model}")
+        print(f"デフォルト voice: {settings.supertonic_default_voice}")
+        print(f"デフォルト language: {settings.supertonic_default_lang}")
+        print(f"total_steps: {settings.supertonic_total_steps}")
+        print("voice 候補: M1, M2, M3, M4, M5（男性）/ F1, F2, F3, F4, F5（女性）")
+        print("対応言語 (supertonic-3, 31言語 + na fallback):")
+        print("  en, ko, ja, ar, bg, cs, da, de, el, es, et, fi, fr, hi, hr, hu,")
+        print("  id, it, lt, lv, nl, pl, pt, ro, ru, sk, sl, sv, tr, uk, vi, na")
+        print("注意: GPU 不要（ONNX Runtime で CPU 動作）。Voice cloning は未対応（preset のみ）。")
+        print("ライセンス: コードは MIT、重みは OpenRAIL-M（商用 OK、ディープフェイク等の use-based 制限あり）。")
     else:
         print("Irodori-TTS は現状 voice 切り替えを持たない想定です。")
 


### PR DESCRIPTION
## Summary

- Adds **Supertonic** (https://github.com/supertone-inc/supertonic) — Supertone Inc.'s ultra-lightweight on-device TTS — as a new engine, served via the same OpenAI-compatible `/v1/audio/speech` contract as the other engines.
- Distributed as the `supertonic` PyPI package and built on **ONNX Runtime**, so the default `supertonic-3` model (~99M params, ~305MB assets, **31 languages** including JP / KO / EN plus a `na` fallback) runs entirely on CPU — no GPU required.
- The OpenAI `voice` field exposes the 10 built-in presets (`M1`–`M5`, `F1`–`F5`). Voice cloning is **not** in the public Python SDK (cloned voices are produced via Supertone's separate Voice Builder service), so requesting `voice=clone` returns a 4xx with a clear message — matching the repo's existing "no silent fallback" rule from `CLAUDE.md`.
- Supertonic-3 needs a per-request language hint, but OpenAI's `/v1/audio/speech` schema has no `language` field. The wrapper accepts an optional `language` JSON field and falls back to a tiny script-based auto-detector (Hiragana/Katakana/CJK → `ja`, Hangul → `ko`) so the default Japanese smoke text "just works" without forcing callers to send a non-standard parameter. The detector default is overridable via `--supertonic-default-lang`.

## License

| | License | Notes |
|---|---|---|
| Code (`supertone-inc/supertonic`) | **MIT** | https://github.com/supertone-inc/supertonic/blob/main/LICENSE |
| Model weights (`Supertone/supertonic-3`) | **BigScience Open RAIL-M** | https://huggingface.co/Supertone/supertonic-3 — commercial use **OK**, with use-based ethical restrictions (no impersonation, deepfakes, defamation, automated legal decisions, etc.). |

OpenRAIL-M's restrictions are about misuse (Attachment A), not commercial reach, so this lands in the "OK" column of the README license table alongside Kokoro / Chatterbox / OuteTTS 0.6B.

## Colab verification

End-to-end verified on Google Colab (free tier, **no GPU**) against `feat/add-supertonic`. The wrapper installed `supertonic==1.2.1` from PyPI, downloaded the `supertonic-3` ONNX assets on first request, and served `/v1/audio/speech` behind a `trycloudflare` public URL.

Public-URL test matrix (all responses verified, WAVs valid 16-bit mono 44.1 kHz PCM):

| # | Request | Expected | Result |
|---|---|---|---|
| 1 | Japanese text, no `language` field, `voice=M1` | 200 + WAV (auto-detect → `ja`) | ✅ 200, 301 KB |
| 2 | English text, `language=en`, `voice=F2` | 200 + WAV | ✅ 200, 246 KB |
| 3 | Korean text, no `language`, `voice=M3` | 200 + WAV (auto-detect → `ko`) | ✅ 200, 270 KB |
| 4 | `voice=default` | 200 + WAV (alias of `--supertonic-default-voice`) | ✅ 200, 160 KB |
| 5 | `voice=clone` | 400 with explicit "not supported" message | ✅ 400 |
| 6 | `voice=X9` (unknown) | 400 listing available presets | ✅ 400 |

Verification trycloudflare URL (temporary, see Notes section in the README about Colab being non-persistent): `https://promise-taxation-novels-harris.trycloudflare.com/v1`

## Test plan

- [x] `python3 colab/bootstrap.py --engine Supertonic --dry-run` succeeds locally and prints the voice-hint block.
- [x] `INSTALLERS["Supertonic"]` resolves to `src.installers.supertonic.install`.
- [x] `multi_tts_openai_colab.py` and the embedded cells in `README.md` / `README.ja.md` are byte-identical after running the CLAUDE.md sync script.
- [x] Engine installed cleanly on Colab via `uv pip install supertonic>=0.1.0`.
- [x] Smoke test from `synth_test_wav` writes a valid 44.1 kHz WAV.
- [x] All 6 public-URL scenarios above behave as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)