### PR TITLE
Add Irodori-TTS-Lite (int4-quantized Irodori-TTS) as a new engine

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -12,6 +12,7 @@ Google Colab 上で選択したローカル TTS を一時的に OpenAI 互換 `/
 |---|---|---|
 | Kokoro | 動作OK | 日本語 / 英語 / 中国語 他 |
 | Irodori-TTS | 動作OK | 日本語 |
+| Irodori-TTS-Lite | 動作OK（GPU 必須、VRAM ~1GB、int4 量子化） | 日本語 |
 | Piper | 動作OK | 英語（デフォルト）/ 多言語 |
 | Piper-Plus | 動作OK | 日本語 / 英語 / 中国語 他 6言語 |
 | Qwen3-TTS | 動作OK (GPU必須) | 日本語 / 英語 / 中国語 他 10言語 |
@@ -79,7 +80,7 @@ REPO_URL = "https://github.com/shinshin86/local-tts-on-google-colab.git"  #@para
 REPO_REF = "main"  #@param {type:"string"}
 WORKDIR = "/content/local-tts-on-google-colab"  #@param {type:"string"}
 
-ENGINE = "Kokoro"  #@param ["Bark", "ChatTTS", "Chatterbox", "CosyVoice2", "CSM-1B", "Dia", "DramaBox", "F5-TTS", "Fish-Speech", "GPT-SoVITS", "Higgs-Audio-v2", "Irodori-TTS", "Kokoro", "Kyutai-TTS", "MaskGCT", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "OpenVoice-V2", "Orpheus-TTS", "OuteTTS", "Piper", "Piper-Plus", "Pocket-TTS", "Qwen3-TTS", "Sarashina-TTS", "Scenema", "Spark-TTS", "Style-Bert-VITS2", "StyleTTS2", "Supertonic", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos"]
+ENGINE = "Kokoro"  #@param ["Bark", "ChatTTS", "Chatterbox", "CosyVoice2", "CSM-1B", "Dia", "DramaBox", "F5-TTS", "Fish-Speech", "GPT-SoVITS", "Higgs-Audio-v2", "Irodori-TTS", "Irodori-TTS-Lite", "Kokoro", "Kyutai-TTS", "MaskGCT", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "OpenVoice-V2", "Orpheus-TTS", "OuteTTS", "Piper", "Piper-Plus", "Pocket-TTS", "Qwen3-TTS", "Sarashina-TTS", "Scenema", "Spark-TTS", "Style-Bert-VITS2", "StyleTTS2", "Supertonic", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos"]
 EXPOSE_PUBLIC_URL = True  #@param {type:"boolean"}
 TEST_TEXT = "こんにちは。これは OpenAI 互換 TTS の動作確認です。"  #@param {type:"string"}
 TEST_SPEED = 1.0  #@param {type:"number"}
@@ -104,6 +105,16 @@ IRODORI_HF_CHECKPOINT = "Aratako/Irodori-TTS-500M-v3"  #@param ["Aratako/Irodori
 IRODORI_CODEC_REPO = "Aratako/Semantic-DACVAE-Japanese-32dim"  #@param {type:"string"}
 IRODORI_MODEL_PRECISION = "fp32"  #@param ["fp32", "bf16", "fp16"]
 IRODORI_CODEC_PRECISION = "fp32"  #@param ["fp32", "bf16", "fp16"]
+
+#@markdown ---
+#@markdown Irodori-TTS-Lite (int4-quantized Irodori-TTS, ~1GB VRAM, MIT)
+#@markdown - Default checkpoint is voice-design int4 (speaker baked in, seconds derived from text via pyopenjtalk).
+#@markdown - For the v3-derived int4 with built-in Duration Predictor, switch to
+#@markdown   "kizuna-intelligence/Irodori-TTS-500M-v3-int4" AND set IRODORI_LITE_CHECKPOINT_FILE="model.safetensors".
+IRODORI_LITE_HF_CHECKPOINT = "kizuna-intelligence/Irodori-TTS-Lite-int4"  #@param ["kizuna-intelligence/Irodori-TTS-Lite-int4", "kizuna-intelligence/Irodori-TTS-500M-v3-int4"]
+IRODORI_LITE_CHECKPOINT_FILE = "dit_int4.safetensors"  #@param ["dit_int4.safetensors", "model.safetensors"]
+IRODORI_LITE_CODEC_REPO = "Aratako/Semantic-DACVAE-Japanese-32dim"  #@param {type:"string"}
+IRODORI_LITE_CODEC_INT4 = False  #@param {type:"boolean"}
 
 #@markdown ---
 #@markdown Kokoro
@@ -437,6 +448,12 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         IRODORI_MODEL_PRECISION,
         "--irodori-codec-precision",
         IRODORI_CODEC_PRECISION,
+        "--irodori-lite-hf-checkpoint",
+        IRODORI_LITE_HF_CHECKPOINT,
+        "--irodori-lite-checkpoint-file",
+        IRODORI_LITE_CHECKPOINT_FILE,
+        "--irodori-lite-codec-repo",
+        IRODORI_LITE_CODEC_REPO,
         "--kokoro-default-voice",
         KOKORO_DEFAULT_VOICE,
         "--kokoro-default-lang-code",
@@ -708,6 +725,8 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         "--scenema-vc-cfg-rate",
         str(SCENEMA_VC_CFG_RATE),
     ]
+    if IRODORI_LITE_CODEC_INT4:
+        cmd.append("--irodori-lite-codec-int4")
     if SARASHINA_USE_VLLM:
         cmd.append("--sarashina-use-vllm")
     if BARK_USE_SMALL_MODELS:
@@ -796,6 +815,19 @@ V3 では上流の以下の変更にラッパー側で自動追従します:
 
 - **Duration Predictor**: V3 では `seconds=None` を渡し、入力テキストから出力長を自動推定させます（V2 / V1 は従来通り 30 秒固定）。
 - **SilentCipher ウォーターマーク統合**: V3 重みには [SilentCipher](https://github.com/sony/silentcipher) が同梱されており、上流の `InferenceRuntime` 内で常時初期化されます（`RuntimeKey` から `enable_watermark` 引数も削除されており、ユーザー側からの無効化スイッチは公開されていません）。SilentCipher の重みが読み込める限り、生成音声には常にウォーターマークが入ります。**ウォーターマークの除去は禁止**です（モデルリリースの一部として配布されています）。
+
+### Irodori-TTS-Lite
+
+[kizuna-intelligence/Irodori-TTS-Lite](https://github.com/kizuna-intelligence/Irodori-TTS-Lite) を使った Irodori-TTS の int4 量子化推論ランタイムです。`irodori_tts.inference_runtime.InferenceRuntime.from_key` をモンキーパッチして、4-bit safetensors を Triton の `FusedInt4Linear` カーネルで直接読み込めるようにします。エンドツーエンドのピーク VRAM は約 1 GB（fp32 パスの ~2 GB から削減）で、音質はほぼ劣化しません。
+
+利用可能な int4 チェックポイントは 2 種類:
+
+- **`kizuna-intelligence/Irodori-TTS-Lite-int4`**（デフォルト）: voice-design int4（話者は重みに焼き込み、Duration Predictor なし）。ラッパー側で `pyopenjtalk` の音素数から `seconds` を導出します。
+- **`kizuna-intelligence/Irodori-TTS-500M-v3-int4`**: v3 ベースの int4（Duration Predictor 付き）。利用するには `IRODORI_LITE_HF_CHECKPOINT=kizuna-intelligence/Irodori-TTS-500M-v3-int4` **かつ** `IRODORI_LITE_CHECKPOINT_FILE=model.safetensors` を指定してください。
+
+voice 切り替えは未対応（話者は重みに焼き込まれているため、Irodori-TTS 本体と同じ挙動）。DACVAE コーデックは `Aratako/Semantic-DACVAE-Japanese-32dim`（fp16）をデフォルトで使用します。`IRODORI_LITE_CODEC_INT4=1` を指定するとコーデックも int4 化され、デコード遅延が約 150 ms 増える代わりにピーク VRAM が約 500 MB 削減されます。
+
+GPU 必須: int4 パスは Triton カーネルを使用するため、Linux + CUDA（= Colab GPU ランタイム）が必要です。
 
 ### Piper
 
@@ -1227,6 +1259,7 @@ Scenema AI による zero-shot な表現力豊か / 演技指向 TTS です（[S
 |---|---|---|---|---|
 | Kokoro | Apache 2.0 | Apache 2.0 | OK | |
 | Irodori-TTS | MIT | MIT (v1 / v2 / v3) | OK | なりすまし・ディープフェイク生成を禁止する倫理規定あり。V3 は SilentCipher ウォーターマーク同梱（除去禁止） |
+| Irodori-TTS-Lite | MIT | MIT (`kizuna-intelligence/Irodori-TTS-Lite-int4`, `kizuna-intelligence/Irodori-TTS-500M-v3-int4`) | OK | Irodori-TTS 用の int4 量子化ランタイム。Triton カーネル使用のため Linux + CUDA 必須。`fused_int4_linear.py` は OneCompression（Fujitsu Ltd., MIT）からベンダリング |
 | Piper | GPL-3.0 | MIT | 要注意 | デフォルト音声 `en_US-lessac-medium` の学習データ（Blizzard 2013）は研究目的限定・商用利用不可 |
 | Piper-Plus | MIT | MIT | OK | |
 | Qwen3-TTS | Apache 2.0 | Apache 2.0 | OK | |
@@ -1282,6 +1315,8 @@ Scenema AI による zero-shot な表現力豊か / 演技指向 TTS です（[S
   https://developers.openai.com/api/reference/resources/audio/subresources/speech/methods/create
 - Irodori-TTS
   https://github.com/Aratako/Irodori-TTS
+- Irodori-TTS-Lite
+  https://github.com/kizuna-intelligence/Irodori-TTS-Lite
 - Kokoro
   https://github.com/hexgrad/kokoro
 - MeloTTS

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Supported engines:
 |---|---|---|
 | Kokoro | Works | Japanese / English / Chinese and more |
 | Irodori-TTS | Works | Japanese |
+| Irodori-TTS-Lite | Works (GPU required, ~1GB VRAM, int4-quantized) | Japanese |
 | Piper | Works | English (default) / multilingual |
 | Piper-Plus | Works | Japanese / English / Chinese and 6 languages |
 | Qwen3-TTS | Works (GPU required) | Japanese / English / Chinese and 10 languages |
@@ -79,7 +80,7 @@ REPO_URL = "https://github.com/shinshin86/local-tts-on-google-colab.git"  #@para
 REPO_REF = "main"  #@param {type:"string"}
 WORKDIR = "/content/local-tts-on-google-colab"  #@param {type:"string"}
 
-ENGINE = "Kokoro"  #@param ["Bark", "ChatTTS", "Chatterbox", "CosyVoice2", "CSM-1B", "Dia", "DramaBox", "F5-TTS", "Fish-Speech", "GPT-SoVITS", "Higgs-Audio-v2", "Irodori-TTS", "Kokoro", "Kyutai-TTS", "MaskGCT", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "OpenVoice-V2", "Orpheus-TTS", "OuteTTS", "Piper", "Piper-Plus", "Pocket-TTS", "Qwen3-TTS", "Sarashina-TTS", "Scenema", "Spark-TTS", "Style-Bert-VITS2", "StyleTTS2", "Supertonic", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos"]
+ENGINE = "Kokoro"  #@param ["Bark", "ChatTTS", "Chatterbox", "CosyVoice2", "CSM-1B", "Dia", "DramaBox", "F5-TTS", "Fish-Speech", "GPT-SoVITS", "Higgs-Audio-v2", "Irodori-TTS", "Irodori-TTS-Lite", "Kokoro", "Kyutai-TTS", "MaskGCT", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "OpenVoice-V2", "Orpheus-TTS", "OuteTTS", "Piper", "Piper-Plus", "Pocket-TTS", "Qwen3-TTS", "Sarashina-TTS", "Scenema", "Spark-TTS", "Style-Bert-VITS2", "StyleTTS2", "Supertonic", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos"]
 EXPOSE_PUBLIC_URL = True  #@param {type:"boolean"}
 TEST_TEXT = "こんにちは。これは OpenAI 互換 TTS の動作確認です。"  #@param {type:"string"}
 TEST_SPEED = 1.0  #@param {type:"number"}
@@ -104,6 +105,16 @@ IRODORI_HF_CHECKPOINT = "Aratako/Irodori-TTS-500M-v3"  #@param ["Aratako/Irodori
 IRODORI_CODEC_REPO = "Aratako/Semantic-DACVAE-Japanese-32dim"  #@param {type:"string"}
 IRODORI_MODEL_PRECISION = "fp32"  #@param ["fp32", "bf16", "fp16"]
 IRODORI_CODEC_PRECISION = "fp32"  #@param ["fp32", "bf16", "fp16"]
+
+#@markdown ---
+#@markdown Irodori-TTS-Lite (int4-quantized Irodori-TTS, ~1GB VRAM, MIT)
+#@markdown - Default checkpoint is voice-design int4 (speaker baked in, seconds derived from text via pyopenjtalk).
+#@markdown - For the v3-derived int4 with built-in Duration Predictor, switch to
+#@markdown   "kizuna-intelligence/Irodori-TTS-500M-v3-int4" AND set IRODORI_LITE_CHECKPOINT_FILE="model.safetensors".
+IRODORI_LITE_HF_CHECKPOINT = "kizuna-intelligence/Irodori-TTS-Lite-int4"  #@param ["kizuna-intelligence/Irodori-TTS-Lite-int4", "kizuna-intelligence/Irodori-TTS-500M-v3-int4"]
+IRODORI_LITE_CHECKPOINT_FILE = "dit_int4.safetensors"  #@param ["dit_int4.safetensors", "model.safetensors"]
+IRODORI_LITE_CODEC_REPO = "Aratako/Semantic-DACVAE-Japanese-32dim"  #@param {type:"string"}
+IRODORI_LITE_CODEC_INT4 = False  #@param {type:"boolean"}
 
 #@markdown ---
 #@markdown Kokoro
@@ -437,6 +448,12 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         IRODORI_MODEL_PRECISION,
         "--irodori-codec-precision",
         IRODORI_CODEC_PRECISION,
+        "--irodori-lite-hf-checkpoint",
+        IRODORI_LITE_HF_CHECKPOINT,
+        "--irodori-lite-checkpoint-file",
+        IRODORI_LITE_CHECKPOINT_FILE,
+        "--irodori-lite-codec-repo",
+        IRODORI_LITE_CODEC_REPO,
         "--kokoro-default-voice",
         KOKORO_DEFAULT_VOICE,
         "--kokoro-default-lang-code",
@@ -708,6 +725,8 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         "--scenema-vc-cfg-rate",
         str(SCENEMA_VC_CFG_RATE),
     ]
+    if IRODORI_LITE_CODEC_INT4:
+        cmd.append("--irodori-lite-codec-int4")
     if SARASHINA_USE_VLLM:
         cmd.append("--sarashina-use-vllm")
     if BARK_USE_SMALL_MODELS:
@@ -796,6 +815,19 @@ V3 adds two upstream changes that this wrapper handles automatically:
 
 - **Duration Predictor**: with V3 the wrapper passes `seconds=None`, letting the model estimate output length from the input text (V2 / V1 stay on the previous 30-second fixed slot).
 - **Integrated SilentCipher watermark**: V3 weights ship with [SilentCipher](https://github.com/sony/silentcipher) and upstream initializes it unconditionally inside `InferenceRuntime` — there is no public kill-switch and `RuntimeKey` no longer accepts an `enable_watermark` flag. Generated audio is watermarked whenever the SilentCipher weights are importable. **Do not strip the watermark**; it is part of the model release.
+
+### Irodori-TTS-Lite
+
+An int4-quantized inference runtime for Irodori-TTS using [kizuna-intelligence/Irodori-TTS-Lite](https://github.com/kizuna-intelligence/Irodori-TTS-Lite). The runtime monkey-patches `irodori_tts.inference_runtime.InferenceRuntime.from_key` so the standard Irodori-TTS pipeline can load 4-bit safetensors with a Triton `FusedInt4Linear` kernel. End-to-end peak VRAM is ~1 GB (vs. ~2 GB for the fp32 path) at essentially unchanged audio quality.
+
+Two checkpoint repositories are available:
+
+- **`kizuna-intelligence/Irodori-TTS-Lite-int4`** (default): voice-design int4 (speaker baked in, no Duration Predictor). The wrapper derives `seconds` from phoneme count via `pyopenjtalk`.
+- **`kizuna-intelligence/Irodori-TTS-500M-v3-int4`** (v3 int4): includes the Duration Predictor. Switch by setting `IRODORI_LITE_HF_CHECKPOINT=kizuna-intelligence/Irodori-TTS-500M-v3-int4` **and** `IRODORI_LITE_CHECKPOINT_FILE=model.safetensors`.
+
+Voice switching is not exposed (same as Irodori-TTS — the speaker is baked into the checkpoint). The DACVAE codec defaults to `Aratako/Semantic-DACVAE-Japanese-32dim` (fp16). Set `IRODORI_LITE_CODEC_INT4=1` to additionally int4-quantize the codec, which trades ~150 ms of decode latency for ~500 MB less peak VRAM.
+
+GPU is required: the int4 path relies on the Triton kernel, so this engine must run on Linux + CUDA (i.e. Colab GPU runtime).
 
 ### Piper
 
@@ -1227,6 +1259,7 @@ The license for each engine is as follows. When using them, always check each pr
 |---|---|---|---|---|
 | Kokoro | Apache 2.0 | Apache 2.0 | OK | |
 | Irodori-TTS | MIT | MIT (v1 / v2 / v3) | OK | Ethical policy prohibits impersonation / deepfake generation. V3 ships with SilentCipher watermarking — do not strip |
+| Irodori-TTS-Lite | MIT | MIT (`kizuna-intelligence/Irodori-TTS-Lite-int4`, `kizuna-intelligence/Irodori-TTS-500M-v3-int4`) | OK | int4-quantized runtime over Irodori-TTS. Triton kernel requires Linux + CUDA. `fused_int4_linear.py` vendored from OneCompression (Fujitsu Ltd., MIT) |
 | Piper | GPL-3.0 | MIT | Caution | The default voice `en_US-lessac-medium` is trained on the Blizzard 2013 dataset (Lessac Technologies), which is research-only and prohibits commercial use |
 | Piper-Plus | MIT | MIT | OK | |
 | Qwen3-TTS | Apache 2.0 | Apache 2.0 | OK | |
@@ -1282,6 +1315,8 @@ This repository itself is intended for short-term operational verification and t
   https://developers.openai.com/api/reference/resources/audio/subresources/speech/methods/create
 - Irodori-TTS
   https://github.com/Aratako/Irodori-TTS
+- Irodori-TTS-Lite
+  https://github.com/kizuna-intelligence/Irodori-TTS-Lite
 - Kokoro
   https://github.com/hexgrad/kokoro
 - MeloTTS

--- a/colab/bootstrap.py
+++ b/colab/bootstrap.py
@@ -34,6 +34,14 @@ def parse_args():
     parser.add_argument("--irodori-codec-repo", default="Aratako/Semantic-DACVAE-Japanese-32dim")
     parser.add_argument("--irodori-model-precision", default="fp32")
     parser.add_argument("--irodori-codec-precision", default="fp32")
+    parser.add_argument(
+        "--irodori-lite-hf-checkpoint", default="kizuna-intelligence/Irodori-TTS-Lite-int4"
+    )
+    parser.add_argument("--irodori-lite-checkpoint-file", default="dit_int4.safetensors")
+    parser.add_argument(
+        "--irodori-lite-codec-repo", default="Aratako/Semantic-DACVAE-Japanese-32dim"
+    )
+    parser.add_argument("--irodori-lite-codec-int4", action="store_true")
     parser.add_argument("--kokoro-default-voice", default="jf_alpha")
     parser.add_argument("--kokoro-default-lang-code", default="j")
     parser.add_argument("--kyutai-hf-repo", default="kyutai/tts-1.6b-en_fr")
@@ -203,6 +211,10 @@ def main():
         irodori_codec_repo=args.irodori_codec_repo,
         irodori_model_precision=args.irodori_model_precision,
         irodori_codec_precision=args.irodori_codec_precision,
+        irodori_lite_hf_checkpoint=args.irodori_lite_hf_checkpoint,
+        irodori_lite_checkpoint_file=args.irodori_lite_checkpoint_file,
+        irodori_lite_codec_repo=args.irodori_lite_codec_repo,
+        irodori_lite_codec_int4=args.irodori_lite_codec_int4,
         kokoro_default_voice=args.kokoro_default_voice,
         kokoro_default_lang_code=args.kokoro_default_lang_code,
         kyutai_hf_repo=args.kyutai_hf_repo,

--- a/multi_tts_openai_colab.py
+++ b/multi_tts_openai_colab.py
@@ -11,7 +11,7 @@ REPO_URL = "https://github.com/shinshin86/local-tts-on-google-colab.git"  #@para
 REPO_REF = "main"  #@param {type:"string"}
 WORKDIR = "/content/local-tts-on-google-colab"  #@param {type:"string"}
 
-ENGINE = "Kokoro"  #@param ["Bark", "ChatTTS", "Chatterbox", "CosyVoice2", "CSM-1B", "Dia", "DramaBox", "F5-TTS", "Fish-Speech", "GPT-SoVITS", "Higgs-Audio-v2", "Irodori-TTS", "Kokoro", "Kyutai-TTS", "MaskGCT", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "OpenVoice-V2", "Orpheus-TTS", "OuteTTS", "Piper", "Piper-Plus", "Pocket-TTS", "Qwen3-TTS", "Sarashina-TTS", "Scenema", "Spark-TTS", "Style-Bert-VITS2", "StyleTTS2", "Supertonic", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos"]
+ENGINE = "Kokoro"  #@param ["Bark", "ChatTTS", "Chatterbox", "CosyVoice2", "CSM-1B", "Dia", "DramaBox", "F5-TTS", "Fish-Speech", "GPT-SoVITS", "Higgs-Audio-v2", "Irodori-TTS", "Irodori-TTS-Lite", "Kokoro", "Kyutai-TTS", "MaskGCT", "MeloTTS", "MOSS-TTS-Nano", "NeuTTS", "OpenVoice-V2", "Orpheus-TTS", "OuteTTS", "Piper", "Piper-Plus", "Pocket-TTS", "Qwen3-TTS", "Sarashina-TTS", "Scenema", "Spark-TTS", "Style-Bert-VITS2", "StyleTTS2", "Supertonic", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos"]
 EXPOSE_PUBLIC_URL = True  #@param {type:"boolean"}
 TEST_TEXT = "こんにちは。これは OpenAI 互換 TTS の動作確認です。"  #@param {type:"string"}
 TEST_SPEED = 1.0  #@param {type:"number"}
@@ -36,6 +36,16 @@ IRODORI_HF_CHECKPOINT = "Aratako/Irodori-TTS-500M-v3"  #@param ["Aratako/Irodori
 IRODORI_CODEC_REPO = "Aratako/Semantic-DACVAE-Japanese-32dim"  #@param {type:"string"}
 IRODORI_MODEL_PRECISION = "fp32"  #@param ["fp32", "bf16", "fp16"]
 IRODORI_CODEC_PRECISION = "fp32"  #@param ["fp32", "bf16", "fp16"]
+
+#@markdown ---
+#@markdown Irodori-TTS-Lite (int4-quantized Irodori-TTS, ~1GB VRAM, MIT)
+#@markdown - Default checkpoint is voice-design int4 (speaker baked in, seconds derived from text via pyopenjtalk).
+#@markdown - For the v3-derived int4 with built-in Duration Predictor, switch to
+#@markdown   "kizuna-intelligence/Irodori-TTS-500M-v3-int4" AND set IRODORI_LITE_CHECKPOINT_FILE="model.safetensors".
+IRODORI_LITE_HF_CHECKPOINT = "kizuna-intelligence/Irodori-TTS-Lite-int4"  #@param ["kizuna-intelligence/Irodori-TTS-Lite-int4", "kizuna-intelligence/Irodori-TTS-500M-v3-int4"]
+IRODORI_LITE_CHECKPOINT_FILE = "dit_int4.safetensors"  #@param ["dit_int4.safetensors", "model.safetensors"]
+IRODORI_LITE_CODEC_REPO = "Aratako/Semantic-DACVAE-Japanese-32dim"  #@param {type:"string"}
+IRODORI_LITE_CODEC_INT4 = False  #@param {type:"boolean"}
 
 #@markdown ---
 #@markdown Kokoro
@@ -369,6 +379,12 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         IRODORI_MODEL_PRECISION,
         "--irodori-codec-precision",
         IRODORI_CODEC_PRECISION,
+        "--irodori-lite-hf-checkpoint",
+        IRODORI_LITE_HF_CHECKPOINT,
+        "--irodori-lite-checkpoint-file",
+        IRODORI_LITE_CHECKPOINT_FILE,
+        "--irodori-lite-codec-repo",
+        IRODORI_LITE_CODEC_REPO,
         "--kokoro-default-voice",
         KOKORO_DEFAULT_VOICE,
         "--kokoro-default-lang-code",
@@ -640,6 +656,8 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         "--scenema-vc-cfg-rate",
         str(SCENEMA_VC_CFG_RATE),
     ]
+    if IRODORI_LITE_CODEC_INT4:
+        cmd.append("--irodori-lite-codec-int4")
     if SARASHINA_USE_VLLM:
         cmd.append("--sarashina-use-vllm")
     if BARK_USE_SMALL_MODELS:

--- a/src/apps/irodori_lite_app.py
+++ b/src/apps/irodori_lite_app.py
@@ -96,9 +96,9 @@ def get_runtime():
                 checkpoint=checkpoint_path,
                 model_device=MODEL_DEVICE,
                 codec_repo=CODEC_REPO,
-                model_precision="fp16",
+                model_precision="fp32",
                 codec_device=CODEC_DEVICE,
-                codec_precision="fp16",
+                codec_precision="fp32",
                 compile_model=False,
                 compile_dynamic=False,
             )

--- a/src/apps/irodori_lite_app.py
+++ b/src/apps/irodori_lite_app.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+import irodori_tts_lite
+from irodori_tts.inference_runtime import (
+    InferenceRuntime,
+    RuntimeKey,
+    SamplingRequest,
+    default_runtime_device,
+    resolve_cfg_scales,
+    save_wav,
+)
+
+logger = logging.getLogger("uvicorn.error")
+
+# Default: kizuna-intelligence/Irodori-TTS-Lite-int4 (voice-design, no Duration Predictor)
+# Alternate: kizuna-intelligence/Irodori-TTS-500M-v3-int4 (set IRODORI_LITE_CHECKPOINT_FILE=model.safetensors)
+HF_CHECKPOINT = os.environ.get(
+    "IRODORI_LITE_HF_CHECKPOINT", "kizuna-intelligence/Irodori-TTS-Lite-int4"
+)
+CHECKPOINT_FILE = os.environ.get("IRODORI_LITE_CHECKPOINT_FILE", "dit_int4.safetensors")
+MODEL_DEVICE = os.environ.get("IRODORI_LITE_MODEL_DEVICE", default_runtime_device())
+CODEC_DEVICE = os.environ.get("IRODORI_LITE_CODEC_DEVICE", default_runtime_device())
+CODEC_REPO = os.environ.get(
+    "IRODORI_LITE_CODEC_REPO", "Aratako/Semantic-DACVAE-Japanese-32dim"
+)
+CODEC_INT4 = os.environ.get("IRODORI_LITE_CODEC_INT4", "0") == "1"
+OPENAI_MODEL_ID = os.environ.get("OPENAI_MODEL_ID", HF_CHECKPOINT)
+
+# v3-int4 ships the Duration Predictor; the default voice-design int4 does not, so we
+# derive seconds from phoneme count via pyopenjtalk (mirrors the upstream example).
+IS_V3 = "v3" in HF_CHECKPOINT.lower()
+
+app = FastAPI(title="Irodori-TTS-Lite OpenAI Compatible TTS")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[],
+    allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
+    allow_credentials=False,
+    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_headers=["*"],
+    expose_headers=["x-openai-model", "x-openai-voice"],
+)
+
+
+class AudioSpeechRequest(BaseModel):
+    model: str = OPENAI_MODEL_ID
+    input: str
+    voice: str | None = None
+    response_format: str = "wav"
+    speed: float = 1.0
+
+
+_runtime = None
+_patched = False
+
+
+def estimate_seconds(text: str) -> float:
+    try:
+        import pyopenjtalk
+
+        phs = pyopenjtalk.g2p(text, kana=False).split()
+        return max(2.0, len(phs) / 11.0 + 0.6)
+    except Exception:
+        return max(2.0, len(text) / 6.0 + 0.6)
+
+
+def get_runtime():
+    global _runtime, _patched
+    if not _patched:
+        configure_kwargs = {"use_fused": True, "force_fp16": True}
+        if CODEC_INT4:
+            configure_kwargs["codec_int4"] = True
+        irodori_tts_lite.configure(**configure_kwargs)
+        irodori_tts_lite.patch()
+        _patched = True
+
+    if _runtime is None:
+        if "/" in HF_CHECKPOINT and not HF_CHECKPOINT.startswith("/"):
+            checkpoint_uri = f"hf://{HF_CHECKPOINT}/{CHECKPOINT_FILE}"
+        else:
+            checkpoint_uri = HF_CHECKPOINT
+        checkpoint_path = irodori_tts_lite.resolve_checkpoint(checkpoint_uri)
+        _runtime = InferenceRuntime.from_key(
+            RuntimeKey(
+                checkpoint=checkpoint_path,
+                model_device=MODEL_DEVICE,
+                codec_repo=CODEC_REPO,
+                model_precision="fp16",
+                codec_device=CODEC_DEVICE,
+                codec_precision="fp16",
+                compile_model=False,
+                compile_dynamic=False,
+            )
+        )
+    return _runtime
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, exc: Exception):
+    logger.exception("Unhandled exception while serving request")
+    return JSONResponse(
+        status_code=500,
+        content={"error": type(exc).__name__, "detail": str(exc)},
+    )
+
+
+@app.get("/")
+def root():
+    return {"ok": True, "engine": "Irodori-TTS-Lite", "model": OPENAI_MODEL_ID}
+
+
+@app.get("/v1/models")
+def list_models():
+    return {
+        "object": "list",
+        "data": [
+            {
+                "id": OPENAI_MODEL_ID,
+                "object": "model",
+                "owned_by": "local",
+            }
+        ],
+    }
+
+
+@app.get("/v1/voices")
+def list_voices():
+    return {"object": "list", "data": []}
+
+
+@app.post("/v1/audio/speech")
+async def audio_speech(payload: AudioSpeechRequest):
+    if payload.response_format.lower() != "wav":
+        raise HTTPException(status_code=400, detail="This wrapper currently supports only wav.")
+
+    runtime = get_runtime()
+    cfg_scale_text, _cfg_scale_caption, cfg_scale_speaker, _ = resolve_cfg_scales(
+        cfg_guidance_mode="independent",
+        cfg_scale_text=3.0,
+        cfg_scale_caption=3.0,
+        cfg_scale_speaker=5.0,
+        cfg_scale=None,
+    )
+
+    seconds = None if IS_V3 else estimate_seconds(payload.input)
+    result = runtime.synthesize(
+        SamplingRequest(
+            text=payload.input,
+            ref_wav=None,
+            ref_latent=None,
+            no_ref=True,
+            ref_normalize_db=None,
+            ref_ensure_max=False,
+            num_candidates=1,
+            decode_mode="sequential",
+            seconds=seconds,
+            max_ref_seconds=30.0,
+            max_text_len=None,
+            num_steps=40,
+            cfg_scale_text=cfg_scale_text,
+            cfg_scale_speaker=cfg_scale_speaker,
+            cfg_guidance_mode="independent",
+            cfg_scale=None,
+            cfg_min_t=0.5,
+            cfg_max_t=1.0,
+            truncation_factor=None,
+            rescale_k=None,
+            rescale_sigma=None,
+            context_kv_cache=True,
+            speaker_kv_scale=None,
+            speaker_kv_min_t=None,
+            speaker_kv_max_layers=None,
+            seed=None,
+            trim_tail=True,
+            tail_window_size=20,
+            tail_std_threshold=0.05,
+            tail_mean_threshold=0.1,
+        ),
+        log_fn=None,
+    )
+
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+        tmp_path = tmp.name
+
+    try:
+        save_wav(tmp_path, result.audio, result.sample_rate)
+        audio_bytes = Path(tmp_path).read_bytes()
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+
+    return Response(
+        content=audio_bytes,
+        media_type="audio/wav",
+        headers={
+            "Content-Length": str(len(audio_bytes)),
+            "x-openai-model": payload.model,
+            "x-openai-voice": payload.voice or "",
+        },
+    )

--- a/src/config.py
+++ b/src/config.py
@@ -55,6 +55,14 @@ class Settings:
     irodori_codec_repo: str = "Aratako/Semantic-DACVAE-Japanese-32dim"
     irodori_model_precision: str = "fp32"
     irodori_codec_precision: str = "fp32"
+    # Irodori-TTS-Lite: int4-quantized runtime that monkey-patches the upstream Irodori-TTS.
+    # Default: voice-design int4 (no Duration Predictor; seconds derived from text).
+    # Switch to "kizuna-intelligence/Irodori-TTS-500M-v3-int4" with checkpoint_file="model.safetensors"
+    # to use the v3 int4 (with Duration Predictor).
+    irodori_lite_hf_checkpoint: str = "kizuna-intelligence/Irodori-TTS-Lite-int4"
+    irodori_lite_checkpoint_file: str = "dit_int4.safetensors"
+    irodori_lite_codec_repo: str = "Aratako/Semantic-DACVAE-Japanese-32dim"
+    irodori_lite_codec_int4: bool = False
     kokoro_default_voice: str = "jf_alpha"
     kokoro_default_lang_code: str = "j"
     kyutai_hf_repo: str = "kyutai/tts-1.6b-en_fr"

--- a/src/installers/__init__.py
+++ b/src/installers/__init__.py
@@ -10,6 +10,7 @@ from .fish_speech import install as install_fish_speech
 from .gpt_sovits import install as install_gpt_sovits
 from .higgs_audio import install as install_higgs_audio
 from .irodori import install as install_irodori
+from .irodori_lite import install as install_irodori_lite
 from .qwen3_tts import install as install_qwen3_tts
 from .kokoro import install as install_kokoro
 from .kyutai_tts import install as install_kyutai_tts
@@ -49,6 +50,7 @@ INSTALLERS = {
     "GPT-SoVITS": install_gpt_sovits,
     "Higgs-Audio-v2": install_higgs_audio,
     "Irodori-TTS": install_irodori,
+    "Irodori-TTS-Lite": install_irodori_lite,
     "Kokoro": install_kokoro,
     "Kyutai-TTS": install_kyutai_tts,
     "MaskGCT": install_maskgct,

--- a/src/installers/irodori_lite.py
+++ b/src/installers/irodori_lite.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import os
+
+from src.config import Settings
+from src.runtime import ensure_git_clone, popen, run, uv_pip_install, write_text
+
+
+def install(settings: Settings) -> dict:
+    # Irodori-TTS-Lite is a monkey-patch over upstream irodori_tts.inference_runtime,
+    # so we still need the upstream Irodori-TTS repo for the InferenceRuntime / SamplingRequest
+    # surface; Lite's patch() rewires from_key to load int4 safetensors.
+    repo_dir = settings.engines_dir / "Irodori-TTS-Lite"
+    ensure_git_clone("https://github.com/Aratako/Irodori-TTS", repo_dir)
+    write_text(repo_dir / "app.py", settings.read_repo_text("src/apps/irodori_lite_app.py"))
+    run(["uv", "sync"], cwd=str(repo_dir))
+    python_bin = repo_dir / ".venv" / "bin" / "python"
+    uv_pip_install(
+        python_bin,
+        ["fastapi", "uvicorn", "huggingface_hub", "pyopenjtalk"],
+        cwd=str(repo_dir),
+    )
+    uv_pip_install(
+        python_bin,
+        ["git+https://github.com/facebookresearch/dacvae.git"],
+        cwd=str(repo_dir),
+    )
+    uv_pip_install(
+        python_bin,
+        ["git+https://github.com/kizuna-intelligence/Irodori-TTS-Lite.git"],
+        cwd=str(repo_dir),
+    )
+    env = {
+        **os.environ,
+        "PYTHONUNBUFFERED": "1",
+        "IRODORI_LITE_HF_CHECKPOINT": settings.irodori_lite_hf_checkpoint,
+        "IRODORI_LITE_CHECKPOINT_FILE": settings.irodori_lite_checkpoint_file,
+        "IRODORI_LITE_CODEC_REPO": settings.irodori_lite_codec_repo,
+        "IRODORI_LITE_CODEC_INT4": "1" if settings.irodori_lite_codec_int4 else "0",
+        "OPENAI_MODEL_ID": settings.openai_model_id or settings.irodori_lite_hf_checkpoint,
+    }
+    proc = popen(
+        [
+            str(repo_dir / ".venv" / "bin" / "uvicorn"),
+            "app:app",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            str(settings.app_port),
+            "--log-level",
+            "debug",
+            "--access-log",
+        ],
+        cwd=str(repo_dir),
+        env=env,
+        log_path=settings.log_dir / "irodori-lite-uvicorn.log",
+    )
+    return {
+        "proc": proc,
+        "app_dir": repo_dir,
+        "log_path": settings.log_dir / "irodori-lite-uvicorn.log",
+    }

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -448,6 +448,19 @@ def print_engine_voice_hints(settings: Settings):
         print("  id, it, lt, lv, nl, pl, pt, ro, ru, sk, sl, sv, tr, uk, vi, na")
         print("注意: GPU 不要（ONNX Runtime で CPU 動作）。Voice cloning は未対応（preset のみ）。")
         print("ライセンス: コードは MIT、重みは OpenRAIL-M（商用 OK、ディープフェイク等の use-based 制限あり）。")
+    elif settings.engine == "Irodori-TTS-Lite":
+        print("Irodori-TTS-Lite は Irodori-TTS の int4 量子化ランタイムです（~1GB VRAM、音質ほぼ無劣化、MIT）。")
+        print(f"モデル: {settings.irodori_lite_hf_checkpoint} / file: {settings.irodori_lite_checkpoint_file}")
+        print(f"コーデック: {settings.irodori_lite_codec_repo}")
+        print(f"codec int4: {'有効（VRAM さらに節約）' if settings.irodori_lite_codec_int4 else '無効（fp16 codec）'}")
+        print("voice パラメータは現在 'default'（voice-design に焼き込まれた話者）のみ対応です。")
+        if "v3" in settings.irodori_lite_hf_checkpoint.lower():
+            print("v3 int4: Duration Predictor を使用するため seconds は自動推定されます。")
+        else:
+            print("voice-design int4: Duration Predictor を持たないため pyopenjtalk の音素数から seconds を導出します。")
+        print("注意: GPU 推奨（VRAM ~1GB）。Triton カーネル使用のため Linux + CUDA 必須。")
+        print("ライセンス: コード（runtime / patch）と重み（kizuna-intelligence/*-int4）はいずれも MIT。")
+        print("           ベースの Aratako/Irodori-TTS と DACVAE コーデックも MIT。")
     else:
         print("Irodori-TTS は現状 voice 切り替えを持たない想定です。")
 


### PR DESCRIPTION
## Summary

- Add **Irodori-TTS-Lite** as a new engine: int4-quantized inference runtime over Irodori-TTS that loads 4-bit safetensors via a Triton `FusedInt4Linear` kernel. End-to-end peak VRAM is ~1 GB (vs. ~2 GB for the fp32 path) at essentially unchanged audio quality.
- Default checkpoint: `kizuna-intelligence/Irodori-TTS-Lite-int4` (voice-design int4, no Duration Predictor — wrapper derives `seconds` from phoneme count via `pyopenjtalk`). Switch via env to `kizuna-intelligence/Irodori-TTS-500M-v3-int4` + `IRODORI_LITE_CHECKPOINT_FILE=model.safetensors` for the v3-derived int4 with built-in Duration Predictor.
- Optional `IRODORI_LITE_CODEC_INT4=1` additionally int4-quantizes the DACVAE codec (trades ~150 ms decode latency for ~500 MB less peak VRAM).

## License

Both the Lite runtime code and the int4 weights (`kizuna-intelligence/Irodori-TTS-Lite-int4`, `kizuna-intelligence/Irodori-TTS-500M-v3-int4`) are **MIT**. The base `Aratako/Irodori-TTS` and `Aratako/Semantic-DACVAE-Japanese-32dim` codec are also MIT. The vendored `fused_int4_linear.py` in Lite is from OneCompression (Fujitsu Ltd., MIT).

## Implementation notes

- Lite is a monkey-patch over `irodori_tts.inference_runtime.InferenceRuntime.from_key`, so the installer still clones upstream `Aratako/Irodori-TTS` and adds `pyopenjtalk` + `irodori_tts_lite` to the venv.
- `RuntimeKey` uses `model_precision="fp32"` / `codec_precision="fp32"` (upstream `resolve_runtime_dtype` only accepts `fp32`/`bf16` — `"fp16"` raises). The Lite kernel still runs fp16 internally because the app calls `irodori_tts_lite.configure(use_fused=True, force_fp16=True)` before `patch()`.
- Triton kernel requires Linux + CUDA, so this engine is GPU-only.

## Colab verification

Verified on a Colab GPU runtime with the feature branch checked out.

- trycloudflare public URL: `https://heavy-scoop-dale-benefits.trycloudflare.com`
- `GET /` returns `{"ok":true,"engine":"Irodori-TTS-Lite","model":"kizuna-intelligence/Irodori-TTS-Lite-int4"}`
- `POST /v1/audio/speech` (Japanese input) returned a valid 48 kHz mono PCM wav (~750 KB) over the public URL.
- Lite kernel logs from the run:
  - `[irodori_tts_lite] detected packed AutoBit checkpoint with 288 quantized Linears`
  - `[irodori_tts_lite] fused=144 eager_dequant=144 fallback=0`
  - `[irodori_tts_lite] warmup done in 102359 ms`

## Test plan

- [x] `python colab/bootstrap.py --engine Irodori-TTS-Lite --dry-run` prints the expected voice hints + dry-run summary locally
- [x] Engine launches on Colab GPU runtime and serves the OpenAI-compatible `/v1/audio/speech` endpoint
- [x] Public trycloudflare URL serves audio end-to-end with default checkpoint (`Irodori-TTS-Lite-int4`)
- [ ] (Optional / not required for this PR) Verify v3-int4 mode (`IRODORI_LITE_HF_CHECKPOINT=kizuna-intelligence/Irodori-TTS-500M-v3-int4`, `IRODORI_LITE_CHECKPOINT_FILE=model.safetensors`)
- [ ] (Optional) Verify `IRODORI_LITE_CODEC_INT4=1` codec-int4 path

🤖 Generated with [Claude Code](https://claude.com/claude-code)