### PR TITLE
Add DramaBox TTS engine (verified on Colab A100)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -44,7 +44,7 @@ Google Colab 上で選択したローカル TTS を一時的に OpenAI 互換 `/
 | MaskGCT | Colab 動作確認済み (GPU必須・~10-12GB・**商用不可**) | 英語 / 中国語 |
 | GPT-SoVITS | Colab でエンジン起動確認済み（synthesis には参照音声必須・default speaker モード非対応・`--gpt-sovits-prompt-wav` と `--gpt-sovits-prompt-text` を指定） | 中 / 英 / 日 / 韓 / 粤 |
 | Higgs-Audio-v2 | デフォルトで動作不可（HF 上の checkpoint が未リリースの `boson_multimodal` / transformers 5.x を要求。エンジンは起動するが audio tokenizer ロード時に上流コードと config schema が一致せず推論失敗） | 英語 |
-| DramaBox | Colab A100 で検証予定（GPU 必須、VRAM ~24GB ピーク、**LTX-2 Community License — 非競合条項あり**） | 英語 |
+| DramaBox | Colab A100 動作確認済み（GPU 必須、VRAM ~24GB ピーク、**LTX-2 Community License — 非競合条項あり**） | 英語 |
 
 `MeloTTS`、`Style-Bert-VITS2` は Colab の uv + venv 環境で依存解決に問題があり、現時点では動作しません。
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -44,6 +44,7 @@ Google Colab 上で選択したローカル TTS を一時的に OpenAI 互換 `/
 | MaskGCT | Colab 動作確認済み (GPU必須・~10-12GB・**商用不可**) | 英語 / 中国語 |
 | GPT-SoVITS | Colab でエンジン起動確認済み（synthesis には参照音声必須・default speaker モード非対応・`--gpt-sovits-prompt-wav` と `--gpt-sovits-prompt-text` を指定） | 中 / 英 / 日 / 韓 / 粤 |
 | Higgs-Audio-v2 | デフォルトで動作不可（HF 上の checkpoint が未リリースの `boson_multimodal` / transformers 5.x を要求。エンジンは起動するが audio tokenizer ロード時に上流コードと config schema が一致せず推論失敗） | 英語 |
+| DramaBox | Colab A100 で検証予定（GPU 必須、VRAM ~24GB ピーク、**LTX-2 Community License — 非競合条項あり**） | 英語 |
 
 `MeloTTS`、`Style-Bert-VITS2` は Colab の uv + venv 環境で依存解決に問題があり、現時点では動作しません。
 
@@ -77,7 +78,7 @@ REPO_URL = "https://github.com/shinshin86/local-tts-on-google-colab.git"  #@para
 REPO_REF = "main"  #@param {type:"string"}
 WORKDIR = "/content/local-tts-on-google-colab"  #@param {type:"string"}
 
-ENGINE = "Kokoro"  #@param ["Bark", "ChatTTS", "Chatterbox", "CosyVoice2", "CSM-1B", "Dia", "F5-TTS", "Fish-Speech", "GPT-SoVITS", "Higgs-Audio-v2", "Irodori-TTS", "Kokoro", "Kyutai-TTS", "MaskGCT", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "OpenVoice-V2", "Orpheus-TTS", "OuteTTS", "Piper", "Piper-Plus", "Pocket-TTS", "Qwen3-TTS", "Sarashina-TTS", "Spark-TTS", "Style-Bert-VITS2", "StyleTTS2", "Supertonic", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos"]
+ENGINE = "Kokoro"  #@param ["Bark", "ChatTTS", "Chatterbox", "CosyVoice2", "CSM-1B", "Dia", "DramaBox", "F5-TTS", "Fish-Speech", "GPT-SoVITS", "Higgs-Audio-v2", "Irodori-TTS", "Kokoro", "Kyutai-TTS", "MaskGCT", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "OpenVoice-V2", "Orpheus-TTS", "OuteTTS", "Piper", "Piper-Plus", "Pocket-TTS", "Qwen3-TTS", "Sarashina-TTS", "Spark-TTS", "Style-Bert-VITS2", "StyleTTS2", "Supertonic", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos"]
 EXPOSE_PUBLIC_URL = True  #@param {type:"boolean"}
 TEST_TEXT = "こんにちは。これは OpenAI 互換 TTS の動作確認です。"  #@param {type:"string"}
 TEST_SPEED = 1.0  #@param {type:"number"}
@@ -322,6 +323,25 @@ HIGGS_PROMPT_WAV = ""  #@param {type:"string"}
 HIGGS_PROMPT_TEXT = ""  #@param {type:"string"}
 HIGGS_MAX_NEW_TOKENS = 1024  #@param {type:"integer"}
 HIGGS_TEMPERATURE = 0.7  #@param {type:"number"}
+
+#@markdown ---
+#@markdown DramaBox (A100 required, VRAM ~24GB, English-only, voice cloning)
+#@markdown - Resemble AI's directable / expressive TTS (IC-LoRA fine-tune of LTX-2.3, paralinguistic cues like laughs/sighs).
+#@markdown - **License: LTX-2 Community License** (Lightricks). Non-compete clause; commercial license required for org revenue $10M+.
+#@markdown - Generated audio is **always watermarked** with Resemble Perth (imperceptible, non-removable per upstream).
+#@markdown - First-run downloads ~8.5GB (DramaBox) + Gemma 3 12B snapshot.
+DRAMABOX_HF_MODEL = "ResembleAI/Dramabox"  #@param {type:"string"}
+DRAMABOX_GEMMA_REPO = "unsloth/gemma-3-12b-it-bnb-4bit"  #@param {type:"string"}
+DRAMABOX_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
+DRAMABOX_DEFAULT_REF_VOICE = "female_american"  #@param ["female_american", "female_shadowheart", "male_arnie", "male_conan", "male_harvey_keitel", "male_old_movie", "male_petergriffin", "male_samuel_j"]
+DRAMABOX_PROMPT_WAV = ""  #@param {type:"string"}
+DRAMABOX_DTYPE = "bf16"  #@param ["bf16", "fp16"]
+DRAMABOX_CFG_SCALE = 2.5  #@param {type:"number"}
+DRAMABOX_STG_SCALE = 1.5  #@param {type:"number"}
+DRAMABOX_DURATION_MULTIPLIER = 1.1  #@param {type:"number"}
+DRAMABOX_SEED = 42  #@param {type:"integer"}
+DRAMABOX_COMPILE = False  #@param {type:"boolean"}
+DRAMABOX_NO_BNB_4BIT = False  #@param {type:"boolean"}
 
 #@markdown ---
 #@markdown Supertonic (CPU OK, 31 languages incl JP/KO/EN, ONNX)
@@ -626,11 +646,35 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         SUPERTONIC_DEFAULT_LANG,
         "--supertonic-total-steps",
         str(SUPERTONIC_TOTAL_STEPS),
