### PR TITLE
Add Scenema Audio TTS engine (unverified on Colab — Gemma 3 HF gating)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -45,6 +45,7 @@ Google Colab 上で選択したローカル TTS を一時的に OpenAI 互換 `/
 | GPT-SoVITS | Colab でエンジン起動確認済み（synthesis には参照音声必須・default speaker モード非対応・`--gpt-sovits-prompt-wav` と `--gpt-sovits-prompt-text` を指定） | 中 / 英 / 日 / 韓 / 粤 |
 | Higgs-Audio-v2 | デフォルトで動作不可（HF 上の checkpoint が未リリースの `boson_multimodal` / transformers 5.x を要求。エンジンは起動するが audio tokenizer ロード時に上流コードと config schema が一致せず推論失敗） | 英語 |
 | DramaBox | Colab A100 動作確認済み（GPU 必須、VRAM ~24GB ピーク、**LTX-2 Community License — 非競合条項あり**） | 英語 |
+| Scenema | **Colab A100（40GB VRAM）必須**。初回起動時に約 38GB ダウンロード。音声モデルは LTX-2.3 派生のため **LTX-2 Community License**（DramaBox と同じ）。Gemma 3 12B IT 利用（HF gated、`HF_TOKEN` 必須） | 英語中心の多言語 |
 
 `MeloTTS`、`Style-Bert-VITS2` は Colab の uv + venv 環境で依存解決に問題があり、現時点では動作しません。
 
@@ -78,7 +79,7 @@ REPO_URL = "https://github.com/shinshin86/local-tts-on-google-colab.git"  #@para
 REPO_REF = "main"  #@param {type:"string"}
 WORKDIR = "/content/local-tts-on-google-colab"  #@param {type:"string"}
 
-ENGINE = "Kokoro"  #@param ["Bark", "ChatTTS", "Chatterbox", "CosyVoice2", "CSM-1B", "Dia", "DramaBox", "F5-TTS", "Fish-Speech", "GPT-SoVITS", "Higgs-Audio-v2", "Irodori-TTS", "Kokoro", "Kyutai-TTS", "MaskGCT", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "OpenVoice-V2", "Orpheus-TTS", "OuteTTS", "Piper", "Piper-Plus", "Pocket-TTS", "Qwen3-TTS", "Sarashina-TTS", "Spark-TTS", "Style-Bert-VITS2", "StyleTTS2", "Supertonic", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos"]
+ENGINE = "Kokoro"  #@param ["Bark", "ChatTTS", "Chatterbox", "CosyVoice2", "CSM-1B", "Dia", "DramaBox", "F5-TTS", "Fish-Speech", "GPT-SoVITS", "Higgs-Audio-v2", "Irodori-TTS", "Kokoro", "Kyutai-TTS", "MaskGCT", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "OpenVoice-V2", "Orpheus-TTS", "OuteTTS", "Piper", "Piper-Plus", "Pocket-TTS", "Qwen3-TTS", "Sarashina-TTS", "Scenema", "Spark-TTS", "Style-Bert-VITS2", "StyleTTS2", "Supertonic", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos"]
 EXPOSE_PUBLIC_URL = True  #@param {type:"boolean"}
 TEST_TEXT = "こんにちは。これは OpenAI 互換 TTS の動作確認です。"  #@param {type:"string"}
 TEST_SPEED = 1.0  #@param {type:"number"}
@@ -342,6 +343,27 @@ DRAMABOX_DURATION_MULTIPLIER = 1.1  #@param {type:"number"}
 DRAMABOX_SEED = 42  #@param {type:"integer"}
 DRAMABOX_COMPILE = False  #@param {type:"boolean"}
 DRAMABOX_NO_BNB_4BIT = False  #@param {type:"boolean"}
+
+#@markdown ---
+#@markdown Scenema (A100 required, 40GB VRAM, English-centric multilingual, voice cloning)
+#@markdown - Zero-shot expressive voice cloning + speech generation (Scenema AI).
+#@markdown - Audio model is derived from LTX-2.3 → **LTX-2 Community License** (Lightricks, same as DramaBox).
+#@markdown - Uses Gemma 3 12B IT (gated): accept https://huggingface.co/google/gemma-3-12b-it and set `HF_TOKEN`.
+#@markdown - First-run downloads ~38GB (audio transformer + pipeline + Gemma 3 12B + SeedVC + BigVGAN + Whisper).
+#@markdown - Pass plain text → wrapped in `<speak voice="..." gender="...">` automatically.
+#@markdown   Or write the full `<speak>...<action>...</action>...</speak>` XML yourself for emotion control.
+SCENEMA_DEFAULT_VOICE = "default"  #@param ["default", "warm_male", "smoky_female", "child_girl", "elderly_male", "elderly_female", "clone"]
+SCENEMA_DEFAULT_GENDER = "male"  #@param ["male", "female"]
+SCENEMA_PROMPT_WAV = ""  #@param {type:"string"}
+SCENEMA_GEMMA_QUANTIZE = "nf4"  #@param ["nf4", ""]
+SCENEMA_SEED = -1  #@param {type:"integer"}
+SCENEMA_PACE = 1.5  #@param {type:"number"}
+SCENEMA_NO_VALIDATE = False  #@param {type:"boolean"}
+SCENEMA_MIN_MATCH_RATIO = 0.90  #@param {type:"number"}
+SCENEMA_SKIP_VC = False  #@param {type:"boolean"}
+SCENEMA_VC_STEPS = 25  #@param {type:"integer"}
+SCENEMA_VC_CFG_RATE = 0.5  #@param {type:"number"}
+SCENEMA_BACKGROUND_SFX = False  #@param {type:"boolean"}
 
 #@markdown ---
 #@markdown Supertonic (CPU OK, 31 languages incl JP/KO/EN, ONNX)
@@ -666,6 +688,24 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         str(DRAMABOX_DURATION_MULTIPLIER),
         "--dramabox-seed",
         str(DRAMABOX_SEED),
+        "--scenema-default-voice",
+        SCENEMA_DEFAULT_VOICE,
+        "--scenema-default-gender",
+        SCENEMA_DEFAULT_GENDER,
+        "--scenema-prompt-wav",
+        SCENEMA_PROMPT_WAV,
+        "--scenema-gemma-quantize",
+        SCENEMA_GEMMA_QUANTIZE,
+        "--scenema-seed",
+        str(SCENEMA_SEED),
+        "--scenema-pace",
+        str(SCENEMA_PACE),
+        "--scenema-min-match-ratio",
+        str(SCENEMA_MIN_MATCH_RATIO),
+        "--scenema-vc-steps",
+        str(SCENEMA_VC_STEPS),
+        "--scenema-vc-cfg-rate",
+        str(SCENEMA_VC_CFG_RATE),
     ]
     if SARASHINA_USE_VLLM:
         cmd.append("--sarashina-use-vllm")
@@ -675,6 +715,12 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         cmd.append("--dramabox-compile")
     if DRAMABOX_NO_BNB_4BIT:
         cmd.append("--dramabox-no-bnb-4bit")
+    if SCENEMA_NO_VALIDATE:
+        cmd.append("--scenema-no-validate")
+    if SCENEMA_SKIP_VC:
+        cmd.append("--scenema-skip-vc")
+    if SCENEMA_BACKGROUND_SFX:
+        cmd.append("--scenema-background-sfx")
     cmd.append("--expose-public-url" if EXPOSE_PUBLIC_URL else "--no-expose-public-url")
     return cmd
 
@@ -1123,6 +1169,34 @@ A woman speaks warmly, "Hello, how are you today?" She laughs, "Hahaha, it is so
 
 本リポジトリは Colab での個人・研究用途の評価ラッパーです。LTX-2 Community License が自身の用途に適合するかは利用者の責任で確認してください。
 
+### Scenema
+
+Scenema AI による zero-shot な表現力豊か / 演技指向 TTS です（[ScenemaAI/scenema-audio](https://github.com/ScenemaAI/scenema-audio)）。音声 diffusion transformer は Lightricks の LTX-2（22B 音声 + 映像モデル）から抽出した派生で、テキスト条件付けに Gemma 3 12B IT、声色変換に SeedVC、クリーン化に MelBandRoFormer を組み合わせています。最大の特徴は「演技」で、英語の自由記述で声色を描写すると、意図・ペーシング・息遣い・感情アークまで含めて発話します（参照話者が録音した感情でなくても再現可能）。
+
+**ハードウェア**: **Colab A100（40GB）必須**。本ラッパーは INT8 音声 transformer + NF4 Gemma プロファイル（常駐 VRAM ~13GB）を使用し、24GB GPU でも動作・40GB なら余裕。T4 / V100 ではモデルのホスト不可。初回起動時に合計約 38GB（audio transformer 約 5GB + pipeline 約 7GB + Gemma 3 12B 約 24GB + SeedVC 約 1.6GB + BigVGAN v2 + Whisper Small）をダウンロードします。
+
+**Gemma 3 アクセスが必須**: Hugging Face で [google/gemma-3-12b-it](https://huggingface.co/google/gemma-3-12b-it) の Gemma Terms of Use に同意し、Colab Secrets で `HF_TOKEN` を設定してからセルを実行してください。
+
+**OpenAI API へのマッピング**: 本リポジトリは Scenema を標準の `/v1/audio/speech` エンドポイントとして公開します。Scenema のネイティブ入力は `<action>` 演技指示を含む構造化 `<speak>` XML なので、入力方法は 2 通り対応します:
+
+1. **プレーンテキスト**（デフォルト）: `input` は `<speak voice="<プリセット description>" gender="<gender>">…</speak>` で自動的にラップされます。`voice` パラメータはプリセット名から description を引き、プリセット名でなければ文字列をそのまま voice description として使用します。OpenAI SDK クライアントはこの形式で利用します。
+2. **XML pass-through**（上級）: `input` が `<speak` で始まる場合、文字列はそのまま Scenema に渡されます。`<action>angry shout</action>` / `<sound>thunder</sound>` / 複数セグメントによる演技指示を活用できます。
+
+`voice` パラメータ:
+
+| voice | 説明 |
+|---|---|
+| `default` | 落ち着いた英国訛りの男性ナレーター（ベースライン中性ボイス）。 |
+| `warm_male` | 温かみのある中年男性ナレーター。深いがやわらかいトーン。 |
+| `smoky_female` | スモーキーで低音域の女性ボイス。親密で告白的なトーン。 |
+| `child_girl` | 明るく息せき切った 6 歳の女の子。 |
+| `elderly_male` | 渋い高齢男性の語り手。深いバリトン。 |
+| `elderly_female` | 70 代女性の柔らかいアルト。 |
+| `clone` | ゼロショット音声クローン。`--scenema-prompt-wav` 指定時のみ有効（10〜20 秒、感情変化のある参照音声推奨）。 |
+| `<任意の文字列>` | そのまま Scenema の voice description として使用（例: `"Male, mid 60s. Deep baritone with gravel. Slight Southern American inflection."`）。 |
+
+**ライセンス警告（重要）**: コードは MIT ですが、**音声 transformer の重みは LTX-2.3 派生のため LTX-2 Community License Agreement**（Lightricks）が継承されます — DramaBox と同じ制約の強いライセンスです。Gemma 3 12B IT は別途 Gemma Terms of Use（Google）の対象です。両方を自身の用途に対して遵守できるかは利用者の責任で確認してください。Acceptable use 制限は広範（なりすまし / ディープフェイク / 偽情報 / 軍事 / 医療助言など禁止）。
+
 ### MeloTTS (現在動作不可)
 
 [myshell-ai/MeloTTS](https://github.com/myshell-ai/MeloTTS) を使う構成ですが、依存パッケージ `tokenizers` のビルドに Rust コンパイラが必要なため、現在の Colab 環境ではインストールに失敗します。
@@ -1174,6 +1248,9 @@ A woman speaks warmly, "Hello, how are you today?" She laughs, "Hahaha, it is so
 | Higgs-Audio-v2 (code) | Apache 2.0 | — | — | LLM ベース音声基盤モデル。英語中心 |
 | Higgs-Audio-v2 (重み) | — | Boson Higgs Audio 2 Community License | 要注意 | Llama 派生 community license。MAU 10万超は追加ライセンス必須、出力で他 LLM 学習禁止 |
 | DramaBox | LTX-2 Community License (Lightricks) | LTX-2 Community License | **年商 $10M+ の組織は商用ライセンス必須** | 英語。非競合条項あり、再配布時は同ライセンス継承必須、Perth ウォーターマーク常時付与 |
+| Scenema (code) | MIT | — | — | リポジトリ: `ScenemaAI/scenema-audio` |
+| Scenema (音声重み) | — | LTX-2 Community License (Lightricks) | **年商 $10M+ の組織は商用ライセンス必須** | 音声 transformer は LTX-2.3 派生のため LTX-2 Community License が継承される。DramaBox と同じ注意点（非競合条項、acceptable use 制限、再配布時のライセンス継承） |
+| Scenema (Gemma 3 12B IT) | — | Gemma Terms of Use (Google) | 要注意 | HF gated。モデルカードで同意のうえ `HF_TOKEN` を設定。商用利用は Gemma 規約の prohibited use policy 遵守が条件 |
 
 **Piper について**: `piper-tts` パッケージは GPL-3.0 です。また、デフォルトの `en_US-lessac-medium` 音声は Lessac Technologies 提供の Blizzard 2013 データセットで学習されており、このデータセットのライセンスは商用利用を禁止しています。商用利用が必要な場合は、許容的なライセンスで学習された別の voice モデルを選択してください。
 
@@ -1263,3 +1340,7 @@ A woman speaks warmly, "Hello, how are you today?" She laughs, "Hahaha, it is so
   https://github.com/resemble-ai/DramaBox
 - DramaBox (Hugging Face)
   https://huggingface.co/ResembleAI/Dramabox
+- Scenema Audio
+  https://github.com/ScenemaAI/scenema-audio
+- Scenema Audio (Hugging Face)
+  https://huggingface.co/ScenemaAI/scenema-audio

--- a/README.ja.md
+++ b/README.ja.md
@@ -1173,9 +1173,17 @@ A woman speaks warmly, "Hello, how are you today?" She laughs, "Hahaha, it is so
 
 Scenema AI による zero-shot な表現力豊か / 演技指向 TTS です（[ScenemaAI/scenema-audio](https://github.com/ScenemaAI/scenema-audio)）。音声 diffusion transformer は Lightricks の LTX-2（22B 音声 + 映像モデル）から抽出した派生で、テキスト条件付けに Gemma 3 12B IT、声色変換に SeedVC、クリーン化に MelBandRoFormer を組み合わせています。最大の特徴は「演技」で、英語の自由記述で声色を描写すると、意図・ペーシング・息遣い・感情アークまで含めて発話します（参照話者が録音した感情でなくても再現可能）。
 
-**ハードウェア**: **Colab A100（40GB）必須**。本ラッパーは INT8 音声 transformer + NF4 Gemma プロファイル（常駐 VRAM ~13GB）を使用し、24GB GPU でも動作・40GB なら余裕。T4 / V100 ではモデルのホスト不可。初回起動時に合計約 38GB（audio transformer 約 5GB + pipeline 約 7GB + Gemma 3 12B 約 24GB + SeedVC 約 1.6GB + BigVGAN v2 + Whisper Small）をダウンロードします。
+**ステータス: Colab 未検証**。インストール / 配線 / API レイヤ（installer・app・voice プリセット・XML pass-through）は一通り実装済みですが、Scenema のテキストエンコーダは **HF gated な Gemma 3 12B IT** です。`HF_TOKEN` の設定と Google の Gemma Terms of Use 同意は本リポのデフォルト検証ワークフローの範囲外のため、Colab A100 での E2E 検証は保留しています。実際に Colab で動かしたい場合は、以下のセットアップを利用者側で行ってください。動作確認できた方からの trycloudflare ログ付き Issue / PR は歓迎です。
 
-**Gemma 3 アクセスが必須**: Hugging Face で [google/gemma-3-12b-it](https://huggingface.co/google/gemma-3-12b-it) の Gemma Terms of Use に同意し、Colab Secrets で `HF_TOKEN` を設定してからセルを実行してください。
+**起動前のセットアップ:**
+
+1. Hugging Face にサインインし、[google/gemma-3-12b-it](https://huggingface.co/google/gemma-3-12b-it) モデルカードの「Acknowledge license」で Gemma Terms of Use に同意。
+2. https://huggingface.co/settings/tokens で **Read** スコープのトークンを発行。
+3. Colab ノートブック左サイドバーの **🔑 Secrets** を開き、**名前 `HF_TOKEN`** で 2 のトークン値を保存、**ノートブックからのアクセスをオン**。
+
+未設定で起動すると lifespan の `snapshot_download("google/gemma-3-12b-it")` が `401 Unauthorized` で失敗し、`AudioProcessor` が ready にならず `/v1/audio/speech` は 503 を返します。
+
+**ハードウェア**: **Colab A100（40GB）必須**。本ラッパーは INT8 音声 transformer + NF4 Gemma プロファイル（常駐 VRAM ~13GB）を使用し、24GB GPU でも動作・40GB なら余裕。T4 / V100 ではモデルのホスト不可。初回起動時に合計約 38GB（audio transformer 約 5GB + pipeline 約 7GB + Gemma 3 12B 約 24GB + SeedVC 約 1.6GB + BigVGAN v2 + Whisper Small）をダウンロードします。
 
 **OpenAI API へのマッピング**: 本リポジトリは Scenema を標準の `/v1/audio/speech` エンドポイントとして公開します。Scenema のネイティブ入力は `<action>` 演技指示を含む構造化 `<speak>` XML なので、入力方法は 2 通り対応します:
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Supported engines:
 | GPT-SoVITS | Engine starts on Colab — reference audio required for synthesis (no default speaker mode; pass `--gpt-sovits-prompt-wav` + `--gpt-sovits-prompt-text`) | Chinese / English / Japanese / Korean / Cantonese |
 | Higgs-Audio-v2 | Not working by default (upstream HF checkpoint requires unreleased `boson_multimodal` / transformers 5.x; engine starts but inference fails inside the audio tokenizer loader) | English |
 | DramaBox | Works on Colab A100 (GPU required, VRAM ~24GB peak, **LTX-2 Community License — non-compete clause**) | English |
-| Scenema | **Requires Colab A100 (40GB VRAM)**. First-run downloads ~38GB. Audio model derived from LTX-2.3 → **LTX-2 Community License** (same as DramaBox). Uses Gemma 3 12B IT (HF-gated, needs `HF_TOKEN`) | English-centric multilingual |
+| Scenema | **Not verified on Colab** — text encoder is Gemma 3 12B IT (HF-gated), so running this engine requires accepting the Gemma Terms of Use on Hugging Face and providing `HF_TOKEN` via Colab Secrets. Code paths are in place but end-to-end Colab verification was deferred because `HF_TOKEN` setup is out of scope for this repo's default workflow. **Requires Colab A100 (40GB VRAM)**. First-run downloads ~38GB. Audio model derived from LTX-2.3 → **LTX-2 Community License** (same as DramaBox) | English-centric multilingual |
 
 `MeloTTS` and `Style-Bert-VITS2` currently have dependency resolution issues under Colab's uv + venv environment and do not work.
 
@@ -1173,9 +1173,17 @@ This repository wraps DramaBox only for personal / research evaluation on Colab 
 
 A zero-shot expressive voice cloning / speech-generation engine from Scenema AI ([ScenemaAI/scenema-audio](https://github.com/ScenemaAI/scenema-audio)). Its audio diffusion transformer is extracted from Lightricks' LTX-2 (22B audiovisual model) and conditioned with Gemma 3 12B IT, paired with SeedVC for voice identity transfer and a MelBandRoFormer separator for clean speech. The marquee feature is "performance": describe a voice in free-form English and the model delivers it with intent, pacing, breath control, and emotional arcs — including emotions the reference speaker never recorded.
 
-**Hardware**: **Colab A100 (40 GB) is required.** The wrapper uses the INT8 audio transformer + NF4 Gemma profile (~13 GB resident VRAM, fits in 24 GB and comfortably on 40 GB). T4 / V100 cannot host this model. First run downloads ~38 GB total: audio transformer (~5 GB), pipeline checkpoint (~7 GB), Gemma 3 12B IT (~24 GB), SeedVC (~1.6 GB), BigVGAN v2 + Whisper Small.
+**Status: not verified on Colab.** The full install / wiring / API layer is implemented (installer, app, voice presets, XML pass-through), but Scenema's text encoder is **Gemma 3 12B IT, which is HF-gated**. End-to-end verification on Colab A100 was deferred because configuring `HF_TOKEN` and accepting Google's Gemma Terms of Use sits outside this repo's default verification workflow. If you want to actually run this engine on Colab, you need to do the setup yourself (see below). Confirmed-good Colab logs from a user would be welcome — please open an issue / PR with the trycloudflare evidence.
 
-**Gemma 3 access is required.** Visit [google/gemma-3-12b-it](https://huggingface.co/google/gemma-3-12b-it) on Hugging Face, accept the Gemma Terms of Use, then set `HF_TOKEN` from Colab Secrets before launching the cell.
+**Setup required before launch:**
+
+1. Sign in to Hugging Face and accept the Gemma Terms of Use on the [google/gemma-3-12b-it](https://huggingface.co/google/gemma-3-12b-it) model card ("Acknowledge license").
+2. Create a Read-scoped Hugging Face token at https://huggingface.co/settings/tokens.
+3. In the Colab notebook, open the left sidebar **🔑 Secrets** panel, add a new secret named **`HF_TOKEN`** with the token value, and **enable notebook access**.
+
+Without this, the lifespan startup `snapshot_download("google/gemma-3-12b-it")` returns `401 Unauthorized` and `AudioProcessor` never becomes ready — `/v1/audio/speech` will return 503.
+
+**Hardware**: **Colab A100 (40 GB) is required.** The wrapper uses the INT8 audio transformer + NF4 Gemma profile (~13 GB resident VRAM, fits in 24 GB and comfortably on 40 GB). T4 / V100 cannot host this model. First run downloads ~38 GB total: audio transformer (~5 GB), pipeline checkpoint (~7 GB), Gemma 3 12B IT (~24 GB), SeedVC (~1.6 GB), BigVGAN v2 + Whisper Small.
 
 **OpenAI API mapping.** This repo exposes Scenema through the standard `/v1/audio/speech` endpoint. Because Scenema's native input is a structured `<speak>` XML with `<action>` performance directions, two input paths are supported:
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Supported engines:
 | GPT-SoVITS | Engine starts on Colab — reference audio required for synthesis (no default speaker mode; pass `--gpt-sovits-prompt-wav` + `--gpt-sovits-prompt-text`) | Chinese / English / Japanese / Korean / Cantonese |
 | Higgs-Audio-v2 | Not working by default (upstream HF checkpoint requires unreleased `boson_multimodal` / transformers 5.x; engine starts but inference fails inside the audio tokenizer loader) | English |
 | DramaBox | Works on Colab A100 (GPU required, VRAM ~24GB peak, **LTX-2 Community License — non-compete clause**) | English |
+| Scenema | **Requires Colab A100 (40GB VRAM)**. First-run downloads ~38GB. Audio model derived from LTX-2.3 → **LTX-2 Community License** (same as DramaBox). Uses Gemma 3 12B IT (HF-gated, needs `HF_TOKEN`) | English-centric multilingual |
 
 `MeloTTS` and `Style-Bert-VITS2` currently have dependency resolution issues under Colab's uv + venv environment and do not work.
 
@@ -78,7 +79,7 @@ REPO_URL = "https://github.com/shinshin86/local-tts-on-google-colab.git"  #@para
 REPO_REF = "main"  #@param {type:"string"}
 WORKDIR = "/content/local-tts-on-google-colab"  #@param {type:"string"}
 
-ENGINE = "Kokoro"  #@param ["Bark", "ChatTTS", "Chatterbox", "CosyVoice2", "CSM-1B", "Dia", "DramaBox", "F5-TTS", "Fish-Speech", "GPT-SoVITS", "Higgs-Audio-v2", "Irodori-TTS", "Kokoro", "Kyutai-TTS", "MaskGCT", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "OpenVoice-V2", "Orpheus-TTS", "OuteTTS", "Piper", "Piper-Plus", "Pocket-TTS", "Qwen3-TTS", "Sarashina-TTS", "Spark-TTS", "Style-Bert-VITS2", "StyleTTS2", "Supertonic", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos"]
+ENGINE = "Kokoro"  #@param ["Bark", "ChatTTS", "Chatterbox", "CosyVoice2", "CSM-1B", "Dia", "DramaBox", "F5-TTS", "Fish-Speech", "GPT-SoVITS", "Higgs-Audio-v2", "Irodori-TTS", "Kokoro", "Kyutai-TTS", "MaskGCT", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "OpenVoice-V2", "Orpheus-TTS", "OuteTTS", "Piper", "Piper-Plus", "Pocket-TTS", "Qwen3-TTS", "Sarashina-TTS", "Scenema", "Spark-TTS", "Style-Bert-VITS2", "StyleTTS2", "Supertonic", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos"]
 EXPOSE_PUBLIC_URL = True  #@param {type:"boolean"}
 TEST_TEXT = "こんにちは。これは OpenAI 互換 TTS の動作確認です。"  #@param {type:"string"}
 TEST_SPEED = 1.0  #@param {type:"number"}
@@ -342,6 +343,27 @@ DRAMABOX_DURATION_MULTIPLIER = 1.1  #@param {type:"number"}
 DRAMABOX_SEED = 42  #@param {type:"integer"}
 DRAMABOX_COMPILE = False  #@param {type:"boolean"}
 DRAMABOX_NO_BNB_4BIT = False  #@param {type:"boolean"}
+
+#@markdown ---
+#@markdown Scenema (A100 required, 40GB VRAM, English-centric multilingual, voice cloning)
+#@markdown - Zero-shot expressive voice cloning + speech generation (Scenema AI).
+#@markdown - Audio model is derived from LTX-2.3 → **LTX-2 Community License** (Lightricks, same as DramaBox).
+#@markdown - Uses Gemma 3 12B IT (gated): accept https://huggingface.co/google/gemma-3-12b-it and set `HF_TOKEN`.
+#@markdown - First-run downloads ~38GB (audio transformer + pipeline + Gemma 3 12B + SeedVC + BigVGAN + Whisper).
+#@markdown - Pass plain text → wrapped in `<speak voice="..." gender="...">` automatically.
+#@markdown   Or write the full `<speak>...<action>...</action>...</speak>` XML yourself for emotion control.
+SCENEMA_DEFAULT_VOICE = "default"  #@param ["default", "warm_male", "smoky_female", "child_girl", "elderly_male", "elderly_female", "clone"]
+SCENEMA_DEFAULT_GENDER = "male"  #@param ["male", "female"]
+SCENEMA_PROMPT_WAV = ""  #@param {type:"string"}
+SCENEMA_GEMMA_QUANTIZE = "nf4"  #@param ["nf4", ""]
+SCENEMA_SEED = -1  #@param {type:"integer"}
+SCENEMA_PACE = 1.5  #@param {type:"number"}
+SCENEMA_NO_VALIDATE = False  #@param {type:"boolean"}
+SCENEMA_MIN_MATCH_RATIO = 0.90  #@param {type:"number"}
+SCENEMA_SKIP_VC = False  #@param {type:"boolean"}
+SCENEMA_VC_STEPS = 25  #@param {type:"integer"}
+SCENEMA_VC_CFG_RATE = 0.5  #@param {type:"number"}
+SCENEMA_BACKGROUND_SFX = False  #@param {type:"boolean"}
 
 #@markdown ---
 #@markdown Supertonic (CPU OK, 31 languages incl JP/KO/EN, ONNX)
@@ -666,6 +688,24 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         str(DRAMABOX_DURATION_MULTIPLIER),
         "--dramabox-seed",
         str(DRAMABOX_SEED),
+        "--scenema-default-voice",
+        SCENEMA_DEFAULT_VOICE,
+        "--scenema-default-gender",
+        SCENEMA_DEFAULT_GENDER,
+        "--scenema-prompt-wav",
+        SCENEMA_PROMPT_WAV,
+        "--scenema-gemma-quantize",
+        SCENEMA_GEMMA_QUANTIZE,
+        "--scenema-seed",
+        str(SCENEMA_SEED),
+        "--scenema-pace",
+        str(SCENEMA_PACE),
+        "--scenema-min-match-ratio",
+        str(SCENEMA_MIN_MATCH_RATIO),
+        "--scenema-vc-steps",
+        str(SCENEMA_VC_STEPS),
+        "--scenema-vc-cfg-rate",
+        str(SCENEMA_VC_CFG_RATE),
     ]
     if SARASHINA_USE_VLLM:
         cmd.append("--sarashina-use-vllm")
@@ -675,6 +715,12 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         cmd.append("--dramabox-compile")
     if DRAMABOX_NO_BNB_4BIT:
         cmd.append("--dramabox-no-bnb-4bit")
+    if SCENEMA_NO_VALIDATE:
+        cmd.append("--scenema-no-validate")
+    if SCENEMA_SKIP_VC:
+        cmd.append("--scenema-skip-vc")
+    if SCENEMA_BACKGROUND_SFX:
+        cmd.append("--scenema-background-sfx")
     cmd.append("--expose-public-url" if EXPOSE_PUBLIC_URL else "--no-expose-public-url")
     return cmd
 
@@ -1123,6 +1169,34 @@ The `voice` parameter exposes:
 
 This repository wraps DramaBox only for personal / research evaluation on Colab — operators are responsible for confirming their own use case complies with the LTX-2 Community License.
 
+### Scenema
+
+A zero-shot expressive voice cloning / speech-generation engine from Scenema AI ([ScenemaAI/scenema-audio](https://github.com/ScenemaAI/scenema-audio)). Its audio diffusion transformer is extracted from Lightricks' LTX-2 (22B audiovisual model) and conditioned with Gemma 3 12B IT, paired with SeedVC for voice identity transfer and a MelBandRoFormer separator for clean speech. The marquee feature is "performance": describe a voice in free-form English and the model delivers it with intent, pacing, breath control, and emotional arcs — including emotions the reference speaker never recorded.
+
+**Hardware**: **Colab A100 (40 GB) is required.** The wrapper uses the INT8 audio transformer + NF4 Gemma profile (~13 GB resident VRAM, fits in 24 GB and comfortably on 40 GB). T4 / V100 cannot host this model. First run downloads ~38 GB total: audio transformer (~5 GB), pipeline checkpoint (~7 GB), Gemma 3 12B IT (~24 GB), SeedVC (~1.6 GB), BigVGAN v2 + Whisper Small.
+
+**Gemma 3 access is required.** Visit [google/gemma-3-12b-it](https://huggingface.co/google/gemma-3-12b-it) on Hugging Face, accept the Gemma Terms of Use, then set `HF_TOKEN` from Colab Secrets before launching the cell.
+
+**OpenAI API mapping.** This repo exposes Scenema through the standard `/v1/audio/speech` endpoint. Because Scenema's native input is a structured `<speak>` XML with `<action>` performance directions, two input paths are supported:
+
+1. **Plain text** (default): `input` is wrapped automatically as `<speak voice="<preset description>" gender="<gender>">…</speak>`. The `voice` parameter selects a preset or — for non-preset values — is used as the voice description verbatim. This is what OpenAI SDK clients will use.
+2. **XML pass-through** (advanced): if `input` begins with `<speak`, the string is forwarded to Scenema unchanged. Use this to add `<action>angry shout</action>` / `<sound>thunder</sound>` / multi-segment performance direction.
+
+The `voice` parameter exposes:
+
+| voice | description |
+|---|---|
+| `default` | Warm British-accented male narrator (baseline neutral voice). |
+| `warm_male` | Warm middle-aged male narrator. Deep but gentle tone. |
+| `smoky_female` | Smoky low-register female voice, intimate confessional tone. |
+| `child_girl` | Bright six-year-old girl, breathless and excited. |
+| `elderly_male` | Weathered elderly male storyteller, deep baritone. |
+| `elderly_female` | Soft alto, woman in her seventies. |
+| `clone` | Zero-shot voice cloning. Requires `--scenema-prompt-wav` (10–20 s of reference audio with some emotional variability). |
+| `<any other string>` | Used directly as a Scenema voice description (e.g. `"Male, mid 60s. Deep baritone with gravel. Slight Southern American inflection."`). |
+
+**License caveat (important):** code is MIT, but the **audio transformer weights inherit the LTX-2 Community License Agreement** (Lightricks) — the same restrictive license as DramaBox. Gemma 3 12B IT is additionally bound by the Gemma Terms of Use (Google). Operators are responsible for confirming their use case complies with both. Acceptable-use limits are extensive (no impersonation, no deepfakes, no disinformation, no military / weapons / medical-advice uses, etc.).
+
 ### MeloTTS (currently not working)
 
 Intended to use [myshell-ai/MeloTTS](https://github.com/myshell-ai/MeloTTS), but the dependency `tokenizers` requires a Rust compiler to build, so installation fails in the current Colab environment.
@@ -1174,6 +1248,9 @@ The license for each engine is as follows. When using them, always check each pr
 | Higgs-Audio-v2 (code) | Apache 2.0 | — | — | LLM-based audio foundation model. EN focus |
 | Higgs-Audio-v2 (weights) | — | Boson Higgs Audio 2 Community License | Caution | Llama-derived community license. Restricted: >100k MAU needs extra license; outputs cannot be used to train other LLMs |
 | DramaBox | LTX-2 Community License (Lightricks) | LTX-2 Community License | **Not allowed without commercial license** for orgs with annual revenue $10M+ | English. Non-compete clause; redistributions must propagate the same license. Perth watermark always applied |
+| Scenema (code) | MIT | — | — | Repo: `ScenemaAI/scenema-audio` |
+| Scenema (audio weights) | — | LTX-2 Community License (Lightricks) | **Not allowed without commercial license** for orgs with annual revenue $10M+ | Audio transformer is derived from LTX-2.3; the LTX-2 Community License flows through. Same caveats as DramaBox (non-compete, acceptable-use restrictions, propagation requirement) |
+| Scenema (Gemma 3 12B IT) | — | Gemma Terms of Use (Google) | Caution | HF-gated; accept on the model card and set `HF_TOKEN`. Commercial use is permitted under Gemma terms but the prohibited-use policy applies |
 
 **About Piper**: The `piper-tts` package is GPL-3.0. Also, the default `en_US-lessac-medium` voice is trained on the Blizzard 2013 dataset provided by Lessac Technologies, and its license prohibits commercial use. If you need commercial use, choose another voice model trained with a permissive license.
 
@@ -1263,3 +1340,7 @@ This repository itself is intended for short-term operational verification and t
   https://github.com/resemble-ai/DramaBox
 - DramaBox (Hugging Face)
   https://huggingface.co/ResembleAI/Dramabox
+- Scenema Audio
+  https://github.com/ScenemaAI/scenema-audio
+- Scenema Audio (Hugging Face)
+  https://huggingface.co/ScenemaAI/scenema-audio

--- a/colab/bootstrap.py
+++ b/colab/bootstrap.py
@@ -169,6 +169,18 @@ def parse_args():
     parser.add_argument("--dramabox-seed", type=int, default=42)
     parser.add_argument("--dramabox-compile", action="store_true")
     parser.add_argument("--dramabox-no-bnb-4bit", action="store_true")
+    parser.add_argument("--scenema-default-voice", default="default")
+    parser.add_argument("--scenema-default-gender", default="male")
+    parser.add_argument("--scenema-prompt-wav", default="")
+    parser.add_argument("--scenema-gemma-quantize", default="nf4")
+    parser.add_argument("--scenema-seed", type=int, default=-1)
+    parser.add_argument("--scenema-pace", type=float, default=1.5)
+    parser.add_argument("--scenema-no-validate", action="store_true")
+    parser.add_argument("--scenema-min-match-ratio", type=float, default=0.90)
+    parser.add_argument("--scenema-skip-vc", action="store_true")
+    parser.add_argument("--scenema-vc-steps", type=int, default=25)
+    parser.add_argument("--scenema-vc-cfg-rate", type=float, default=0.5)
+    parser.add_argument("--scenema-background-sfx", action="store_true")
     parser.add_argument("--root-dir", default="/content/openai-compatible-local-tts")
     return parser.parse_args()
 
@@ -324,6 +336,18 @@ def main():
         dramabox_seed=args.dramabox_seed,
         dramabox_compile=args.dramabox_compile,
         dramabox_bnb_4bit=not args.dramabox_no_bnb_4bit,
+        scenema_default_voice=args.scenema_default_voice,
+        scenema_default_gender=args.scenema_default_gender,
+        scenema_prompt_wav=args.scenema_prompt_wav,
+        scenema_gemma_quantize=args.scenema_gemma_quantize,
+        scenema_seed=args.scenema_seed,
+        scenema_pace=args.scenema_pace,
+        scenema_validate=not args.scenema_no_validate,
+        scenema_min_match_ratio=args.scenema_min_match_ratio,
+        scenema_skip_vc=args.scenema_skip_vc,
+        scenema_vc_steps=args.scenema_vc_steps,
+        scenema_vc_cfg_rate=args.scenema_vc_cfg_rate,
+        scenema_background_sfx=args.scenema_background_sfx,
         root_dir=Path(args.root_dir),
         repo_dir=REPO_DIR,
     )

--- a/multi_tts_openai_colab.py
+++ b/multi_tts_openai_colab.py
@@ -11,7 +11,7 @@ REPO_URL = "https://github.com/shinshin86/local-tts-on-google-colab.git"  #@para
 REPO_REF = "main"  #@param {type:"string"}
 WORKDIR = "/content/local-tts-on-google-colab"  #@param {type:"string"}
 
-ENGINE = "Kokoro"  #@param ["Bark", "ChatTTS", "Chatterbox", "CosyVoice2", "CSM-1B", "Dia", "DramaBox", "F5-TTS", "Fish-Speech", "GPT-SoVITS", "Higgs-Audio-v2", "Irodori-TTS", "Kokoro", "Kyutai-TTS", "MaskGCT", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "OpenVoice-V2", "Orpheus-TTS", "OuteTTS", "Piper", "Piper-Plus", "Pocket-TTS", "Qwen3-TTS", "Sarashina-TTS", "Spark-TTS", "Style-Bert-VITS2", "StyleTTS2", "Supertonic", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos"]
+ENGINE = "Kokoro"  #@param ["Bark", "ChatTTS", "Chatterbox", "CosyVoice2", "CSM-1B", "Dia", "DramaBox", "F5-TTS", "Fish-Speech", "GPT-SoVITS", "Higgs-Audio-v2", "Irodori-TTS", "Kokoro", "Kyutai-TTS", "MaskGCT", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "OpenVoice-V2", "Orpheus-TTS", "OuteTTS", "Piper", "Piper-Plus", "Pocket-TTS", "Qwen3-TTS", "Sarashina-TTS", "Scenema", "Spark-TTS", "Style-Bert-VITS2", "StyleTTS2", "Supertonic", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos"]
 EXPOSE_PUBLIC_URL = True  #@param {type:"boolean"}
 TEST_TEXT = "こんにちは。これは OpenAI 互換 TTS の動作確認です。"  #@param {type:"string"}
 TEST_SPEED = 1.0  #@param {type:"number"}
@@ -275,6 +275,27 @@ DRAMABOX_DURATION_MULTIPLIER = 1.1  #@param {type:"number"}
 DRAMABOX_SEED = 42  #@param {type:"integer"}
 DRAMABOX_COMPILE = False  #@param {type:"boolean"}
 DRAMABOX_NO_BNB_4BIT = False  #@param {type:"boolean"}
+
+#@markdown ---
+#@markdown Scenema (A100 required, 40GB VRAM, English-centric multilingual, voice cloning)
+#@markdown - Zero-shot expressive voice cloning + speech generation (Scenema AI).
+#@markdown - Audio model is derived from LTX-2.3 → **LTX-2 Community License** (Lightricks, same as DramaBox).
+#@markdown - Uses Gemma 3 12B IT (gated): accept https://huggingface.co/google/gemma-3-12b-it and set `HF_TOKEN`.
+#@markdown - First-run downloads ~38GB (audio transformer + pipeline + Gemma 3 12B + SeedVC + BigVGAN + Whisper).
+#@markdown - Pass plain text → wrapped in `<speak voice="..." gender="...">` automatically.
+#@markdown   Or write the full `<speak>...<action>...</action>...</speak>` XML yourself for emotion control.
+SCENEMA_DEFAULT_VOICE = "default"  #@param ["default", "warm_male", "smoky_female", "child_girl", "elderly_male", "elderly_female", "clone"]
+SCENEMA_DEFAULT_GENDER = "male"  #@param ["male", "female"]
+SCENEMA_PROMPT_WAV = ""  #@param {type:"string"}
+SCENEMA_GEMMA_QUANTIZE = "nf4"  #@param ["nf4", ""]
+SCENEMA_SEED = -1  #@param {type:"integer"}
+SCENEMA_PACE = 1.5  #@param {type:"number"}
+SCENEMA_NO_VALIDATE = False  #@param {type:"boolean"}
+SCENEMA_MIN_MATCH_RATIO = 0.90  #@param {type:"number"}
+SCENEMA_SKIP_VC = False  #@param {type:"boolean"}
+SCENEMA_VC_STEPS = 25  #@param {type:"integer"}
+SCENEMA_VC_CFG_RATE = 0.5  #@param {type:"number"}
+SCENEMA_BACKGROUND_SFX = False  #@param {type:"boolean"}
 
 #@markdown ---
 #@markdown Supertonic (CPU OK, 31 languages incl JP/KO/EN, ONNX)
@@ -599,6 +620,24 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         str(DRAMABOX_DURATION_MULTIPLIER),
         "--dramabox-seed",
         str(DRAMABOX_SEED),
+        "--scenema-default-voice",
+        SCENEMA_DEFAULT_VOICE,
+        "--scenema-default-gender",
+        SCENEMA_DEFAULT_GENDER,
+        "--scenema-prompt-wav",
+        SCENEMA_PROMPT_WAV,
+        "--scenema-gemma-quantize",
+        SCENEMA_GEMMA_QUANTIZE,
+        "--scenema-seed",
+        str(SCENEMA_SEED),
+        "--scenema-pace",
+        str(SCENEMA_PACE),
+        "--scenema-min-match-ratio",
+        str(SCENEMA_MIN_MATCH_RATIO),
+        "--scenema-vc-steps",
+        str(SCENEMA_VC_STEPS),
+        "--scenema-vc-cfg-rate",
+        str(SCENEMA_VC_CFG_RATE),
     ]
     if SARASHINA_USE_VLLM:
         cmd.append("--sarashina-use-vllm")
@@ -608,6 +647,12 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         cmd.append("--dramabox-compile")
     if DRAMABOX_NO_BNB_4BIT:
         cmd.append("--dramabox-no-bnb-4bit")
+    if SCENEMA_NO_VALIDATE:
+        cmd.append("--scenema-no-validate")
+    if SCENEMA_SKIP_VC:
+        cmd.append("--scenema-skip-vc")
+    if SCENEMA_BACKGROUND_SFX:
+        cmd.append("--scenema-background-sfx")
     cmd.append("--expose-public-url" if EXPOSE_PUBLIC_URL else "--no-expose-public-url")
     return cmd
 

--- a/src/apps/scenema_app.py
+++ b/src/apps/scenema_app.py
@@ -1,0 +1,361 @@
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import uuid
+from contextlib import asynccontextmanager
+from pathlib import Path
+from xml.sax.saxutils import escape
+
+from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse, JSONResponse
+from pydantic import BaseModel
+
+logger = logging.getLogger("uvicorn.error")
+
+OPENAI_MODEL_ID = os.environ.get("OPENAI_MODEL_ID", "scenema")
+SCENEMA_REPO_DIR = os.environ.get("SCENEMA_REPO_DIR", "")
+SEEDVC_PATH = os.environ.get("SEEDVC_PATH", "")
+MELBAND_NODE_PATH = os.environ.get("MELBAND_NODE_PATH", "")
+MODEL_DIR = Path(os.environ.get("MODEL_DIR", "/content/scenema-models"))
+PROMPT_WAV = os.environ.get("SCENEMA_PROMPT_WAV", "")
+DEFAULT_VOICE = os.environ.get("SCENEMA_DEFAULT_VOICE", "default")
+DEFAULT_GENDER = os.environ.get("SCENEMA_DEFAULT_GENDER", "male")
+SEED = int(os.environ.get("SCENEMA_SEED", "-1"))
+PACE = float(os.environ.get("SCENEMA_PACE", "1.5"))
+VALIDATE = os.environ.get("SCENEMA_VALIDATE", "1") == "1"
+MIN_MATCH_RATIO = float(os.environ.get("SCENEMA_MIN_MATCH_RATIO", "0.90"))
+SKIP_VC = os.environ.get("SCENEMA_SKIP_VC", "0") == "1"
+VC_STEPS = int(os.environ.get("SCENEMA_VC_STEPS", "25"))
+VC_CFG_RATE = float(os.environ.get("SCENEMA_VC_CFG_RATE", "0.5"))
+BACKGROUND_SFX = os.environ.get("SCENEMA_BACKGROUND_SFX", "0") == "1"
+APP_PORT = int(os.environ.get("SCENEMA_APP_PORT", "8000"))
+
+# Upstream layout: scenema-audio uses PYTHONPATH=/app/src + sibling clones for
+# seed-vc and the MelBandRoFormer node. Mirror that here.
+if SCENEMA_REPO_DIR:
+    for sub in ("src",):
+        path = str(Path(SCENEMA_REPO_DIR) / sub)
+        if path not in sys.path:
+            sys.path.insert(0, path)
+for extra in (SEEDVC_PATH, MELBAND_NODE_PATH):
+    if extra and extra not in sys.path:
+        sys.path.insert(0, extra)
+
+
+# Free-form voice description presets. Users can also pass an arbitrary
+# description directly as the `voice` parameter — if it doesn't match a
+# preset name, it is used as the voice description verbatim.
+SCENEMA_VOICE_PRESETS: dict[str, dict[str, str]] = {
+    "default": {
+        "description": "A warm, clear male narrator with a slight British accent. Measured, thoughtful pacing.",
+        "gender": "male",
+    },
+    "warm_male": {
+        "description": "Warm middle-aged male narrator. Deep but gentle tone, unhurried pacing, slight rasp.",
+        "gender": "male",
+    },
+    "smoky_female": {
+        "description": "Smoky low-register female voice, intimate confessional tone, slight breathiness.",
+        "gender": "female",
+    },
+    "child_girl": {
+        "description": "Bright six-year-old girl, breathless and excited, slight lisp on S sounds.",
+        "gender": "female",
+    },
+    "elderly_male": {
+        "description": "Weathered elderly male storyteller, deep baritone, slow deliberate pacing, nostalgic warmth.",
+        "gender": "male",
+    },
+    "elderly_female": {
+        "description": "Soft alto, woman in her seventies, unhurried, warm and grandmotherly.",
+        "gender": "female",
+    },
+}
+
+
+_processor = None  # type: ignore[var-annotated]
+_ProcessJob = None  # type: ignore[var-annotated]
+
+
+def _download_models() -> None:
+    """Fetch missing checkpoints. Ported from scenema-audio src/server.py."""
+    from huggingface_hub import hf_hub_download, snapshot_download
+
+    HF_REPO = "ScenemaAI/scenema-audio"
+    GEMMA_REPO = "google/gemma-3-12b-it"
+    SEEDVC_REPO = "Plachta/Seed-VC"
+    BIGVGAN_REPO = "nvidia/bigvgan_v2_22khz_80band_256x"
+    WHISPER_REPO = "openai/whisper-small"
+
+    token = os.environ.get("HF_TOKEN") or None
+    MODEL_DIR.mkdir(parents=True, exist_ok=True)
+
+    audio_ckpt = Path(
+        os.environ.get(
+            "AUDIO_CKPT",
+            str(MODEL_DIR / "scenema-audio-transformer-int8.safetensors"),
+        )
+    )
+    if not audio_ckpt.exists():
+        logger.info("Scenema: downloading audio transformer (INT8, ~4.9 GB)...")
+        hf_hub_download(
+            HF_REPO,
+            "scenema-audio-transformer-int8.safetensors",
+            local_dir=str(audio_ckpt.parent),
+            token=token,
+        )
+
+    pipeline_ckpt = Path(
+        os.environ.get(
+            "PIPELINE_CKPT",
+            str(MODEL_DIR / "scenema-audio-pipeline.safetensors"),
+        )
+    )
+    if not pipeline_ckpt.exists():
+        logger.info("Scenema: downloading pipeline checkpoint (~7.1 GB)...")
+        hf_hub_download(
+            HF_REPO,
+            "scenema-audio-pipeline.safetensors",
+            local_dir=str(pipeline_ckpt.parent),
+            token=token,
+        )
+
+    vae_ckpt = Path(
+        os.environ.get(
+            "VAE_ENCODER_CKPT",
+            str(MODEL_DIR / "scenema-audio-vae-encoder.safetensors"),
+        )
+    )
+    if not vae_ckpt.exists():
+        logger.info("Scenema: downloading VAE encoder (~42 MB)...")
+        hf_hub_download(
+            HF_REPO,
+            "scenema-audio-vae-encoder.safetensors",
+            local_dir=str(vae_ckpt.parent),
+            token=token,
+        )
+
+    gemma_root = Path(os.environ.get("GEMMA_ROOT", str(MODEL_DIR / "gemma-3-12b-it")))
+    if not gemma_root.exists() or not any(gemma_root.glob("*.safetensors")):
+        logger.info(
+            "Scenema: downloading Gemma 3 12B IT (~24 GB, gated — needs HF_TOKEN)..."
+        )
+        snapshot_download(
+            GEMMA_REPO,
+            local_dir=str(gemma_root),
+            ignore_patterns=["*.gguf"],
+            token=token,
+        )
+
+    seedvc_cache = Path(SEEDVC_PATH) / "checkpoints" if SEEDVC_PATH else None
+    if seedvc_cache is not None and (
+        not seedvc_cache.exists() or not any(seedvc_cache.glob("*.pth"))
+    ):
+        logger.info("Scenema: downloading SeedVC checkpoints (~1.6 GB)...")
+        hf_cache = seedvc_cache / "hf_cache"
+        hf_cache.mkdir(parents=True, exist_ok=True)
+        os.environ["HF_HUB_CACHE"] = str(hf_cache)
+        hf_hub_download(
+            SEEDVC_REPO,
+            "DiT_seed_v2_uvit_whisper_small_wavenet_bigvgan_pruned.pth",
+            local_dir=str(seedvc_cache),
+            token=token,
+        )
+        hf_hub_download(
+            SEEDVC_REPO,
+            "config_dit_mel_seed_uvit_whisper_small_wavenet.yml",
+            local_dir=str(seedvc_cache),
+            token=token,
+        )
+        snapshot_download(BIGVGAN_REPO, local_dir=str(hf_cache / "bigvgan"))
+        snapshot_download(WHISPER_REPO, local_dir=str(hf_cache / "whisper-small"))
+
+
+def _resolve_voice_description(voice: str) -> tuple[str, str]:
+    """Return (voice_description, gender) for a `voice` parameter.
+
+    Preset names map to a baked description. Anything else is treated as a
+    free-form Scenema voice description and used verbatim.
+    """
+    preset = SCENEMA_VOICE_PRESETS.get(voice)
+    if preset is not None:
+        return preset["description"], preset["gender"]
+    return voice, DEFAULT_GENDER
+
+
+def _wrap_as_speak(text: str, description: str, gender: str) -> str:
+    """Wrap plain text in a <speak> envelope. Pass through XML unchanged."""
+    stripped = text.lstrip()
+    if stripped.startswith("<speak"):
+        return text
+    safe_desc = escape(description, {'"': "&quot;"})
+    safe_gender = escape(gender, {'"': "&quot;"})
+    body = escape(text)
+    return f'<speak voice="{safe_desc}" gender="{safe_gender}">{body}</speak>'
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    global _processor, _ProcessJob
+
+    _download_models()
+
+    # Lazy imports — these pull in torch / bitsandbytes / Gemma weights.
+    from audio_core.processor import AudioProcessor  # type: ignore[import-not-found]
+    from common.handlers.base import ProcessJob  # type: ignore[import-not-found]
+
+    _ProcessJob = ProcessJob
+    _processor = AudioProcessor()
+    _processor.startup()
+    logger.info("Scenema: AudioProcessor ready")
+
+    try:
+        yield
+    finally:
+        try:
+            _processor.shutdown()
+        except Exception:
+            logger.exception("Scenema: shutdown failed")
+
+
+app = FastAPI(title="Scenema Audio OpenAI Compatible TTS", lifespan=lifespan)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[],
+    allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
+    allow_credentials=False,
+    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_headers=["*"],
+    expose_headers=["x-openai-model", "x-openai-voice"],
+)
+
+
+class AudioSpeechRequest(BaseModel):
+    model: str = OPENAI_MODEL_ID
+    input: str
+    voice: str | None = None
+    response_format: str = "wav"
+    speed: float = 1.0
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, exc: Exception):
+    logger.exception("Unhandled exception while serving request")
+    return JSONResponse(
+        status_code=500,
+        content={"error": type(exc).__name__, "detail": str(exc)},
+    )
+
+
+@app.get("/")
+def root():
+    return {
+        "ok": True,
+        "engine": "Scenema",
+        "model": OPENAI_MODEL_ID,
+        "default_voice": DEFAULT_VOICE,
+        "presets": sorted(SCENEMA_VOICE_PRESETS.keys()),
+        "clone_available": bool(PROMPT_WAV),
+    }
+
+
+@app.get("/v1/models")
+def list_models():
+    return {
+        "object": "list",
+        "data": [{"id": OPENAI_MODEL_ID, "object": "model", "owned_by": "scenema-ai"}],
+    }
+
+
+@app.get("/v1/voices")
+def list_voices():
+    voices: list[dict] = []
+    for name, preset in SCENEMA_VOICE_PRESETS.items():
+        voices.append(
+            {
+                "id": name,
+                "object": "voice",
+                "gender": preset["gender"],
+                "description": preset["description"],
+            }
+        )
+    if PROMPT_WAV:
+        voices.append({"id": "clone", "object": "voice", "ref": PROMPT_WAV})
+    return {"object": "list", "data": voices}
+
+
+@app.get("/scenema-prompt-wav")
+def serve_prompt_wav():
+    """Serve the configured prompt wav so AudioProcessor can fetch it via httpx.
+
+    AudioProcessor downloads `reference_voice_url` over HTTP — file:// won't
+    work. We host the local prompt wav here and pass our own URL through.
+    """
+    if not PROMPT_WAV or not Path(PROMPT_WAV).exists():
+        raise HTTPException(status_code=404, detail="No prompt wav configured.")
+    return FileResponse(PROMPT_WAV, media_type="audio/wav")
+
+
+@app.post("/v1/audio/speech")
+async def audio_speech(payload: AudioSpeechRequest):
+    if payload.response_format.lower() != "wav":
+        raise HTTPException(status_code=400, detail="This wrapper currently supports only wav.")
+    if _processor is None or _ProcessJob is None:
+        raise HTTPException(status_code=503, detail="Scenema processor not ready yet.")
+
+    voice = payload.voice or DEFAULT_VOICE
+
+    reference_voice_url: str | None = None
+    if voice == "clone":
+        if not PROMPT_WAV:
+            raise HTTPException(
+                status_code=400,
+                detail="voice='clone' requires --scenema-prompt-wav at startup.",
+            )
+        # Serve the wav off our own port so AudioProcessor can httpx.get it.
+        reference_voice_url = f"http://127.0.0.1:{APP_PORT}/scenema-prompt-wav"
+        description, gender = _resolve_voice_description(DEFAULT_VOICE)
+    else:
+        description, gender = _resolve_voice_description(voice)
+
+    prompt_xml = _wrap_as_speak(payload.input, description, gender)
+
+    job = _ProcessJob(
+        job_id=str(uuid.uuid4()),
+        input={
+            "prompt": prompt_xml,
+            "mode": "generate",
+            "reference_voice_url": reference_voice_url,
+            "background_sfx": BACKGROUND_SFX,
+            "validate": VALIDATE,
+            "seed": SEED,
+            "pace": PACE,
+            "min_match_ratio": MIN_MATCH_RATIO,
+            "skip_vc": SKIP_VC,
+            "vc_steps": VC_STEPS,
+            "vc_cfg_rate": VC_CFG_RATE,
+        },
+    )
+
+    result = await _processor.process(job)
+
+    if not result.success or result.output is None or not result.output.data:
+        detail = result.error or (
+            result.output.error if result.output else "generation failed"
+        )
+        raise HTTPException(status_code=500, detail=detail)
+
+    audio_bytes = result.output.data
+    return Response(
+        content=audio_bytes,
+        media_type="audio/wav",
+        headers={
+            "Content-Length": str(len(audio_bytes)),
+            "x-openai-model": payload.model,
+            "x-openai-voice": voice,
+        },
+    )

--- a/src/config.py
+++ b/src/config.py
@@ -188,6 +188,18 @@ class Settings:
     dramabox_seed: int = 42
     dramabox_compile: bool = False
     dramabox_bnb_4bit: bool = True
+    scenema_default_voice: str = "default"
+    scenema_default_gender: str = "male"
+    scenema_prompt_wav: str = ""
+    scenema_gemma_quantize: str = "nf4"
+    scenema_seed: int = -1
+    scenema_pace: float = 1.5
+    scenema_validate: bool = True
+    scenema_min_match_ratio: float = 0.90
+    scenema_skip_vc: bool = False
+    scenema_vc_steps: int = 25
+    scenema_vc_cfg_rate: float = 0.5
+    scenema_background_sfx: bool = False
     root_dir: Path = Path("/content/openai-compatible-local-tts")
     repo_dir: Path = field(default_factory=default_repo_dir)
     app_port: int = 8000

--- a/src/installers/__init__.py
+++ b/src/installers/__init__.py
@@ -24,6 +24,7 @@ from .piper import install as install_piper
 from .piper_plus import install as install_piper_plus
 from .pocket_tts import install as install_pocket_tts
 from .sarashina_tts import install as install_sarashina_tts
+from .scenema import install as install_scenema
 from .spark_tts import install as install_spark_tts
 from .style_bert import install as install_style_bert
 from .styletts2 import install as install_styletts2
@@ -65,6 +66,7 @@ INSTALLERS = {
     "Pocket-TTS": install_pocket_tts,
     "Qwen3-TTS": install_qwen3_tts,
     "Sarashina-TTS": install_sarashina_tts,
+    "Scenema": install_scenema,
     "Spark-TTS": install_spark_tts,
     "TinyTTS": install_tiny_tts,
     "VibeVoice": install_vibevoice,

--- a/src/installers/scenema.py
+++ b/src/installers/scenema.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from src.config import Settings
+from src.runtime import ensure_git_clone, ensure_venv, popen, uv_pip_install, write_text
+
+
+SCENEMA_REPO_URL = "https://github.com/ScenemaAI/scenema-audio.git"
+SEEDVC_REPO_URL = "https://github.com/Plachtaa/seed-vc.git"
+MELBAND_NODE_REPO_URL = "https://github.com/kijai/ComfyUI-MelBandRoFormer.git"
+
+# Pinned in upstream Dockerfile to keep ltx-core / ltx-pipelines compatible
+# with the AudioEngine API Scenema imports.
+LTX2_PIN = "41d924371612b692c0fd1e4d9d94c3dfb3c02cb3"
+
+
+def install(settings: Settings) -> dict:
+    engine_dir = settings.engines_dir / "scenema"
+    engine_dir.mkdir(parents=True, exist_ok=True)
+
+    scenema_dir = engine_dir / "scenema-audio"
+    seedvc_dir = engine_dir / "seed-vc"
+    melband_dir = engine_dir / "melband_roformer_node"
+    models_dir = engine_dir / "models"
+    models_dir.mkdir(parents=True, exist_ok=True)
+
+    ensure_git_clone(SCENEMA_REPO_URL, scenema_dir)
+    ensure_git_clone(SEEDVC_REPO_URL, seedvc_dir)
+    ensure_git_clone(MELBAND_NODE_REPO_URL, melband_dir)
+
+    python_bin = ensure_venv(engine_dir)
+
+    # 1) Torch (cu128 wheels, matches scenema-audio Dockerfile pin).
+    uv_pip_install(
+        python_bin,
+        [
+            "--index-url",
+            "https://download.pytorch.org/whl/cu128",
+            "torch==2.7.1",
+            "torchaudio==2.7.1",
+        ],
+    )
+
+    # 2) Core ML deps + LTX-2 packages (pinned subdirectory installs).
+    uv_pip_install(
+        python_bin,
+        [
+            "numpy==2.2.6",
+            "transformers==4.57.6",
+            "accelerate==1.13.0",
+            "safetensors==0.7.0",
+            "sentencepiece==0.2.1",
+            f"ltx-core @ git+https://github.com/Lightricks/LTX-2.git@{LTX2_PIN}#subdirectory=packages/ltx-core",
+            f"ltx-pipelines @ git+https://github.com/Lightricks/LTX-2.git@{LTX2_PIN}#subdirectory=packages/ltx-pipelines",
+        ],
+    )
+
+    # 3) SeedVC / MelBandRoFormer architecture deps.
+    uv_pip_install(
+        python_bin,
+        [
+            "scipy==1.13.1",
+            "librosa==0.10.2",
+            "huggingface-hub==0.36.2",
+            "munch==4.0.0",
+            "einops==0.8.0",
+            "descript-audio-codec==1.0.0",
+            "pydub==0.25.1",
+            "soundfile==0.12.1",
+            "hydra-core==1.3.2",
+            "pyyaml==6.0.3",
+            "python-dotenv==1.2.2",
+            "diffusers==0.37.1",
+            "onnxruntime==1.25.0",
+            "funasr==1.3.1",
+            "rotary-embedding-torch==0.8.9",
+            "beartype==0.22.9",
+        ],
+    )
+
+    # 4) Server-side deps + Kokoro phoneme chunker + faster-whisper validator.
+    uv_pip_install(
+        python_bin,
+        [
+            "fastapi==0.136.1",
+            "uvicorn[standard]==0.46.0",
+            "httpx==0.28.1",
+            "psutil==7.2.2",
+            "bitsandbytes==0.49.2",
+            "kokoro==0.9.4",
+            "faster-whisper==1.2.1",
+            "ctranslate2==4.7.1",
+        ],
+    )
+
+    # 5) MelBandRoFormer small fp16 weight (~436MB). Bake here so the
+    #    server's lifespan doesn't have to re-download on every cold start.
+    melband_weight = models_dir / "MelBandRoformer_fp16.safetensors"
+    if not melband_weight.exists():
+        from src.runtime import run
+
+        run(
+            [
+                "wget",
+                "-q",
+                "-O",
+                str(melband_weight),
+                "https://huggingface.co/Kijai/MelBandRoFormer_comfy/resolve/main/MelBandRoformer_fp16.safetensors",
+            ]
+        )
+
+    write_text(engine_dir / "app.py", settings.read_repo_text("src/apps/scenema_app.py"))
+
+    env = {
+        **os.environ,
+        "PYTHONUNBUFFERED": "1",
+        "OPENAI_MODEL_ID": settings.openai_model_id or "scenema",
+        "SCENEMA_REPO_DIR": str(scenema_dir),
+        "SEEDVC_PATH": str(seedvc_dir),
+        "MELBAND_NODE_PATH": str(melband_dir),
+        "MELBAND_MODEL_PATH": str(melband_weight),
+        "MODEL_DIR": str(models_dir),
+        "HF_HUB_CACHE": str(models_dir / "hf_cache"),
+        # Default 24GB profile (INT8 audio transformer + NF4 Gemma) — fits
+        # comfortably on Colab A100 40GB.
+        "AUDIO_CKPT": str(models_dir / "scenema-audio-transformer-int8.safetensors"),
+        "VAE_ENCODER_CKPT": str(models_dir / "scenema-audio-vae-encoder.safetensors"),
+        "PIPELINE_CKPT": str(models_dir / "scenema-audio-pipeline.safetensors"),
+        "GEMMA_ROOT": str(models_dir / "gemma-3-12b-it"),
+        "GEMMA_QUANTIZE": settings.scenema_gemma_quantize,
+        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
+        "SCENEMA_DEFAULT_VOICE": settings.scenema_default_voice,
+        "SCENEMA_PROMPT_WAV": settings.scenema_prompt_wav,
+        "SCENEMA_DEFAULT_GENDER": settings.scenema_default_gender,
+        "SCENEMA_SEED": str(settings.scenema_seed),
+        "SCENEMA_PACE": str(settings.scenema_pace),
+        "SCENEMA_VALIDATE": "1" if settings.scenema_validate else "0",
+        "SCENEMA_MIN_MATCH_RATIO": str(settings.scenema_min_match_ratio),
+        "SCENEMA_SKIP_VC": "1" if settings.scenema_skip_vc else "0",
+        "SCENEMA_VC_STEPS": str(settings.scenema_vc_steps),
+        "SCENEMA_VC_CFG_RATE": str(settings.scenema_vc_cfg_rate),
+        "SCENEMA_BACKGROUND_SFX": "1" if settings.scenema_background_sfx else "0",
+        "SCENEMA_APP_PORT": str(settings.app_port),
+    }
+    hf_token = os.environ.get("HF_TOKEN", "")
+    if hf_token:
+        env["HF_TOKEN"] = hf_token
+
+    proc = popen(
+        [
+            str(engine_dir / ".venv" / "bin" / "uvicorn"),
+            "app:app",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            str(settings.app_port),
+            "--log-level",
+            "info",
+        ],
+        cwd=str(engine_dir),
+        env=env,
+        log_path=settings.log_dir / "scenema-uvicorn.log",
+    )
+    return {
+        "proc": proc,
+        "app_dir": engine_dir,
+        "log_path": settings.log_dir / "scenema-uvicorn.log",
+    }

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -72,6 +72,8 @@ def resolve_selected_voice(settings: Settings) -> str:
         return settings.supertonic_default_voice
     if settings.engine == "DramaBox":
         return settings.dramabox_default_voice
+    if settings.engine == "Scenema":
+        return settings.scenema_default_voice
     return ""
 
 
@@ -411,6 +413,29 @@ def print_engine_voice_hints(settings: Settings):
         print("生成音声には Resemble Perth による不可聴ウォーターマークが常時付与されます（除去不可）。")
         print("ライセンス警告: コードと重みは **LTX-2 Community License Agreement**（Lightricks）。")
         print("                年商 $10M+ の組織は商用ライセンス必須。非競合条項・配布時の同ライセンス継承条項あり。")
+    elif settings.engine == "Scenema":
+        print("Scenema Audio は Scenema AI の表現力豊か / 演技指向 TTS です（LTX-2.3 派生 + Gemma 3 12B、英語中心、多言語可）。")
+        print(f"デフォルト voice: {settings.scenema_default_voice} / gender: {settings.scenema_default_gender}")
+        print(f"seed: {settings.scenema_seed} (-1=ランダム) / pace: {settings.scenema_pace} / validate: {settings.scenema_validate}")
+        print(f"skip_vc: {settings.scenema_skip_vc} / vc_steps: {settings.scenema_vc_steps} / vc_cfg_rate: {settings.scenema_vc_cfg_rate}")
+        print(f"background_sfx: {settings.scenema_background_sfx} / Gemma quantize: {settings.scenema_gemma_quantize}")
+        print("voice 候補: default, warm_male, smoky_female, child_girl, elderly_male, elderly_female")
+        print("            voice に上記プリセット名以外を渡すと、その文字列を voice description として直接使用します。")
+        if settings.scenema_prompt_wav:
+            print(f"             clone（参照音声: {settings.scenema_prompt_wav}）")
+        else:
+            print("             clone は --scenema-prompt-wav を指定すると有効になります（10〜20秒の参照音声推奨）")
+        print("入力テキストはそのまま <speak> でラップされ Scenema に渡されます。")
+        print("上級者は input に直接 <speak voice=\"...\" gender=\"...\"><action>...</action>... </speak> の XML を書くと、")
+        print("pass-through され action / sound タグなどの演技指示がそのまま効きます。")
+        print("対応言語: 英語中心。Scenema は主要世界言語にも対応（モデルカード参照）。")
+        print("注意: A100 GPU 必須（40GB VRAM）。初回起動時に約 38GB のチェックポイントをダウンロードします。")
+        print("      Gemma 3 12B IT は HF gated。https://huggingface.co/google/gemma-3-12b-it で同意し、")
+        print("      Colab Secrets で HF_TOKEN を設定してから起動してください。")
+        print("ライセンス: コードは MIT。Scenema Audio の重み（ScenemaAI/scenema-audio）は LTX-2.3 から派生のため、")
+        print("            **LTX-2 Community License Agreement**（Lightricks）が適用されます（DramaBox と同じ）。")
+        print("            Gemma 3 12B IT は Gemma Terms of Use（Google）。")
+        print("            年商 $10M+ の組織は LTX-2 商用ライセンス、Gemma も商用利用は Gemma 規約遵守が必要です。")
     elif settings.engine == "Supertonic":
         print("Supertonic は Supertone Inc. の超軽量オンデバイス TTS です（ONNX、~99M params、CPU 動作可）。")
         print(f"モデル: {settings.supertonic_model}")


### PR DESCRIPTION
## Summary

- Adds **Scenema Audio** ([ScenemaAI/scenema-audio](https://github.com/ScenemaAI/scenema-audio)) as a new TTS engine in the standard installer / app / launcher layout.
- Exposes Scenema's structured `<speak>` performance XML through OpenAI's flat `/v1/audio/speech` API by auto-wrapping plain `input` with a voice-description preset, while passing through XML unchanged when the caller writes one — so OpenAI SDK clients keep working and advanced users can still drive `<action>` / `<sound>` emotion control.
- Marked **Not verified on Colab** in both READMEs: the upstream text encoder is `google/gemma-3-12b-it` (HF-gated), so running the engine requires accepting the Gemma Terms of Use and configuring `HF_TOKEN` via Colab Secrets — which is outside this repo's default verification workflow. The READMEs include a 3-step user-side setup runbook (license acceptance → token creation → Colab Secrets) so anyone with `HF_TOKEN` can run it themselves.

### Licensing notes

- Code: MIT (`ScenemaAI/scenema-audio`).
- Audio transformer weights are derived from Lightricks LTX-2.3, so the **LTX-2 Community License Agreement** flows through — same restrictive license as DramaBox (non-compete, $10 M revenue threshold for free commercial use, propagation on redistribution, acceptable-use policy).
- Gemma 3 12B IT is bound by the **Gemma Terms of Use** (Google) and is HF-gated.

Both rows are recorded as separate entries in the README license tables.

### Voice mapping

| `voice` | Behavior |
|---|---|
| `default` / `warm_male` / `smoky_female` / `child_girl` / `elderly_male` / `elderly_female` | Baked free-form voice-description preset, auto-wrapped as `<speak voice="…" gender="…">{input}</speak>`. |
| `clone` | Zero-shot voice cloning. Wrapper hosts the configured prompt wav at `GET /scenema-prompt-wav` and passes that URL as Scenema's `reference_voice_url` (Scenema's `_download_reference` uses `httpx.get`, so `file://` is not viable). Requires `--scenema-prompt-wav`. |
| any other string | Used verbatim as a Scenema voice description (e.g. `"Male, mid 60s. Deep baritone with gravel."`). |
| `input` starting with `<speak` | Forwarded unchanged. `<action>` / `<sound>` work normally. |

### Hardware

- **Colab A100 (40 GB) required.** First run downloads ~38 GB (audio transformer ~5 GB + pipeline ~7 GB + Gemma 3 12B ~24 GB + SeedVC ~1.6 GB + BigVGAN v2 + Whisper Small).
- INT8 audio transformer + NF4 Gemma profile (~13 GB resident VRAM).
- LTX-2 packages are pinned to the same commit (`41d92437`) as Scenema's upstream Dockerfile to keep `AudioEngine` import compatibility.

## Test plan

- [ ] User with `HF_TOKEN` configured runs the Colab cell with `REPO_REF=feat/add-scenema-audio`, `ENGINE=Scenema` on an A100 runtime.
- [ ] Confirm trycloudflare public URL appears and `GET /` / `/v1/models` / `/v1/voices` return 200.
- [ ] `POST /v1/audio/speech` with plain `input` and `voice="default"` returns a valid WAV.
- [ ] `POST /v1/audio/speech` with `input` starting with `<speak voice="..." gender="..."><action>...</action>...</speak>` returns a valid WAV exercising the action tag.
- [ ] (Optional) `POST /v1/audio/speech` with `voice="clone"` and `--scenema-prompt-wav` configured produces a cloned-voice WAV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)