+        "--dramabox-hf-model",
+        DRAMABOX_HF_MODEL,
+        "--dramabox-gemma-repo",
+        DRAMABOX_GEMMA_REPO,
+        "--dramabox-default-voice",
+        DRAMABOX_DEFAULT_VOICE,
+        "--dramabox-default-ref-voice",
+        DRAMABOX_DEFAULT_REF_VOICE,
+        "--dramabox-prompt-wav",
+        DRAMABOX_PROMPT_WAV,
+        "--dramabox-dtype",
+        DRAMABOX_DTYPE,
+        "--dramabox-cfg-scale",
+        str(DRAMABOX_CFG_SCALE),
+        "--dramabox-stg-scale",
+        str(DRAMABOX_STG_SCALE),
+        "--dramabox-duration-multiplier",
+        str(DRAMABOX_DURATION_MULTIPLIER),
+        "--dramabox-seed",
+        str(DRAMABOX_SEED),
     ]
     if SARASHINA_USE_VLLM:
         cmd.append("--sarashina-use-vllm")
     if BARK_USE_SMALL_MODELS:
         cmd.append("--bark-use-small-models")
+    if DRAMABOX_COMPILE:
+        cmd.append("--dramabox-compile")
+    if DRAMABOX_NO_BNB_4BIT:
+        cmd.append("--dramabox-no-bnb-4bit")
     cmd.append("--expose-public-url" if EXPOSE_PUBLIC_URL else "--no-expose-public-url")
     return cmd
 
@@ -1046,6 +1090,39 @@ GPT-SoVITS は本質的に few-shot cloning モデルで、内蔵の「default s
 
 **ステータス（現時点でデフォルト動作不可）:** HF 上の checkpoint は `boson-ai/higgs-audio` の未リリースブランチと transformers 5.x を要求しますが、PyPI の `boson_multimodal` は transformers 4.46.x ベースです。エンジンの組み込み（インストール / venv / app / voice list / cloudflared）は正しく動作し、Colab L4 で `/`、`/v1/models`、`/v1/voices` はすべて 200 を返しますが、`/v1/audio/speech` は audio tokenizer のロード（`load_higgs_audio_tokenizer`）で 500 になります。具体的には HF の flat config キー（`acoustic_model_config`、`semantic_model_config`）を `HiggsAudioTokenizer.__init__` がそのまま受け付けないためです。前段の 2 つの不一致（`text_config` のデフォルトが `padding_idx=128001 / num_embeddings=32000` を引き起こす問題、および未リリース transformers 5.x にしか存在しない `tokenizer_class=TokenizersBackend` 参照）はラッパー側で workaround 済みですが、audio tokenizer の schema drift は `boson-ai/higgs-audio` 上流の修正が必要です。上流が公開済み config に合わせてコードを更新すれば、本ラッパーはそのまま動作するはずです。
 
+### DramaBox
+
+[resemble-ai/DramaBox](https://github.com/resemble-ai/DramaBox) の Resemble AI による「ディレクション可能」な表現力豊か TTS です。Lightricks の LTX-2.3（音声専用 branch）を IC-LoRA で fine-tune し、テキストエンコーダに Gemma 3 12B を採用。英語プロンプトの中で感情・ペーシング・笑い声・ため息などのパラ言語的要素を直接ディレクション可能。ボイスクローンは 10 秒以上の参照音声で動作します。
+
+**ハードウェア**: VRAM ~24GB ピークが必要なため、**Google Colab A100（40GB）必須** です。T4 / V100 ではモデルのホスト不可。
+
+ラッパーは上流の GitHub repo を clone し、`requirements.txt`（`torch==2.8.0`、`pydantic==2.10.6`、`bitsandbytes`、`resemble-perth` など）をインストール、FastAPI app から `<repo>/src` と `<repo>/ltx2` を sys.path に挿入してモジュール解決します。初回起動時に `ResembleAI/Dramabox` から約 8.5GB、加えて `unsloth/gemma-3-12b-it-bnb-4bit` の snapshot をダウンロードします。
+
+プロンプトはディレクター指示風の英語が推奨です。例:
+
+```
+A woman speaks warmly, "Hello, how are you today?" She laughs, "Hahaha, it is so good to see you!"
+```
+
+`voice` パラメータ:
+
+| voice | 説明 |
+|---|---|
+| `default` | プリセット `--dramabox-default-ref-voice`（デフォルト `female_american`）を使用。 |
+| `clone` | 音声クローン。`--dramabox-prompt-wav` を指定したときのみ有効（10秒以上推奨）。 |
+| `<preset_name>` | `DramaBox/assets/voices/` 同梱プリセット: `female_american`、`female_shadowheart`、`male_arnie`、`male_conan`、`male_harvey_keitel`、`male_old_movie`、`male_petergriffin`、`male_samuel_j`。 |
+
+**ウォーターマーク**: 生成された音声には常に Resemble の **Perth** 不可聴ウォーターマーカー（`perth.PerthImplicitWatermarker`）が埋め込まれます。これは上流の設計通り保持しています（除去禁止）。人間の聴覚では判別できませんが、Resemble のツールで AI 生成音声として検出できます。
+
+**ライセンス警告（重要）:** コード・重みとも **LTX-2 Community License Agreement**（Lightricks）で配布されており、Apache 2.0 / MIT / Llama Community License よりも実質的に厳しいです:
+
+- 非商用は自由、年商 1,000 万米ドル未満の組織も商用可ですが、それを超える組織は Lightricks から有償ライセンスの取得が必要。
+- **非競合条項**: モデルや派生物を使って競合モデルを学習させたり、Lightricks の提供と直接競合する製品を構築することは禁止。
+- 派生物を再配布する場合、同じライセンス（使用制限・acceptable use policy 含む）を継承する必要あり。
+- Acceptable use 制限は広範: 同意のないディープフェイク・なりすまし禁止、AI 生成であることを開示しない使用禁止、誤情報禁止、医療助言禁止、自動法的判断禁止、軍事 / 武器 / マルウェア用途禁止 など。
+
+本リポジトリは Colab での個人・研究用途の評価ラッパーです。LTX-2 Community License が自身の用途に適合するかは利用者の責任で確認してください。
+
 ### MeloTTS (現在動作不可)
 
 [myshell-ai/MeloTTS](https://github.com/myshell-ai/MeloTTS) を使う構成ですが、依存パッケージ `tokenizers` のビルドに Rust コンパイラが必要なため、現在の Colab 環境ではインストールに失敗します。
@@ -1096,6 +1173,7 @@ GPT-SoVITS は本質的に few-shot cloning モデルで、内蔵の「default s
 | GPT-SoVITS | MIT | MIT | OK | 中 / 英 / 日 / 韓 / 粤 few-shot voice cloning。参照音声 + 書き起こし必須 |
 | Higgs-Audio-v2 (code) | Apache 2.0 | — | — | LLM ベース音声基盤モデル。英語中心 |
 | Higgs-Audio-v2 (重み) | — | Boson Higgs Audio 2 Community License | 要注意 | Llama 派生 community license。MAU 10万超は追加ライセンス必須、出力で他 LLM 学習禁止 |
+| DramaBox | LTX-2 Community License (Lightricks) | LTX-2 Community License | **年商 $10M+ の組織は商用ライセンス必須** | 英語。非競合条項あり、再配布時は同ライセンス継承必須、Perth ウォーターマーク常時付与 |
 
 **Piper について**: `piper-tts` パッケージは GPL-3.0 です。また、デフォルトの `en_US-lessac-medium` 音声は Lessac Technologies 提供の Blizzard 2013 データセットで学習されており、このデータセットのライセンスは商用利用を禁止しています。商用利用が必要な場合は、許容的なライセンスで学習された別の voice モデルを選択してください。
 
@@ -1181,3 +1259,7 @@ GPT-SoVITS は本質的に few-shot cloning モデルで、内蔵の「default s
   https://github.com/RVC-Boss/GPT-SoVITS
 - Higgs Audio v2
   https://github.com/boson-ai/higgs-audio
+- DramaBox
+  https://github.com/resemble-ai/DramaBox
+- DramaBox (Hugging Face)
+  https://huggingface.co/ResembleAI/Dramabox

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Supported engines:
 | MaskGCT | Working on Colab (GPU required, ~10-12GB, **non-commercial weights**) | English / Chinese |
 | GPT-SoVITS | Engine starts on Colab — reference audio required for synthesis (no default speaker mode; pass `--gpt-sovits-prompt-wav` + `--gpt-sovits-prompt-text`) | Chinese / English / Japanese / Korean / Cantonese |
 | Higgs-Audio-v2 | Not working by default (upstream HF checkpoint requires unreleased `boson_multimodal` / transformers 5.x; engine starts but inference fails inside the audio tokenizer loader) | English |
+| DramaBox | Pending Colab A100 verification (GPU required, VRAM ~24GB peak, **LTX-2 Community License — non-compete clause**) | English |
 
 `MeloTTS` and `Style-Bert-VITS2` currently have dependency resolution issues under Colab's uv + venv environment and do not work.
 
@@ -77,7 +78,7 @@ REPO_URL = "https://github.com/shinshin86/local-tts-on-google-colab.git"  #@para
 REPO_REF = "main"  #@param {type:"string"}
 WORKDIR = "/content/local-tts-on-google-colab"  #@param {type:"string"}
 
-ENGINE = "Kokoro"  #@param ["Bark", "ChatTTS", "Chatterbox", "CosyVoice2", "CSM-1B", "Dia", "F5-TTS", "Fish-Speech", "GPT-SoVITS", "Higgs-Audio-v2", "Irodori-TTS", "Kokoro", "Kyutai-TTS", "MaskGCT", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "OpenVoice-V2", "Orpheus-TTS", "OuteTTS", "Piper", "Piper-Plus", "Pocket-TTS", "Qwen3-TTS", "Sarashina-TTS", "Spark-TTS", "Style-Bert-VITS2", "StyleTTS2", "Supertonic", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos"]
+ENGINE = "Kokoro"  #@param ["Bark", "ChatTTS", "Chatterbox", "CosyVoice2", "CSM-1B", "Dia", "DramaBox", "F5-TTS", "Fish-Speech", "GPT-SoVITS", "Higgs-Audio-v2", "Irodori-TTS", "Kokoro", "Kyutai-TTS", "MaskGCT", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "OpenVoice-V2", "Orpheus-TTS", "OuteTTS", "Piper", "Piper-Plus", "Pocket-TTS", "Qwen3-TTS", "Sarashina-TTS", "Spark-TTS", "Style-Bert-VITS2", "StyleTTS2", "Supertonic", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos"]
 EXPOSE_PUBLIC_URL = True  #@param {type:"boolean"}
 TEST_TEXT = "こんにちは。これは OpenAI 互換 TTS の動作確認です。"  #@param {type:"string"}
 TEST_SPEED = 1.0  #@param {type:"number"}
@@ -322,6 +323,25 @@ HIGGS_PROMPT_WAV = ""  #@param {type:"string"}
 HIGGS_PROMPT_TEXT = ""  #@param {type:"string"}
 HIGGS_MAX_NEW_TOKENS = 1024  #@param {type:"integer"}
 HIGGS_TEMPERATURE = 0.7  #@param {type:"number"}
+
+#@markdown ---
+#@markdown DramaBox (A100 required, VRAM ~24GB, English-only, voice cloning)
+#@markdown - Resemble AI's directable / expressive TTS (IC-LoRA fine-tune of LTX-2.3, paralinguistic cues like laughs/sighs).
+#@markdown - **License: LTX-2 Community License** (Lightricks). Non-compete clause; commercial license required for org revenue $10M+.
+#@markdown - Generated audio is **always watermarked** with Resemble Perth (imperceptible, non-removable per upstream).
+#@markdown - First-run downloads ~8.5GB (DramaBox) + Gemma 3 12B snapshot.
+DRAMABOX_HF_MODEL = "ResembleAI/Dramabox"  #@param {type:"string"}
+DRAMABOX_GEMMA_REPO = "unsloth/gemma-3-12b-it-bnb-4bit"  #@param {type:"string"}
+DRAMABOX_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
+DRAMABOX_DEFAULT_REF_VOICE = "female_american"  #@param ["female_american", "female_shadowheart", "male_arnie", "male_conan", "male_harvey_keitel", "male_old_movie", "male_petergriffin", "male_samuel_j"]
+DRAMABOX_PROMPT_WAV = ""  #@param {type:"string"}
+DRAMABOX_DTYPE = "bf16"  #@param ["bf16", "fp16"]
+DRAMABOX_CFG_SCALE = 2.5  #@param {type:"number"}
+DRAMABOX_STG_SCALE = 1.5  #@param {type:"number"}
+DRAMABOX_DURATION_MULTIPLIER = 1.1  #@param {type:"number"}
+DRAMABOX_SEED = 42  #@param {type:"integer"}
+DRAMABOX_COMPILE = False  #@param {type:"boolean"}
+DRAMABOX_NO_BNB_4BIT = False  #@param {type:"boolean"}
 
 #@markdown ---
 #@markdown Supertonic (CPU OK, 31 languages incl JP/KO/EN, ONNX)
@@ -626,11 +646,35 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         SUPERTONIC_DEFAULT_LANG,
         "--supertonic-total-steps",
         str(SUPERTONIC_TOTAL_STEPS),
+        "--dramabox-hf-model",
+        DRAMABOX_HF_MODEL,
+        "--dramabox-gemma-repo",
+        DRAMABOX_GEMMA_REPO,
+        "--dramabox-default-voice",
+        DRAMABOX_DEFAULT_VOICE,
+        "--dramabox-default-ref-voice",
+        DRAMABOX_DEFAULT_REF_VOICE,
+        "--dramabox-prompt-wav",
+        DRAMABOX_PROMPT_WAV,
+        "--dramabox-dtype",
+        DRAMABOX_DTYPE,
+        "--dramabox-cfg-scale",
+        str(DRAMABOX_CFG_SCALE),
+        "--dramabox-stg-scale",
+        str(DRAMABOX_STG_SCALE),
+        "--dramabox-duration-multiplier",
+        str(DRAMABOX_DURATION_MULTIPLIER),
+        "--dramabox-seed",
+        str(DRAMABOX_SEED),
     ]
     if SARASHINA_USE_VLLM:
         cmd.append("--sarashina-use-vllm")
     if BARK_USE_SMALL_MODELS:
         cmd.append("--bark-use-small-models")
+    if DRAMABOX_COMPILE:
+        cmd.append("--dramabox-compile")
+    if DRAMABOX_NO_BNB_4BIT:
+        cmd.append("--dramabox-no-bnb-4bit")
     cmd.append("--expose-public-url" if EXPOSE_PUBLIC_URL else "--no-expose-public-url")
     return cmd
 
@@ -1046,6 +1090,39 @@ The `voice` parameter exposes:
 
 **Status (currently not working by default):** the published HF checkpoint expects an unreleased branch of `boson-ai/higgs-audio` plus transformers 5.x, while the released `boson_multimodal` PyPI package targets transformers 4.46.x. The engine wiring (install / venv / app / voice list / cloudflared) is correct and `/`, `/v1/models`, `/v1/voices` all return 200 on Colab L4, but `/v1/audio/speech` returns 500 because the audio tokenizer loader (`load_higgs_audio_tokenizer`) passes the flat HF config keys (`acoustic_model_config`, `semantic_model_config`) to a `HiggsAudioTokenizer.__init__` that does not accept them. Two earlier mismatches are already worked around in this wrapper (text-config defaults that broke `nn.Embedding(padding_idx=128001, num_embeddings=32000)`, and a `tokenizer_class=TokenizersBackend` reference that only exists in unreleased transformers 5.x) but the audio-tokenizer schema drift requires an upstream fix in `boson-ai/higgs-audio` itself. Once upstream realigns code with the published config, this engine should work without further changes here.
 
+### DramaBox
+
+A directable / expressive TTS from Resemble AI ([resemble-ai/DramaBox](https://github.com/resemble-ai/DramaBox)). It is an IC-LoRA fine-tune of Lightricks' LTX-2.3 audio-only branch, with a Gemma 3 12B text encoder; users can drive emotion, pacing, laughs, sighs, and other paralinguistic cues directly from the English text prompt. Voice cloning uses any 10+ second audio reference.
+
+**Hardware**: requires ~24 GB VRAM peak, so **Google Colab A100 (40 GB) is required**. T4 / V100 cannot host this model.
+
+The wrapper clones the upstream GitHub repo, installs `requirements.txt` (which pins `torch==2.8.0`, `pydantic==2.10.6`, `bitsandbytes`, `resemble-perth`, etc.), and points the FastAPI app at `<repo>/src` + `<repo>/ltx2` for module resolution. First run downloads ~8.5 GB from `ResembleAI/Dramabox` plus the `unsloth/gemma-3-12b-it-bnb-4bit` snapshot.
+
+Prompts work best in director-instruction English, for example:
+
+```
+A woman speaks warmly, "Hello, how are you today?" She laughs, "Hahaha, it is so good to see you!"
+```
+
+The `voice` parameter exposes:
+
+| voice | description |
+|---|---|
+| `default` | Uses preset `--dramabox-default-ref-voice` (default `female_american`). |
+| `clone` | Voice cloning. Only available when `--dramabox-prompt-wav` is configured (10+ seconds recommended). |
+| `<preset_name>` | Any bundled preset under `DramaBox/assets/voices/`: `female_american`, `female_shadowheart`, `male_arnie`, `male_conan`, `male_harvey_keitel`, `male_old_movie`, `male_petergriffin`, `male_samuel_j`. |
+
+**Watermarking**: Every generated audio file is invisibly watermarked with Resemble's **Perth** implicit watermarker (`perth.PerthImplicitWatermarker`). This is left enabled as the upstream design intends — do not patch it out. The watermark is imperceptible to humans but allows Resemble's tools to identify AI-generated audio.
+
+**License caveat (important):** code and weights are released under the **LTX-2 Community License Agreement** (Lightricks), which is materially more restrictive than Apache 2.0 / MIT / Llama Community License:
+
+- Free for non-commercial use, and free for organizations with annual revenue below USD 10 M; organizations above that threshold must obtain a paid commercial license from Lightricks.
+- A **non-compete clause** forbids using the model (or derivatives) to train other competing models or to build products that directly compete with Lightricks' offerings.
+- When redistributing derivatives, the same license must be propagated (use-restrictions and acceptable-use policy intact).
+- Acceptable-use restrictions are extensive: no deepfakes / impersonation without consent, no undisclosed AI-generated content, no misinformation, no medical advice, no automated legal decisions, no military / weapons / malware uses, etc.
+
+This repository wraps DramaBox only for personal / research evaluation on Colab — operators are responsible for confirming their own use case complies with the LTX-2 Community License.
+
 ### MeloTTS (currently not working)
 
 Intended to use [myshell-ai/MeloTTS](https://github.com/myshell-ai/MeloTTS), but the dependency `tokenizers` requires a Rust compiler to build, so installation fails in the current Colab environment.
@@ -1096,6 +1173,7 @@ The license for each engine is as follows. When using them, always check each pr
 | GPT-SoVITS | MIT | MIT | OK | ZH / EN / JA / KO / YUE few-shot voice cloning. Reference audio + transcript required |
 | Higgs-Audio-v2 (code) | Apache 2.0 | — | — | LLM-based audio foundation model. EN focus |
 | Higgs-Audio-v2 (weights) | — | Boson Higgs Audio 2 Community License | Caution | Llama-derived community license. Restricted: >100k MAU needs extra license; outputs cannot be used to train other LLMs |
+| DramaBox | LTX-2 Community License (Lightricks) | LTX-2 Community License | **Not allowed without commercial license** for orgs with annual revenue $10M+ | English. Non-compete clause; redistributions must propagate the same license. Perth watermark always applied |
 
 **About Piper**: The `piper-tts` package is GPL-3.0. Also, the default `en_US-lessac-medium` voice is trained on the Blizzard 2013 dataset provided by Lessac Technologies, and its license prohibits commercial use. If you need commercial use, choose another voice model trained with a permissive license.
 
@@ -1181,3 +1259,7 @@ This repository itself is intended for short-term operational verification and t
   https://github.com/RVC-Boss/GPT-SoVITS
 - Higgs Audio v2
   https://github.com/boson-ai/higgs-audio
+- DramaBox
+  https://github.com/resemble-ai/DramaBox
+- DramaBox (Hugging Face)
+  https://huggingface.co/ResembleAI/Dramabox

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Supported engines:
 | MaskGCT | Working on Colab (GPU required, ~10-12GB, **non-commercial weights**) | English / Chinese |
 | GPT-SoVITS | Engine starts on Colab — reference audio required for synthesis (no default speaker mode; pass `--gpt-sovits-prompt-wav` + `--gpt-sovits-prompt-text`) | Chinese / English / Japanese / Korean / Cantonese |
 | Higgs-Audio-v2 | Not working by default (upstream HF checkpoint requires unreleased `boson_multimodal` / transformers 5.x; engine starts but inference fails inside the audio tokenizer loader) | English |
-| DramaBox | Pending Colab A100 verification (GPU required, VRAM ~24GB peak, **LTX-2 Community License — non-compete clause**) | English |
+| DramaBox | Works on Colab A100 (GPU required, VRAM ~24GB peak, **LTX-2 Community License — non-compete clause**) | English |
 
 `MeloTTS` and `Style-Bert-VITS2` currently have dependency resolution issues under Colab's uv + venv environment and do not work.
 

--- a/colab/bootstrap.py
+++ b/colab/bootstrap.py
@@ -157,6 +157,18 @@ def parse_args():
     parser.add_argument("--supertonic-default-voice", default="M1")
     parser.add_argument("--supertonic-default-lang", default="en")
     parser.add_argument("--supertonic-total-steps", type=int, default=5)
+    parser.add_argument("--dramabox-hf-model", default="ResembleAI/Dramabox")
+    parser.add_argument("--dramabox-gemma-repo", default="unsloth/gemma-3-12b-it-bnb-4bit")
+    parser.add_argument("--dramabox-default-voice", default="default")
+    parser.add_argument("--dramabox-default-ref-voice", default="female_american")
+    parser.add_argument("--dramabox-prompt-wav", default="")
+    parser.add_argument("--dramabox-dtype", default="bf16")
+    parser.add_argument("--dramabox-cfg-scale", type=float, default=2.5)
+    parser.add_argument("--dramabox-stg-scale", type=float, default=1.5)
+    parser.add_argument("--dramabox-duration-multiplier", type=float, default=1.1)
+    parser.add_argument("--dramabox-seed", type=int, default=42)
+    parser.add_argument("--dramabox-compile", action="store_true")
+    parser.add_argument("--dramabox-no-bnb-4bit", action="store_true")
     parser.add_argument("--root-dir", default="/content/openai-compatible-local-tts")
     return parser.parse_args()
 
@@ -300,6 +312,18 @@ def main():
         supertonic_default_voice=args.supertonic_default_voice,
         supertonic_default_lang=args.supertonic_default_lang,
         supertonic_total_steps=args.supertonic_total_steps,
+        dramabox_hf_model=args.dramabox_hf_model,
+        dramabox_gemma_repo=args.dramabox_gemma_repo,
+        dramabox_default_voice=args.dramabox_default_voice,
+        dramabox_default_ref_voice=args.dramabox_default_ref_voice,
+        dramabox_prompt_wav=args.dramabox_prompt_wav,
+        dramabox_dtype=args.dramabox_dtype,
+        dramabox_cfg_scale=args.dramabox_cfg_scale,
+        dramabox_stg_scale=args.dramabox_stg_scale,
+        dramabox_duration_multiplier=args.dramabox_duration_multiplier,
+        dramabox_seed=args.dramabox_seed,
+        dramabox_compile=args.dramabox_compile,
+        dramabox_bnb_4bit=not args.dramabox_no_bnb_4bit,
         root_dir=Path(args.root_dir),
         repo_dir=REPO_DIR,
     )

--- a/multi_tts_openai_colab.py
+++ b/multi_tts_openai_colab.py
@@ -11,7 +11,7 @@ REPO_URL = "https://github.com/shinshin86/local-tts-on-google-colab.git"  #@para
 REPO_REF = "main"  #@param {type:"string"}
 WORKDIR = "/content/local-tts-on-google-colab"  #@param {type:"string"}
 
-ENGINE = "Kokoro"  #@param ["Bark", "ChatTTS", "Chatterbox", "CosyVoice2", "CSM-1B", "Dia", "F5-TTS", "Fish-Speech", "GPT-SoVITS", "Higgs-Audio-v2", "Irodori-TTS", "Kokoro", "Kyutai-TTS", "MaskGCT", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "OpenVoice-V2", "Orpheus-TTS", "OuteTTS", "Piper", "Piper-Plus", "Pocket-TTS", "Qwen3-TTS", "Sarashina-TTS", "Spark-TTS", "Style-Bert-VITS2", "StyleTTS2", "Supertonic", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos"]
+ENGINE = "Kokoro"  #@param ["Bark", "ChatTTS", "Chatterbox", "CosyVoice2", "CSM-1B", "Dia", "DramaBox", "F5-TTS", "Fish-Speech", "GPT-SoVITS", "Higgs-Audio-v2", "Irodori-TTS", "Kokoro", "Kyutai-TTS", "MaskGCT", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "OpenVoice-V2", "Orpheus-TTS", "OuteTTS", "Piper", "Piper-Plus", "Pocket-TTS", "Qwen3-TTS", "Sarashina-TTS", "Spark-TTS", "Style-Bert-VITS2", "StyleTTS2", "Supertonic", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos"]
 EXPOSE_PUBLIC_URL = True  #@param {type:"boolean"}
 TEST_TEXT = "こんにちは。これは OpenAI 互換 TTS の動作確認です。"  #@param {type:"string"}
 TEST_SPEED = 1.0  #@param {type:"number"}
@@ -256,6 +256,25 @@ HIGGS_PROMPT_WAV = ""  #@param {type:"string"}
 HIGGS_PROMPT_TEXT = ""  #@param {type:"string"}
 HIGGS_MAX_NEW_TOKENS = 1024  #@param {type:"integer"}
 HIGGS_TEMPERATURE = 0.7  #@param {type:"number"}
+
+#@markdown ---
+#@markdown DramaBox (A100 required, VRAM ~24GB, English-only, voice cloning)
+#@markdown - Resemble AI's directable / expressive TTS (IC-LoRA fine-tune of LTX-2.3, paralinguistic cues like laughs/sighs).
+#@markdown - **License: LTX-2 Community License** (Lightricks). Non-compete clause; commercial license required for org revenue $10M+.
+#@markdown - Generated audio is **always watermarked** with Resemble Perth (imperceptible, non-removable per upstream).
+#@markdown - First-run downloads ~8.5GB (DramaBox) + Gemma 3 12B snapshot.
+DRAMABOX_HF_MODEL = "ResembleAI/Dramabox"  #@param {type:"string"}
+DRAMABOX_GEMMA_REPO = "unsloth/gemma-3-12b-it-bnb-4bit"  #@param {type:"string"}
+DRAMABOX_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
+DRAMABOX_DEFAULT_REF_VOICE = "female_american"  #@param ["female_american", "female_shadowheart", "male_arnie", "male_conan", "male_harvey_keitel", "male_old_movie", "male_petergriffin", "male_samuel_j"]
+DRAMABOX_PROMPT_WAV = ""  #@param {type:"string"}
+DRAMABOX_DTYPE = "bf16"  #@param ["bf16", "fp16"]
+DRAMABOX_CFG_SCALE = 2.5  #@param {type:"number"}
+DRAMABOX_STG_SCALE = 1.5  #@param {type:"number"}
+DRAMABOX_DURATION_MULTIPLIER = 1.1  #@param {type:"number"}
+DRAMABOX_SEED = 42  #@param {type:"integer"}
+DRAMABOX_COMPILE = False  #@param {type:"boolean"}
+DRAMABOX_NO_BNB_4BIT = False  #@param {type:"boolean"}
 
 #@markdown ---
 #@markdown Supertonic (CPU OK, 31 languages incl JP/KO/EN, ONNX)
@@ -560,11 +579,35 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         SUPERTONIC_DEFAULT_LANG,
         "--supertonic-total-steps",
         str(SUPERTONIC_TOTAL_STEPS),
+        "--dramabox-hf-model",
+        DRAMABOX_HF_MODEL,
+        "--dramabox-gemma-repo",
+        DRAMABOX_GEMMA_REPO,
+        "--dramabox-default-voice",
+        DRAMABOX_DEFAULT_VOICE,
+        "--dramabox-default-ref-voice",
+        DRAMABOX_DEFAULT_REF_VOICE,
+        "--dramabox-prompt-wav",
+        DRAMABOX_PROMPT_WAV,
+        "--dramabox-dtype",
+        DRAMABOX_DTYPE,
+        "--dramabox-cfg-scale",
+        str(DRAMABOX_CFG_SCALE),
+        "--dramabox-stg-scale",
+        str(DRAMABOX_STG_SCALE),
+        "--dramabox-duration-multiplier",
+        str(DRAMABOX_DURATION_MULTIPLIER),
+        "--dramabox-seed",
+        str(DRAMABOX_SEED),
     ]
     if SARASHINA_USE_VLLM:
         cmd.append("--sarashina-use-vllm")
     if BARK_USE_SMALL_MODELS:
         cmd.append("--bark-use-small-models")
+    if DRAMABOX_COMPILE:
+        cmd.append("--dramabox-compile")
+    if DRAMABOX_NO_BNB_4BIT:
+        cmd.append("--dramabox-no-bnb-4bit")
     cmd.append("--expose-public-url" if EXPOSE_PUBLIC_URL else "--no-expose-public-url")
     return cmd
 

--- a/src/apps/dramabox_app.py
+++ b/src/apps/dramabox_app.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+logger = logging.getLogger("uvicorn.error")
+
+OPENAI_MODEL_ID = os.environ.get("OPENAI_MODEL_ID", "dramabox")
+DRAMABOX_REPO_DIR = os.environ.get("DRAMABOX_REPO_DIR", "")
+DRAMABOX_HF_MODEL = os.environ.get("DRAMABOX_HF_MODEL", "ResembleAI/Dramabox")
+DRAMABOX_GEMMA_REPO = os.environ.get("DRAMABOX_GEMMA_REPO", "unsloth/gemma-3-12b-it-bnb-4bit")
+DEFAULT_VOICE = os.environ.get("DRAMABOX_DEFAULT_VOICE", "default")
+DEFAULT_REF_VOICE = os.environ.get("DRAMABOX_DEFAULT_REF_VOICE", "female_american")
+PROMPT_WAV = os.environ.get("DRAMABOX_PROMPT_WAV", "")
+DTYPE = os.environ.get("DRAMABOX_DTYPE", "bf16")
+CFG_SCALE = float(os.environ.get("DRAMABOX_CFG_SCALE", "2.5"))
+STG_SCALE = float(os.environ.get("DRAMABOX_STG_SCALE", "1.5"))
+DURATION_MULTIPLIER = float(os.environ.get("DRAMABOX_DURATION_MULTIPLIER", "1.1"))
+SEED = int(os.environ.get("DRAMABOX_SEED", "42"))
+COMPILE_MODEL = os.environ.get("DRAMABOX_COMPILE", "0") == "1"
+BNB_4BIT = os.environ.get("DRAMABOX_BNB_4BIT", "1") == "1"
+
+# Upstream layout: <repo>/src/inference_server.py imports from <repo>/ltx2 and
+# <repo>/src via sys.path. Mirror that here so we can load TTSServer.
+if DRAMABOX_REPO_DIR:
+    for sub in ("ltx2", "src"):
+        path = str(Path(DRAMABOX_REPO_DIR) / sub)
+        if path not in sys.path:
+            sys.path.insert(0, path)
+
+VOICES_DIR = Path(DRAMABOX_REPO_DIR) / "assets" / "voices" if DRAMABOX_REPO_DIR else None
+
+app = FastAPI(title="DramaBox OpenAI Compatible TTS")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[],
+    allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
+    allow_credentials=False,
+    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_headers=["*"],
+    expose_headers=["x-openai-model", "x-openai-voice"],
+)
+
+
+class AudioSpeechRequest(BaseModel):
+    model: str = OPENAI_MODEL_ID
+    input: str
+    voice: str | None = None
+    response_format: str = "wav"
+    speed: float = 1.0
+
+
+_server = None  # type: ignore[var-annotated]
+
+
+def _resolve_bundled_voice(name: str) -> Path | None:
+    if VOICES_DIR is None:
+        return None
+    for ext in (".wav", ".mp3", ".flac", ".ogg"):
+        candidate = VOICES_DIR / f"{name}{ext}"
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def get_server():
+    global _server
+    if _server is not None:
+        return _server
+
+    # Lazy imports: TTSServer transitively pulls in torch / bnb / gemma weights.
+    from huggingface_hub import hf_hub_download, snapshot_download
+
+    logger.info("DramaBox: fetching checkpoints from %s ...", DRAMABOX_HF_MODEL)
+    transformer_path = hf_hub_download(DRAMABOX_HF_MODEL, "dramabox-dit-v1.safetensors")
+    audio_components_path = hf_hub_download(
+        DRAMABOX_HF_MODEL, "dramabox-audio-components.safetensors"
+    )
+    logger.info("DramaBox: fetching Gemma snapshot from %s ...", DRAMABOX_GEMMA_REPO)
+    gemma_root = snapshot_download(DRAMABOX_GEMMA_REPO)
+
+    from inference_server import TTSServer  # type: ignore[import-not-found]
+
+    logger.info(
+        "DramaBox: loading TTSServer (dtype=%s, compile=%s, bnb_4bit=%s)",
+        DTYPE,
+        COMPILE_MODEL,
+        BNB_4BIT,
+    )
+    _server = TTSServer(
+        checkpoint=transformer_path,
+        full_checkpoint=audio_components_path,
+        gemma_root=gemma_root,
+        device="cuda",
+        dtype=DTYPE,
+        compile_model=COMPILE_MODEL,
+        bnb_4bit=BNB_4BIT,
+    )
+    logger.info("DramaBox: TTSServer ready")
+    return _server
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, exc: Exception):
+    logger.exception("Unhandled exception while serving request")
+    return JSONResponse(
+        status_code=500,
+        content={"error": type(exc).__name__, "detail": str(exc)},
+    )
+
+
+@app.get("/")
+def root():
+    return {
+        "ok": True,
+        "engine": "DramaBox",
+        "model": OPENAI_MODEL_ID,
+        "default_voice": DEFAULT_VOICE,
+        "default_ref_voice": DEFAULT_REF_VOICE,
+    }
+
+
+@app.get("/v1/models")
+def list_models():
+    return {
+        "object": "list",
+        "data": [{"id": OPENAI_MODEL_ID, "object": "model", "owned_by": "resemble-ai"}],
+    }
+
+
+@app.get("/v1/voices")
+def list_voices():
+    voices = [{"id": "default", "object": "voice", "ref": DEFAULT_REF_VOICE}]
+    if PROMPT_WAV:
+        voices.append({"id": "clone", "object": "voice", "ref": PROMPT_WAV})
+    if VOICES_DIR is not None and VOICES_DIR.exists():
+        seen = set()
+        for path in sorted(VOICES_DIR.iterdir()):
+            if path.suffix.lower() in {".wav", ".mp3", ".flac", ".ogg"} and path.stem not in seen:
+                voices.append({"id": path.stem, "object": "voice"})
+                seen.add(path.stem)
+    return {"object": "list", "data": voices}
+
+
+@app.post("/v1/audio/speech")
+async def audio_speech(payload: AudioSpeechRequest):
+    if payload.response_format.lower() != "wav":
+        raise HTTPException(status_code=400, detail="This wrapper currently supports only wav.")
+
+    voice = payload.voice or DEFAULT_VOICE
+
+    if voice == "clone":
+        if not PROMPT_WAV:
+            raise HTTPException(
+                status_code=400,
+                detail="voice='clone' requires --dramabox-prompt-wav at startup.",
+            )
+        voice_ref: Path | None = Path(PROMPT_WAV)
+    elif voice == "default":
+        voice_ref = _resolve_bundled_voice(DEFAULT_REF_VOICE)
+        if voice_ref is None:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Default reference voice '{DEFAULT_REF_VOICE}' not found in "
+                    f"{VOICES_DIR}. Pass --dramabox-default-ref-voice to a valid preset name."
+                ),
+            )
+    else:
+        voice_ref = _resolve_bundled_voice(voice)
+        if voice_ref is None:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Unknown voice: {voice}. Available: default, clone, "
+                    "or any preset under DramaBox/assets/voices/."
+                ),
+            )
+
+    server = get_server()
+
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+        tmp_path = tmp.name
+
+    try:
+        # Perth implicit watermarking stays on (Resemble AI requirement;
+        # see CLAUDE.md "watermarks must not be removed").
+        server.generate_to_file(
+            prompt=payload.input,
+            output=tmp_path,
+            voice_ref=str(voice_ref) if voice_ref else None,
+            cfg_scale=CFG_SCALE,
+            stg_scale=STG_SCALE,
+            duration_multiplier=DURATION_MULTIPLIER,
+            seed=SEED,
+            watermark=True,
+        )
+        audio_bytes = Path(tmp_path).read_bytes()
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+
+    if not audio_bytes:
+        raise HTTPException(status_code=500, detail="No audio was generated.")
+
+    return Response(
+        content=audio_bytes,
+        media_type="audio/wav",
+        headers={
+            "Content-Length": str(len(audio_bytes)),
+            "x-openai-model": payload.model,
+            "x-openai-voice": voice,
+        },
+    )

--- a/src/config.py
+++ b/src/config.py
@@ -176,6 +176,18 @@ class Settings:
     supertonic_default_voice: str = "M1"
     supertonic_default_lang: str = "en"
     supertonic_total_steps: int = 5
+    dramabox_hf_model: str = "ResembleAI/Dramabox"
+    dramabox_gemma_repo: str = "unsloth/gemma-3-12b-it-bnb-4bit"
+    dramabox_default_voice: str = "default"
+    dramabox_default_ref_voice: str = "female_american"
+    dramabox_prompt_wav: str = ""
+    dramabox_dtype: str = "bf16"
+    dramabox_cfg_scale: float = 2.5
+    dramabox_stg_scale: float = 1.5
+    dramabox_duration_multiplier: float = 1.1
+    dramabox_seed: int = 42
+    dramabox_compile: bool = False
+    dramabox_bnb_4bit: bool = True
     root_dir: Path = Path("/content/openai-compatible-local-tts")
     repo_dir: Path = field(default_factory=default_repo_dir)
     app_port: int = 8000

--- a/src/installers/__init__.py
+++ b/src/installers/__init__.py
@@ -4,6 +4,7 @@ from .chattts import install as install_chattts
 from .cosyvoice2 import install as install_cosyvoice2
 from .csm import install as install_csm
 from .dia import install as install_dia
+from .dramabox import install as install_dramabox
 from .f5tts import install as install_f5tts
 from .fish_speech import install as install_fish_speech
 from .gpt_sovits import install as install_gpt_sovits
@@ -41,6 +42,7 @@ INSTALLERS = {
     "CosyVoice2": install_cosyvoice2,
     "CSM-1B": install_csm,
     "Dia": install_dia,
+    "DramaBox": install_dramabox,
     "F5-TTS": install_f5tts,
     "Fish-Speech": install_fish_speech,
     "GPT-SoVITS": install_gpt_sovits,

--- a/src/installers/dramabox.py
+++ b/src/installers/dramabox.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from src.config import Settings
+from src.runtime import ensure_venv, popen, run, uv_pip_install, write_text
+
+
+DRAMABOX_REPO_URL = "https://github.com/resemble-ai/DramaBox.git"
+
+
+def install(settings: Settings) -> dict:
+    engine_dir = settings.engines_dir / "dramabox"
+    engine_dir.mkdir(parents=True, exist_ok=True)
+
+    repo_dir = engine_dir / "DramaBox"
+    if not repo_dir.exists():
+        run(["git", "clone", DRAMABOX_REPO_URL, str(repo_dir)])
+
+    python_bin = ensure_venv(engine_dir)
+    uv_pip_install(python_bin, ["-r", str(repo_dir / "requirements.txt")])
+    uv_pip_install(python_bin, ["fastapi", "uvicorn", "soundfile"])
+
+    write_text(engine_dir / "app.py", settings.read_repo_text("src/apps/dramabox_app.py"))
+
+    env = {
+        **os.environ,
+        "PYTHONUNBUFFERED": "1",
+        "OPENAI_MODEL_ID": settings.openai_model_id or "dramabox",
+        "DRAMABOX_REPO_DIR": str(repo_dir),
+        "DRAMABOX_HF_MODEL": settings.dramabox_hf_model,
+        "DRAMABOX_GEMMA_REPO": settings.dramabox_gemma_repo,
+        "DRAMABOX_DEFAULT_VOICE": settings.dramabox_default_voice,
+        "DRAMABOX_DEFAULT_REF_VOICE": settings.dramabox_default_ref_voice,
+        "DRAMABOX_PROMPT_WAV": settings.dramabox_prompt_wav,
+        "DRAMABOX_DTYPE": settings.dramabox_dtype,
+        "DRAMABOX_CFG_SCALE": str(settings.dramabox_cfg_scale),
+        "DRAMABOX_STG_SCALE": str(settings.dramabox_stg_scale),
+        "DRAMABOX_DURATION_MULTIPLIER": str(settings.dramabox_duration_multiplier),
+        "DRAMABOX_SEED": str(settings.dramabox_seed),
+        "DRAMABOX_COMPILE": "1" if settings.dramabox_compile else "0",
+        "DRAMABOX_BNB_4BIT": "1" if settings.dramabox_bnb_4bit else "0",
+    }
+    proc = popen(
+        [
+            str(engine_dir / ".venv" / "bin" / "uvicorn"),
+            "app:app",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            str(settings.app_port),
+            "--log-level",
+            "info",
+        ],
+        cwd=str(engine_dir),
+        env=env,
+        log_path=settings.log_dir / "dramabox-uvicorn.log",
+    )
+    return {
+        "proc": proc,
+        "app_dir": engine_dir,
+        "log_path": settings.log_dir / "dramabox-uvicorn.log",
+    }

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -70,6 +70,8 @@ def resolve_selected_voice(settings: Settings) -> str:
         return settings.higgs_default_voice
     if settings.engine == "Supertonic":
         return settings.supertonic_default_voice
+    if settings.engine == "DramaBox":
+        return settings.dramabox_default_voice
     return ""
 
 
@@ -389,6 +391,26 @@ def print_engine_voice_hints(settings: Settings):
         print("対応言語: 英語 / 中国語のみ（モデル規約上、それ以外の言語は禁止）")
         print("注意: ライセンスは MIT ですが、Microsoft 公式に「research purpose only」と明記されており、")
         print("      なりすまし・ディスインフォ・実時間音声変換などは禁止です。商用 / 実運用での利用は推奨されていません。")
+    elif settings.engine == "DramaBox":
+        print("DramaBox は Resemble AI の表現力豊か（directable）な TTS です（LTX-2.3 + IC-LoRA、英語中心）。")
+        print(f"モデル: {settings.dramabox_hf_model} + Gemma snapshot: {settings.dramabox_gemma_repo}")
+        print(f"デフォルト voice: {settings.dramabox_default_voice} / 参照プリセット: {settings.dramabox_default_ref_voice}")
+        print(f"cfg_scale: {settings.dramabox_cfg_scale} / stg_scale: {settings.dramabox_stg_scale} / duration_multiplier: {settings.dramabox_duration_multiplier}")
+        print(f"dtype: {settings.dramabox_dtype} / compile: {settings.dramabox_compile} / bnb_4bit: {settings.dramabox_bnb_4bit}")
+        print("voice 候補: default（assets/voices/<DRAMABOX_DEFAULT_REF_VOICE> を参照音声として使用）")
+        if settings.dramabox_prompt_wav:
+            print(f"             clone（参照音声: {settings.dramabox_prompt_wav}）")
+        else:
+            print("             clone は --dramabox-prompt-wav を指定すると有効になります（10秒以上の参照音声推奨）")
+        print("             同梱プリセット（female_american, female_shadowheart, male_arnie, male_conan,")
+        print("                          male_harvey_keitel, male_old_movie, male_petergriffin, male_samuel_j）も voice に直接指定可能です。")
+        print("プロンプト記法: ディレクター調の英語プロンプトを推奨。例:")
+        print("  'A woman speaks warmly, \"Hello, how are you today?\" She laughs, \"Hahaha, it is so good to see you!\"'")
+        print("対応言語: 英語中心（Gemma 3 12B エンベディング）。日本語等の非英語テキストは正しく発音されません。")
+        print("注意: A100 GPU 必須（VRAM ~24GB ピーク、T4/V100 では起動不可）。初回起動時に約 8.5GB のモデル + Gemma snapshot をダウンロードします。")
+        print("生成音声には Resemble Perth による不可聴ウォーターマークが常時付与されます（除去不可）。")
+        print("ライセンス警告: コードと重みは **LTX-2 Community License Agreement**（Lightricks）。")
+        print("                年商 $10M+ の組織は商用ライセンス必須。非競合条項・配布時の同ライセンス継承条項あり。")
     elif settings.engine == "Supertonic":
         print("Supertonic は Supertone Inc. の超軽量オンデバイス TTS です（ONNX、~99M params、CPU 動作可）。")
         print(f"モデル: {settings.supertonic_model}")


### PR DESCRIPTION
## Summary

Adds [resemble-ai/DramaBox](https://github.com/resemble-ai/DramaBox) as a new engine — an IC-LoRA fine-tune of Lightricks' LTX-2.3 audio-only branch with a Gemma 3 12B text encoder, exposing directable / expressive English TTS (laughs, sighs, pacing) and voice cloning with any 10+ second reference clip.

- Engine implemented with the standard layout: `src/installers/dramabox.py`, `src/apps/dramabox_app.py`, registry entry, `Settings` tunables, bootstrap CLI flags, voice resolution + hint, and Colab cell wiring.
- The wrapper clones the upstream GitHub repo, installs `requirements.txt` (`torch==2.8.0`, `pydantic==2.10.6`, `bitsandbytes`, `resemble-perth`, …), and adds `<repo>/src` + `<repo>/ltx2` to `sys.path` for module resolution.
- First run downloads ~8.5 GB from `ResembleAI/Dramabox` plus the `unsloth/gemma-3-12b-it-bnb-4bit` snapshot.
- `voice` parameter accepts `default` (uses `--dramabox-default-ref-voice`, defaulting to `female_american`), `clone` (requires `--dramabox-prompt-wav`), or any bundled preset under `DramaBox/assets/voices/` (`female_american`, `female_shadowheart`, `male_arnie`, `male_conan`, `male_harvey_keitel`, `male_old_movie`, `male_petergriffin`, `male_samuel_j`).

## License caveats

Code and weights are released under the **LTX-2 Community License Agreement** (Lightricks) — materially more restrictive than Apache 2.0 / MIT / Llama Community License:

- Organizations with annual revenue **$10 M+** must obtain a paid commercial license.
- **Non-compete clause** forbids using the model (or derivatives) to train competing models or to build products that directly compete with Lightricks' offerings.
- Redistributions of derivatives must propagate the same license (use-restrictions and acceptable-use policy intact).
- Acceptable-use restrictions are extensive (no non-consensual deepfakes, no undisclosed AI-generated content, no misinformation, no medical advice, no automated legal decisions, no military / weapons / malware uses, etc.).

Surfaced in the README license table, the engine notes section, and the launcher voice hint.

## Watermark

All generated audio is invisibly watermarked with Resemble's **Perth** implicit watermarker (`perth.PerthImplicitWatermarker`). Kept enabled per the CLAUDE.md project rule that watermarks must not be removed.

## Colab A100 verification

Verified on a Google Colab **A100-SXM4 (40 GB)** runtime against the public URL exposed by `trycloudflared`:

- Repository clone + `uv venv` created (Python 3.13.13).
- DramaBox checkpoints (~8.5 GB) + Gemma snapshot fetched on first request.
- TTSServer loaded on cuda in **14.1 s** — PromptEncoder 10.9 s (Gemma 4-bit, 7.8 GB VRAM), AudioConditioner 0.0 s, Transformer 2.3 s (3.3 B params, 6.6 GB VRAM, bf16), AudioDecoder 0.9 s. Total ≈ 14.4 GB VRAM, well within A100 40 GB.
- `/`, `/v1/models`, `/v1/voices` all return 200 with the expected payloads.
- `/v1/audio/speech` `voice=default` (`female_american` reference) produced **10.6 s** of audio in **5.80 s** (Denoise 30 steps in 3.90 s, Decode 0.44 s).
- Perth implicit watermark applied (`loaded PerthNet (Implicit) at step 250,000`).
- Public URL: `https://blond-helpful-supposed-consulting.trycloudflare.com` reachable from outside the notebook; `voice=male_arnie` preset returned a ~2 MB WAV (48 kHz stereo, 16-bit PCM) end-to-end in ~23 s including network round-trip.

## Test plan

- [x] `python colab/bootstrap.py --engine DramaBox --dry-run` exercises argparse + Settings + voice hint output locally.
- [x] Colab A100 — first run installs deps, downloads checkpoints, and returns 200 on `/`, `/v1/models`, `/v1/voices`.
- [x] Colab A100 — `/v1/audio/speech` with `voice=default` returns playable WAV with Perth watermark.
- [x] Colab A100 — public trycloudflare URL serves `/v1/audio/speech` with `voice=male_arnie` preset end-to-end.
- [x] `multi_tts_openai_colab.py` byte-for-byte synced into both README cells.

🤖 Generated with [Claude Code](https://claude.com/claude-code)