### PR TITLE
Add Kokoro-ONNX engine (NVIDIA-optimized Kokoro-82M via onnxruntime)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -11,6 +11,7 @@ Google Colab 上で選択したローカル TTS を一時的に OpenAI 互換 `/
 | エンジン | Colab 動作確認 | 言語 |
 |---|---|---|
 | Kokoro | 動作OK | 日本語 / 英語 / 中国語 他 |
+| Kokoro-ONNX | 動作OK | 日本語 / 英語 / 中国語 他 |
 | Irodori-TTS | 動作OK | 日本語 |
 | Irodori-TTS-Lite | 動作OK（GPU 必須、VRAM ~1GB、int4 量子化） | 日本語 |
 | Piper | 動作OK | 英語（デフォルト）/ 多言語 |
@@ -100,7 +101,7 @@ REPO_URL = "https://github.com/shinshin86/local-tts-on-google-colab.git"  #@para
 REPO_REF = "main"  #@param {type:"string"}
 WORKDIR = "/content/local-tts-on-google-colab"  #@param {type:"string"}
 
-ENGINE = "Kokoro"  #@param ["Bark", "ChatTTS", "Chatterbox", "CosyVoice2", "CSM-1B", "Dia", "DramaBox", "F5-TTS", "Fish-Speech", "GPT-SoVITS", "Higgs-Audio-v2", "Irodori-TTS", "Irodori-TTS-Lite", "Kokoro", "Kyutai-TTS", "MaskGCT", "MeloTTS", "MOSS-TTS-Nano", "MOSS-TTS-v1.5", "NeuTTS", "OpenVoice-V2", "Orpheus-TTS", "OuteTTS", "Piper", "Piper-Plus", "Pocket-TTS", "Qwen3-TTS", "Sarashina-TTS", "Scenema", "Spark-TTS", "Style-Bert-VITS2", "StyleTTS2", "Supertonic", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos"]
+ENGINE = "Kokoro"  #@param ["Bark", "ChatTTS", "Chatterbox", "CosyVoice2", "CSM-1B", "Dia", "DramaBox", "F5-TTS", "Fish-Speech", "GPT-SoVITS", "Higgs-Audio-v2", "Irodori-TTS", "Irodori-TTS-Lite", "Kokoro", "Kokoro-ONNX", "Kyutai-TTS", "MaskGCT", "MeloTTS", "MOSS-TTS-Nano", "MOSS-TTS-v1.5", "NeuTTS", "OpenVoice-V2", "Orpheus-TTS", "OuteTTS", "Piper", "Piper-Plus", "Pocket-TTS", "Qwen3-TTS", "Sarashina-TTS", "Scenema", "Spark-TTS", "Style-Bert-VITS2", "StyleTTS2", "Supertonic", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos"]
 EXPOSE_PUBLIC_URL = True  #@param {type:"boolean"}
 TEST_TEXT = "こんにちは。これは OpenAI 互換 TTS の動作確認です。"  #@param {type:"string"}
 TEST_SPEED = 1.0  #@param {type:"number"}
@@ -143,6 +144,16 @@ IRODORI_LITE_CODEC_INT4 = False  #@param {type:"boolean"}
 #@markdown - License: Apache 2.0 for both code ([hexgrad/kokoro](https://github.com/hexgrad/kokoro)) and weights ([hexgrad/Kokoro-82M](https://huggingface.co/hexgrad/Kokoro-82M)). Commercial use OK.
 KOKORO_DEFAULT_VOICE = "jf_alpha"  #@param ["jf_alpha", "jf_gongitsune", "jm_kumo", "af_heart", "af_bella", "am_adam", "bf_emma", "bm_george", "zf_xiaobei"]
 KOKORO_DEFAULT_LANG_CODE = "j"  #@param ["j", "a", "b", "e", "f", "h", "i", "p", "z"]
+
+#@markdown ---
+#@markdown Kokoro-ONNX (NVIDIA-optimized Kokoro-82M, onnxruntime, GPU/CPU)
+#@markdown - NVIDIA's ONNX build of hexgrad/Kokoro-82M, run via onnxruntime with misaki G2P. 53 preset voices, 9 languages.
+#@markdown - provider: auto/cuda prefer GPU and fall back to CPU; cpu forces CPU-only.
+#@markdown - License: Apache 2.0 for both code and weights ([nvidia/kokoro-82M-onnx-opt](https://huggingface.co/nvidia/kokoro-82M-onnx-opt), base [hexgrad/Kokoro-82M](https://huggingface.co/hexgrad/Kokoro-82M)). Commercial use OK.
+KOKORO_ONNX_HF_MODEL = "nvidia/kokoro-82M-onnx-opt"  #@param {type:"string"}
+KOKORO_ONNX_DEFAULT_VOICE = "jf_alpha"  #@param ["jf_alpha", "jf_gongitsune", "jm_kumo", "af_heart", "af_bella", "am_adam", "am_michael", "bf_emma", "bm_george", "zf_xiaobei", "zm_yunjian", "ef_dora", "ff_siwis", "hf_alpha", "if_sara", "pf_dora"]
+KOKORO_ONNX_DEFAULT_LANG_CODE = "j"  #@param ["j", "a", "b", "e", "f", "h", "i", "p", "z"]
+KOKORO_ONNX_PROVIDER = "auto"  #@param ["auto", "cuda", "cpu"]
 
 #@markdown ---
 #@markdown Kyutai-TTS (GPU recommended, English/French only, CC-BY-4.0 weights)
@@ -505,6 +516,14 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         KOKORO_DEFAULT_VOICE,
         "--kokoro-default-lang-code",
         KOKORO_DEFAULT_LANG_CODE,
+        "--kokoro-onnx-hf-model",
+        KOKORO_ONNX_HF_MODEL,
+        "--kokoro-onnx-default-voice",
+        KOKORO_ONNX_DEFAULT_VOICE,
+        "--kokoro-onnx-default-lang-code",
+        KOKORO_ONNX_DEFAULT_LANG_CODE,
+        "--kokoro-onnx-provider",
+        KOKORO_ONNX_PROVIDER,
         "--kyutai-hf-repo",
         KYUTAI_HF_REPO,
         "--kyutai-voice-repo",
@@ -865,6 +884,14 @@ main()
 ### Kokoro
 
 [hexgrad/kokoro](https://github.com/hexgrad/kokoro) を使った日本語・英語・中国語対応の軽量 TTS です。デフォルト voice は日本語の `jf_alpha` で、フォームから 9 種類の voice を選べます。
+
+### Kokoro-ONNX
+
+NVIDIA が Kokoro-82M を ONNX 化したモデル（[nvidia/kokoro-82M-onnx-opt](https://huggingface.co/nvidia/kokoro-82M-onnx-opt)）を、PyTorch ではなく `onnxruntime` で実行するエンジンです。モデル同梱の `voices.bin` から 53 種類すべての preset voice を公開し、Kokoro と同じ 9 言語（米/英英語・スペイン語・フランス語・ヒンディー語・イタリア語・日本語・ブラジルポルトガル語・中国語）に対応します。言語は voice 名の接頭辞（`a`/`b`=英語, `e`=西語, `f`=仏語, `h`=ヒンディー, `i`=伊語, `j`=日本語, `p`=ポルトガル語, `z`=中国語）から自動判定します。
+
+音素化には Kokoro 公式の G2P である [misaki](https://github.com/hexgrad/misaki) を使用します（日本語=`ja`、中国語=`zh`、英語=`en`+espeak-ng フォールバック、スペイン/フランス/ヒンディー/イタリア/ポルトガル=espeak-ng）。NVIDIA は本モデルを Windows/ONNXRuntime-EP 向けの独自フォニマイザ資産付きで配布しているため、本ラッパーは ONNX グラフ（`tokens` / `style` / `speed` → `audio`）を直接駆動し、音素は misaki から供給することで Colab(Linux) で動く形にしています。
+
+`KOKORO_ONNX_PROVIDER` で実行プロバイダを選べます。`auto`（デフォルト）と `cuda` は GPU 優先・CPU フォールバック、`cpu` は CPU 強制です。82M と軽量なため GPU でも CPU でも快適に動作します。デフォルト voice は日本語の `jf_alpha` で、全 voice は `/v1/voices` で確認できます。Voice cloning は非対応（preset のみ）です。PyTorch 版の `Kokoro` とは別エンジンなので、両方を個別に選択できます。
 
 ### Irodori-TTS
 
@@ -1321,6 +1348,7 @@ Scenema AI による zero-shot な表現力豊か / 演技指向 TTS です（[S
 | エンジン | コード | モデル重み | 商用利用 | 備考 |
 |---|---|---|---|---|
 | Kokoro | Apache 2.0 | Apache 2.0 | OK | |
+| Kokoro-ONNX | Apache 2.0 | Apache 2.0 | OK | NVIDIA による hexgrad/Kokoro-82M の ONNX 再配布。コード・重みとも Apache 2.0 |
 | Irodori-TTS | MIT | MIT (v1 / v2 / v3) | OK | なりすまし・ディープフェイク生成を禁止する倫理規定あり。V3 は SilentCipher ウォーターマーク同梱（除去禁止） |
 | Irodori-TTS-Lite | MIT | MIT (`kizuna-intelligence/Irodori-TTS-Lite-int4`, `kizuna-intelligence/Irodori-TTS-500M-v3-int4`) | OK | Irodori-TTS 用の int4 量子化ランタイム。Triton カーネル使用のため Linux + CUDA 必須。`fused_int4_linear.py` は OneCompression（Fujitsu Ltd., MIT）からベンダリング |
 | Piper | GPL-3.0 | MIT | 要注意 | デフォルト音声 `en_US-lessac-medium` の学習データ（Blizzard 2013）は研究目的限定・商用利用不可 |
@@ -1383,6 +1411,8 @@ Scenema AI による zero-shot な表現力豊か / 演技指向 TTS です（[S
   https://github.com/kizuna-intelligence/Irodori-TTS-Lite
 - Kokoro
   https://github.com/hexgrad/kokoro
+- Kokoro-ONNX
+  https://huggingface.co/nvidia/kokoro-82M-onnx-opt
 - MeloTTS
   https://github.com/myshell-ai/MeloTTS
 - Style-Bert-VITS2

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Supported engines:
 | Engine | Colab Status | Languages |
 |---|---|---|
 | Kokoro | Works | Japanese / English / Chinese and more |
+| Kokoro-ONNX | Works | Japanese / English / Chinese and more |
 | Irodori-TTS | Works | Japanese |
 | Irodori-TTS-Lite | Works (GPU required, ~1GB VRAM, int4-quantized) | Japanese |
 | Piper | Works | English (default) / multilingual |
@@ -99,7 +100,7 @@ REPO_URL = "https://github.com/shinshin86/local-tts-on-google-colab.git"  #@para
 REPO_REF = "main"  #@param {type:"string"}
 WORKDIR = "/content/local-tts-on-google-colab"  #@param {type:"string"}
 
-ENGINE = "Kokoro"  #@param ["Bark", "ChatTTS", "Chatterbox", "CosyVoice2", "CSM-1B", "Dia", "DramaBox", "F5-TTS", "Fish-Speech", "GPT-SoVITS", "Higgs-Audio-v2", "Irodori-TTS", "Irodori-TTS-Lite", "Kokoro", "Kyutai-TTS", "MaskGCT", "MeloTTS", "MOSS-TTS-Nano", "MOSS-TTS-v1.5", "NeuTTS", "OpenVoice-V2", "Orpheus-TTS", "OuteTTS", "Piper", "Piper-Plus", "Pocket-TTS", "Qwen3-TTS", "Sarashina-TTS", "Scenema", "Spark-TTS", "Style-Bert-VITS2", "StyleTTS2", "Supertonic", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos"]
+ENGINE = "Kokoro"  #@param ["Bark", "ChatTTS", "Chatterbox", "CosyVoice2", "CSM-1B", "Dia", "DramaBox", "F5-TTS", "Fish-Speech", "GPT-SoVITS", "Higgs-Audio-v2", "Irodori-TTS", "Irodori-TTS-Lite", "Kokoro", "Kokoro-ONNX", "Kyutai-TTS", "MaskGCT", "MeloTTS", "MOSS-TTS-Nano", "MOSS-TTS-v1.5", "NeuTTS", "OpenVoice-V2", "Orpheus-TTS", "OuteTTS", "Piper", "Piper-Plus", "Pocket-TTS", "Qwen3-TTS", "Sarashina-TTS", "Scenema", "Spark-TTS", "Style-Bert-VITS2", "StyleTTS2", "Supertonic", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos"]
 EXPOSE_PUBLIC_URL = True  #@param {type:"boolean"}
 TEST_TEXT = "こんにちは。これは OpenAI 互換 TTS の動作確認です。"  #@param {type:"string"}
 TEST_SPEED = 1.0  #@param {type:"number"}
@@ -142,6 +143,16 @@ IRODORI_LITE_CODEC_INT4 = False  #@param {type:"boolean"}
 #@markdown - License: Apache 2.0 for both code ([hexgrad/kokoro](https://github.com/hexgrad/kokoro)) and weights ([hexgrad/Kokoro-82M](https://huggingface.co/hexgrad/Kokoro-82M)). Commercial use OK.
 KOKORO_DEFAULT_VOICE = "jf_alpha"  #@param ["jf_alpha", "jf_gongitsune", "jm_kumo", "af_heart", "af_bella", "am_adam", "bf_emma", "bm_george", "zf_xiaobei"]
 KOKORO_DEFAULT_LANG_CODE = "j"  #@param ["j", "a", "b", "e", "f", "h", "i", "p", "z"]
+
+#@markdown ---
+#@markdown Kokoro-ONNX (NVIDIA-optimized Kokoro-82M, onnxruntime, GPU/CPU)
+#@markdown - NVIDIA's ONNX build of hexgrad/Kokoro-82M, run via onnxruntime with misaki G2P. 53 preset voices, 9 languages.
+#@markdown - provider: auto/cuda prefer GPU and fall back to CPU; cpu forces CPU-only.
+#@markdown - License: Apache 2.0 for both code and weights ([nvidia/kokoro-82M-onnx-opt](https://huggingface.co/nvidia/kokoro-82M-onnx-opt), base [hexgrad/Kokoro-82M](https://huggingface.co/hexgrad/Kokoro-82M)). Commercial use OK.
+KOKORO_ONNX_HF_MODEL = "nvidia/kokoro-82M-onnx-opt"  #@param {type:"string"}
+KOKORO_ONNX_DEFAULT_VOICE = "jf_alpha"  #@param ["jf_alpha", "jf_gongitsune", "jm_kumo", "af_heart", "af_bella", "am_adam", "am_michael", "bf_emma", "bm_george", "zf_xiaobei", "zm_yunjian", "ef_dora", "ff_siwis", "hf_alpha", "if_sara", "pf_dora"]
+KOKORO_ONNX_DEFAULT_LANG_CODE = "j"  #@param ["j", "a", "b", "e", "f", "h", "i", "p", "z"]
+KOKORO_ONNX_PROVIDER = "auto"  #@param ["auto", "cuda", "cpu"]
 
 #@markdown ---
 #@markdown Kyutai-TTS (GPU recommended, English/French only, CC-BY-4.0 weights)
@@ -504,6 +515,14 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         KOKORO_DEFAULT_VOICE,
         "--kokoro-default-lang-code",
         KOKORO_DEFAULT_LANG_CODE,
+        "--kokoro-onnx-hf-model",
+        KOKORO_ONNX_HF_MODEL,
+        "--kokoro-onnx-default-voice",
+        KOKORO_ONNX_DEFAULT_VOICE,
+        "--kokoro-onnx-default-lang-code",
+        KOKORO_ONNX_DEFAULT_LANG_CODE,
+        "--kokoro-onnx-provider",
+        KOKORO_ONNX_PROVIDER,
         "--kyutai-hf-repo",
         KYUTAI_HF_REPO,
         "--kyutai-voice-repo",
@@ -864,6 +883,14 @@ This sample is fixed to `wav`. Conversion to formats like `mp3` is not performed
 ### Kokoro
 
 A lightweight TTS using [hexgrad/kokoro](https://github.com/hexgrad/kokoro), supporting Japanese, English, and Chinese. The default voice is the Japanese `jf_alpha`, and 9 voices can be selected from the form.
+
+### Kokoro-ONNX
+
+NVIDIA's ONNX build of Kokoro-82M ([nvidia/kokoro-82M-onnx-opt](https://huggingface.co/nvidia/kokoro-82M-onnx-opt)), run through `onnxruntime` instead of PyTorch. It exposes all 53 preset voices from the model's `voices.bin` and supports the same 9 languages as Kokoro (American/British English, Spanish, French, Hindi, Italian, Japanese, Brazilian Portuguese, Mandarin Chinese). The language is inferred from the voice-name prefix (`a`/`b`=English, `e`=Spanish, `f`=French, `h`=Hindi, `i`=Italian, `j`=Japanese, `p`=Portuguese, `z`=Chinese).
+
+Phonemization uses [misaki](https://github.com/hexgrad/misaki) — the official Kokoro G2P (`ja` for Japanese, `zh` for Chinese, `en` + espeak-ng fallback for English, and espeak-ng for Spanish/French/Hindi/Italian/Portuguese). NVIDIA ships the model with its own self-contained phonemizer assets aimed at a Windows/ONNXRuntime-EP runtime, so this wrapper drives the ONNX graph directly (`tokens` / `style` / `speed` → `audio`) and supplies phonemes via misaki, keeping the Colab path Linux-friendly.
+
+`KOKORO_ONNX_PROVIDER` selects the execution provider: `auto` (default) and `cuda` prefer the GPU and fall back to CPU, while `cpu` forces CPU-only. The model is only 82M parameters, so it runs comfortably on CPU as well as GPU. The default voice is the Japanese `jf_alpha`; the full voice list is available at `/v1/voices`. Voice cloning is not supported (presets only). This is a separate engine from `Kokoro` (the PyTorch build), so both can be selected independently.
 
 ### Irodori-TTS
 
@@ -1320,6 +1347,7 @@ The license for each engine is as follows. When using them, always check each pr
 | Engine | Code | Model Weights | Commercial Use | Notes |
 |---|---|---|---|---|
 | Kokoro | Apache 2.0 | Apache 2.0 | OK | |
+| Kokoro-ONNX | Apache 2.0 | Apache 2.0 | OK | NVIDIA's ONNX repackaging of hexgrad/Kokoro-82M; both are Apache 2.0 |
 | Irodori-TTS | MIT | MIT (v1 / v2 / v3) | OK | Ethical policy prohibits impersonation / deepfake generation. V3 ships with SilentCipher watermarking — do not strip |
 | Irodori-TTS-Lite | MIT | MIT (`kizuna-intelligence/Irodori-TTS-Lite-int4`, `kizuna-intelligence/Irodori-TTS-500M-v3-int4`) | OK | int4-quantized runtime over Irodori-TTS. Triton kernel requires Linux + CUDA. `fused_int4_linear.py` vendored from OneCompression (Fujitsu Ltd., MIT) |
 | Piper | GPL-3.0 | MIT | Caution | The default voice `en_US-lessac-medium` is trained on the Blizzard 2013 dataset (Lessac Technologies), which is research-only and prohibits commercial use |
@@ -1382,6 +1410,8 @@ This repository itself is intended for short-term operational verification and t
   https://github.com/kizuna-intelligence/Irodori-TTS-Lite
 - Kokoro
   https://github.com/hexgrad/kokoro
+- Kokoro-ONNX
+  https://huggingface.co/nvidia/kokoro-82M-onnx-opt
 - MeloTTS
   https://github.com/myshell-ai/MeloTTS
 - Style-Bert-VITS2

--- a/colab/bootstrap.py
+++ b/colab/bootstrap.py
@@ -44,6 +44,10 @@ def parse_args():
     parser.add_argument("--irodori-lite-codec-int4", action="store_true")
     parser.add_argument("--kokoro-default-voice", default="jf_alpha")
     parser.add_argument("--kokoro-default-lang-code", default="j")
+    parser.add_argument("--kokoro-onnx-hf-model", default="nvidia/kokoro-82M-onnx-opt")
+    parser.add_argument("--kokoro-onnx-default-voice", default="jf_alpha")
+    parser.add_argument("--kokoro-onnx-default-lang-code", default="j")
+    parser.add_argument("--kokoro-onnx-provider", default="auto", choices=["auto", "cuda", "cpu"])
     parser.add_argument("--kyutai-hf-repo", default="kyutai/tts-1.6b-en_fr")
     parser.add_argument("--kyutai-voice-repo", default="kyutai/tts-voices")
     parser.add_argument(
@@ -223,6 +227,10 @@ def main():
         irodori_lite_codec_int4=args.irodori_lite_codec_int4,
         kokoro_default_voice=args.kokoro_default_voice,
         kokoro_default_lang_code=args.kokoro_default_lang_code,
+        kokoro_onnx_hf_model=args.kokoro_onnx_hf_model,
+        kokoro_onnx_default_voice=args.kokoro_onnx_default_voice,
+        kokoro_onnx_default_lang_code=args.kokoro_onnx_default_lang_code,
+        kokoro_onnx_provider=args.kokoro_onnx_provider,
         kyutai_hf_repo=args.kyutai_hf_repo,
         kyutai_voice_repo=args.kyutai_voice_repo,
         kyutai_voice=args.kyutai_voice,

--- a/docs/engines.json
+++ b/docs/engines.json
@@ -35,6 +35,7 @@
       "Irodori-TTS",
       "Irodori-TTS-Lite",
       "Kokoro",
+      "Kokoro-ONNX",
       "Kyutai-TTS",
       "MaskGCT",
       "MeloTTS",
@@ -815,6 +816,79 @@
             "z"
           ],
           "flag": "--kokoro-default-lang-code"
+        }
+      ]
+    },
+    {
+      "id": "Kokoro-ONNX",
+      "title": "Kokoro-ONNX (NVIDIA-optimized Kokoro-82M, onnxruntime, GPU/CPU)",
+      "status": "Works",
+      "languages": "Japanese / English / Chinese and more",
+      "description": "NVIDIA's ONNX build of Kokoro-82M ([nvidia/kokoro-82M-onnx-opt](https://huggingface.co/nvidia/kokoro-82M-onnx-opt)), run through `onnxruntime` instead of PyTorch. It exposes all 53 preset voices from the model's `voices.bin` and supports the same 9 languages as Kokoro (American/British English, Spanish, French, Hindi, Italian, Japanese, Brazilian Portuguese, Mandarin Chinese). The language is inferred from the voice-name prefix (`a`/`b`=English, `e`=Spanish, `f`=French, `h`=Hindi, `i`=Italian, `j`=Japanese, `p`=Portuguese, `z`=Chinese).",
+      "notes": [
+        "- NVIDIA's ONNX build of hexgrad/Kokoro-82M, run via onnxruntime with misaki G2P. 53 preset voices, 9 languages.",
+        "- provider: auto/cuda prefer GPU and fall back to CPU; cpu forces CPU-only.",
+        "- License: Apache 2.0 for both code and weights ([nvidia/kokoro-82M-onnx-opt](https://huggingface.co/nvidia/kokoro-82M-onnx-opt), base [hexgrad/Kokoro-82M](https://huggingface.co/hexgrad/Kokoro-82M)). Commercial use OK."
+      ],
+      "prefix": "KOKORO_ONNX",
+      "params": [
+        {
+          "name": "KOKORO_ONNX_HF_MODEL",
+          "default": "nvidia/kokoro-82M-onnx-opt",
+          "type": "string",
+          "flag": "--kokoro-onnx-hf-model"
+        },
+        {
+          "name": "KOKORO_ONNX_DEFAULT_VOICE",
+          "default": "jf_alpha",
+          "type": "select",
+          "options": [
+            "jf_alpha",
+            "jf_gongitsune",
+            "jm_kumo",
+            "af_heart",
+            "af_bella",
+            "am_adam",
+            "am_michael",
+            "bf_emma",
+            "bm_george",
+            "zf_xiaobei",
+            "zm_yunjian",
+            "ef_dora",
+            "ff_siwis",
+            "hf_alpha",
+            "if_sara",
+            "pf_dora"
+          ],
+          "flag": "--kokoro-onnx-default-voice"
+        },
+        {
+          "name": "KOKORO_ONNX_DEFAULT_LANG_CODE",
+          "default": "j",
+          "type": "select",
+          "options": [
+            "j",
+            "a",
+            "b",
+            "e",
+            "f",
+            "h",
+            "i",
+            "p",
+            "z"
+          ],
+          "flag": "--kokoro-onnx-default-lang-code"
+        },
+        {
+          "name": "KOKORO_ONNX_PROVIDER",
+          "default": "auto",
+          "type": "select",
+          "options": [
+            "auto",
+            "cuda",
+            "cpu"
+          ],
+          "flag": "--kokoro-onnx-provider"
         }
       ]
     },

--- a/multi_tts_openai_colab.py
+++ b/multi_tts_openai_colab.py
@@ -11,7 +11,7 @@ REPO_URL = "https://github.com/shinshin86/local-tts-on-google-colab.git"  #@para
 REPO_REF = "main"  #@param {type:"string"}
 WORKDIR = "/content/local-tts-on-google-colab"  #@param {type:"string"}
 
-ENGINE = "Kokoro"  #@param ["Bark", "ChatTTS", "Chatterbox", "CosyVoice2", "CSM-1B", "Dia", "DramaBox", "F5-TTS", "Fish-Speech", "GPT-SoVITS", "Higgs-Audio-v2", "Irodori-TTS", "Irodori-TTS-Lite", "Kokoro", "Kyutai-TTS", "MaskGCT", "MeloTTS", "MOSS-TTS-Nano", "MOSS-TTS-v1.5", "NeuTTS", "OpenVoice-V2", "Orpheus-TTS", "OuteTTS", "Piper", "Piper-Plus", "Pocket-TTS", "Qwen3-TTS", "Sarashina-TTS", "Scenema", "Spark-TTS", "Style-Bert-VITS2", "StyleTTS2", "Supertonic", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos"]
+ENGINE = "Kokoro"  #@param ["Bark", "ChatTTS", "Chatterbox", "CosyVoice2", "CSM-1B", "Dia", "DramaBox", "F5-TTS", "Fish-Speech", "GPT-SoVITS", "Higgs-Audio-v2", "Irodori-TTS", "Irodori-TTS-Lite", "Kokoro", "Kokoro-ONNX", "Kyutai-TTS", "MaskGCT", "MeloTTS", "MOSS-TTS-Nano", "MOSS-TTS-v1.5", "NeuTTS", "OpenVoice-V2", "Orpheus-TTS", "OuteTTS", "Piper", "Piper-Plus", "Pocket-TTS", "Qwen3-TTS", "Sarashina-TTS", "Scenema", "Spark-TTS", "Style-Bert-VITS2", "StyleTTS2", "Supertonic", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos"]
 EXPOSE_PUBLIC_URL = True  #@param {type:"boolean"}
 TEST_TEXT = "こんにちは。これは OpenAI 互換 TTS の動作確認です。"  #@param {type:"string"}
 TEST_SPEED = 1.0  #@param {type:"number"}
@@ -54,6 +54,16 @@ IRODORI_LITE_CODEC_INT4 = False  #@param {type:"boolean"}
 #@markdown - License: Apache 2.0 for both code ([hexgrad/kokoro](https://github.com/hexgrad/kokoro)) and weights ([hexgrad/Kokoro-82M](https://huggingface.co/hexgrad/Kokoro-82M)). Commercial use OK.
 KOKORO_DEFAULT_VOICE = "jf_alpha"  #@param ["jf_alpha", "jf_gongitsune", "jm_kumo", "af_heart", "af_bella", "am_adam", "bf_emma", "bm_george", "zf_xiaobei"]
 KOKORO_DEFAULT_LANG_CODE = "j"  #@param ["j", "a", "b", "e", "f", "h", "i", "p", "z"]
+
+#@markdown ---
+#@markdown Kokoro-ONNX (NVIDIA-optimized Kokoro-82M, onnxruntime, GPU/CPU)
+#@markdown - NVIDIA's ONNX build of hexgrad/Kokoro-82M, run via onnxruntime with misaki G2P. 53 preset voices, 9 languages.
+#@markdown - provider: auto/cuda prefer GPU and fall back to CPU; cpu forces CPU-only.
+#@markdown - License: Apache 2.0 for both code and weights ([nvidia/kokoro-82M-onnx-opt](https://huggingface.co/nvidia/kokoro-82M-onnx-opt), base [hexgrad/Kokoro-82M](https://huggingface.co/hexgrad/Kokoro-82M)). Commercial use OK.
+KOKORO_ONNX_HF_MODEL = "nvidia/kokoro-82M-onnx-opt"  #@param {type:"string"}
+KOKORO_ONNX_DEFAULT_VOICE = "jf_alpha"  #@param ["jf_alpha", "jf_gongitsune", "jm_kumo", "af_heart", "af_bella", "am_adam", "am_michael", "bf_emma", "bm_george", "zf_xiaobei", "zm_yunjian", "ef_dora", "ff_siwis", "hf_alpha", "if_sara", "pf_dora"]
+KOKORO_ONNX_DEFAULT_LANG_CODE = "j"  #@param ["j", "a", "b", "e", "f", "h", "i", "p", "z"]
+KOKORO_ONNX_PROVIDER = "auto"  #@param ["auto", "cuda", "cpu"]
 
 #@markdown ---
 #@markdown Kyutai-TTS (GPU recommended, English/French only, CC-BY-4.0 weights)
@@ -416,6 +426,14 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         KOKORO_DEFAULT_VOICE,
         "--kokoro-default-lang-code",
         KOKORO_DEFAULT_LANG_CODE,
+        "--kokoro-onnx-hf-model",
+        KOKORO_ONNX_HF_MODEL,
+        "--kokoro-onnx-default-voice",
+        KOKORO_ONNX_DEFAULT_VOICE,
+        "--kokoro-onnx-default-lang-code",
+        KOKORO_ONNX_DEFAULT_LANG_CODE,
+        "--kokoro-onnx-provider",
+        KOKORO_ONNX_PROVIDER,
         "--kyutai-hf-repo",
         KYUTAI_HF_REPO,
         "--kyutai-voice-repo",

--- a/src/apps/kokoro_onnx_app.py
+++ b/src/apps/kokoro_onnx_app.py
@@ -1,0 +1,334 @@
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import soundfile as sf
+from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+logger = logging.getLogger("uvicorn.error")
+
+OPENAI_MODEL_ID = os.environ.get("OPENAI_MODEL_ID", "kokoro-82m-onnx")
+HF_MODEL = os.environ.get("KOKORO_ONNX_HF_MODEL", "nvidia/kokoro-82M-onnx-opt")
+DEFAULT_VOICE = os.environ.get("KOKORO_ONNX_DEFAULT_VOICE", "jf_alpha")
+DEFAULT_LANG_CODE = os.environ.get("KOKORO_ONNX_DEFAULT_LANG_CODE", "j")
+# auto = CUDA preferred, CPU fallback; cuda = same; cpu = CPU only.
+PROVIDER = os.environ.get("KOKORO_ONNX_PROVIDER", "auto").lower()
+
+SAMPLE_RATE = 24000
+# Kokoro's ONNX context length is 512; leave room for the pad token 0 at both
+# ends, so a single forward pass takes at most 510 phoneme tokens.
+MAX_CONTENT_TOKENS = 510
+
+# Voice name prefix -> Kokoro lang_code. Matches the upstream Kokoro convention
+# (a=American English, b=British English, e=Spanish, f=French, h=Hindi,
+# i=Italian, j=Japanese, p=Brazilian Portuguese, z=Mandarin Chinese).
+LANG_CODE_BY_PREFIX = {
+    "a": "a",
+    "b": "b",
+    "e": "e",
+    "f": "f",
+    "h": "h",
+    "i": "i",
+    "j": "j",
+    "p": "p",
+    "z": "z",
+}
+
+# lang_codes routed through misaki's EspeakG2P, with the espeak-ng voice name.
+ESPEAK_LANG = {"e": "es", "f": "fr-fr", "h": "hi", "i": "it", "p": "pt-br"}
+
+# Representative subset used for /v1/voices fallback before the model finishes
+# loading; the authoritative list is read from the model's voices.txt at runtime.
+VOICE_PRESETS = [
+    "af_heart",
+    "af_bella",
+    "am_adam",
+    "am_michael",
+    "bf_emma",
+    "bm_george",
+    "jf_alpha",
+    "jf_gongitsune",
+    "jm_kumo",
+    "zf_xiaobei",
+    "zm_yunjian",
+    "ef_dora",
+    "ff_siwis",
+    "hf_alpha",
+    "if_sara",
+    "pf_dora",
+]
+
+app = FastAPI(title="Kokoro-ONNX OpenAI Compatible TTS")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[],
+    allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
+    allow_credentials=False,
+    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_headers=["*"],
+    expose_headers=["x-openai-model", "x-openai-voice"],
+)
+
+
+class AudioSpeechRequest(BaseModel):
+    model: str = OPENAI_MODEL_ID
+    input: str
+    voice: str | None = None
+    response_format: str = "wav"
+    speed: float = 1.0
+
+
+_state: dict = {}
+
+
+def _resolve_providers() -> list[str]:
+    if PROVIDER == "cpu":
+        return ["CPUExecutionProvider"]
+    # "auto" / "cuda": prefer CUDA, fall back to CPU if the GPU provider cannot
+    # be loaded (e.g. no GPU runtime or CUDA/cuDNN mismatch).
+    return ["CUDAExecutionProvider", "CPUExecutionProvider"]
+
+
+def _ensure_loaded() -> dict:
+    if _state:
+        return _state
+
+    import onnxruntime as ort
+    from huggingface_hub import snapshot_download
+
+    model_dir = snapshot_download(HF_MODEL)
+
+    onnx_path = os.path.join(model_dir, "kokoro-82m-v1.0.onnx")
+
+    # tokens.txt: "<symbol> <id>" per line. The symbol itself may be a space,
+    # so split on the last whitespace only.
+    vocab: dict[str, int] = {}
+    for line in Path(os.path.join(model_dir, "tokens.txt")).read_text(encoding="utf-8").splitlines():
+        if not line:
+            continue
+        sym, idx = line.rsplit(" ", 1)
+        vocab[sym] = int(idx)
+
+    # voices.txt: "<index>=<name>" per line.
+    name2idx: dict[str, int] = {}
+    for line in Path(os.path.join(model_dir, "voices.txt")).read_text(encoding="utf-8").splitlines():
+        if not line:
+            continue
+        i, name = line.split("=", 1)
+        name2idx[name.strip()] = int(i)
+
+    # voices.bin: float32, shape (n_speakers, 510, 256).
+    voices = np.fromfile(os.path.join(model_dir, "voices.bin"), dtype=np.float32).reshape(
+        len(name2idx), -1, 256
+    )
+
+    sess = ort.InferenceSession(onnx_path, providers=_resolve_providers())
+
+    _state.update(
+        model_dir=model_dir,
+        vocab=vocab,
+        name2idx=name2idx,
+        voices=voices,
+        sess=sess,
+        space_id=vocab.get(" "),
+        g2p={},
+    )
+    logger.info(
+        "Kokoro-ONNX loaded: provider=%s voices=%d", sess.get_providers()[0], len(name2idx)
+    )
+    return _state
+
+
+def infer_lang_code(voice: str) -> str:
+    prefix = (voice or DEFAULT_VOICE).split("_", 1)[0]
+    return LANG_CODE_BY_PREFIX.get(prefix[:1], DEFAULT_LANG_CODE)
+
+
+def _get_g2p(lang_code: str):
+    state = _ensure_loaded()
+    g2p = state["g2p"].get(lang_code)
+    if g2p is not None:
+        return g2p
+
+    if lang_code in ("a", "b"):
+        from misaki import en
+        from misaki.espeak import EspeakFallback
+
+        british = lang_code == "b"
+        try:
+            fallback = EspeakFallback(british=british)
+        except Exception:  # noqa: BLE001 - fallback is best-effort for OOV words
+            fallback = None
+        g2p = en.G2P(trf=False, british=british, fallback=fallback)
+    elif lang_code == "j":
+        from misaki import ja
+
+        g2p = ja.JAG2P()
+    elif lang_code == "z":
+        from misaki import zh
+
+        g2p = zh.ZHG2P()
+    elif lang_code in ESPEAK_LANG:
+        from misaki.espeak import EspeakG2P
+
+        g2p = EspeakG2P(language=ESPEAK_LANG[lang_code])
+    else:
+        from misaki import en
+
+        g2p = en.G2P(trf=False, british=False)
+
+    state["g2p"][lang_code] = g2p
+    return g2p
+
+
+def _phonemize(text: str, lang_code: str) -> str:
+    g2p = _get_g2p(lang_code)
+    phonemes, _ = g2p(text)
+    return phonemes or ""
+
+
+def _phonemes_to_ids(phonemes: str, vocab: dict[str, int]) -> list[int]:
+    return [vocab[ch] for ch in phonemes if ch in vocab]
+
+
+def _chunk_ids(ids: list[int], space_id: int | None, limit: int = MAX_CONTENT_TOKENS) -> list[list[int]]:
+    """Split a token-id stream into <=limit chunks, preferring word boundaries
+    (the space token) so we never cut a word in half."""
+    if len(ids) <= limit:
+        return [ids]
+    chunks: list[list[int]] = []
+    i, n = 0, len(ids)
+    while i < n:
+        end = min(i + limit, n)
+        if end < n and space_id is not None:
+            cut = end
+            while cut > i and ids[cut - 1] != space_id:
+                cut -= 1
+            if cut > i:
+                end = cut
+        chunks.append(ids[i:end])
+        i = end
+    return chunks
+
+
+def _generate(ids: list[int], voice_idx: int, speed: float) -> np.ndarray:
+    state = _ensure_loaded()
+    voices = state["voices"]
+    sess = state["sess"]
+    audio_chunks: list[np.ndarray] = []
+    for chunk in _chunk_ids(ids, state["space_id"]):
+        if not chunk:
+            continue
+        tokens = np.array([[0, *chunk, 0]], dtype=np.int64)
+        # Style vector is selected by the (unpadded) phoneme-token count.
+        style = voices[voice_idx, min(len(chunk), voices.shape[1] - 1)].reshape(1, 256).astype(
+            np.float32
+        )
+        out = sess.run(
+            ["audio"],
+            {"tokens": tokens, "style": style, "speed": np.array([speed], dtype=np.float32)},
+        )[0]
+        audio_chunks.append(np.asarray(out, dtype=np.float32).reshape(-1))
+    if not audio_chunks:
+        return np.zeros(0, dtype=np.float32)
+    return np.concatenate(audio_chunks)
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, exc: Exception):
+    logger.exception("Unhandled exception while serving request")
+    return JSONResponse(
+        status_code=500,
+        content={"error": type(exc).__name__, "detail": str(exc)},
+    )
+
+
+@app.get("/")
+def root():
+    return {"ok": True, "engine": "Kokoro-ONNX", "model": OPENAI_MODEL_ID}
+
+
+@app.get("/v1/models")
+def list_models():
+    return {
+        "object": "list",
+        "data": [{"id": OPENAI_MODEL_ID, "object": "model", "owned_by": "local"}],
+    }
+
+
+@app.get("/v1/voices")
+def list_voices():
+    voices = VOICE_PRESETS
+    if _state:
+        voices = sorted(_state["name2idx"], key=lambda name: _state["name2idx"][name])
+    return {
+        "object": "list",
+        "data": [{"id": voice, "object": "voice"} for voice in voices],
+    }
+
+
+@app.post("/v1/audio/speech")
+async def audio_speech(payload: AudioSpeechRequest):
+    if payload.response_format.lower() != "wav":
+        raise HTTPException(status_code=400, detail="This wrapper currently supports only wav.")
+
+    state = _ensure_loaded()
+    name2idx = state["name2idx"]
+
+    voice = payload.voice or DEFAULT_VOICE
+    if voice == "default":
+        voice = DEFAULT_VOICE
+    if voice == "clone":
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Kokoro-ONNX does not support runtime voice cloning. "
+                "Use one of the built-in preset voices (see /v1/voices)."
+            ),
+        )
+    if voice not in name2idx:
+        sample = ", ".join(list(name2idx)[:12])
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown voice '{voice}'. Available voices include: {sample}, ... (see /v1/voices).",
+        )
+
+    lang_code = infer_lang_code(voice)
+    phonemes = _phonemize(payload.input, lang_code)
+    ids = _phonemes_to_ids(phonemes, state["vocab"])
+    if not ids:
+        raise HTTPException(
+            status_code=400,
+            detail="Input produced no phonemes; please provide non-empty text.",
+        )
+
+    audio = _generate(ids, name2idx[voice], float(payload.speed))
+    if audio.size == 0:
+        raise HTTPException(status_code=500, detail="No audio was generated.")
+
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+        tmp_path = tmp.name
+
+    try:
+        sf.write(tmp_path, audio, SAMPLE_RATE)
+        audio_bytes = Path(tmp_path).read_bytes()
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+
+    return Response(
+        content=audio_bytes,
+        media_type="audio/wav",
+        headers={
+            "Content-Length": str(len(audio_bytes)),
+            "x-openai-model": payload.model,
+            "x-openai-voice": voice,
+        },
+    )

--- a/src/config.py
+++ b/src/config.py
@@ -16,6 +16,25 @@ KOKORO_VOICE_PRESETS = [
     "zf_xiaobei",
 ]
 
+KOKORO_ONNX_VOICE_PRESETS = [
+    "af_heart",
+    "af_bella",
+    "am_adam",
+    "am_michael",
+    "bf_emma",
+    "bm_george",
+    "jf_alpha",
+    "jf_gongitsune",
+    "jm_kumo",
+    "zf_xiaobei",
+    "zm_yunjian",
+    "ef_dora",
+    "ff_siwis",
+    "hf_alpha",
+    "if_sara",
+    "pf_dora",
+]
+
 NEUTTS_VOICE_PRESETS = ["dave", "jo", "greta", "juliette", "mateo"]
 
 MELO_VOICE_PRESETS = [
@@ -65,6 +84,10 @@ class Settings:
     irodori_lite_codec_int4: bool = False
     kokoro_default_voice: str = "jf_alpha"
     kokoro_default_lang_code: str = "j"
+    kokoro_onnx_hf_model: str = "nvidia/kokoro-82M-onnx-opt"
+    kokoro_onnx_default_voice: str = "jf_alpha"
+    kokoro_onnx_default_lang_code: str = "j"
+    kokoro_onnx_provider: str = "auto"
     kyutai_hf_repo: str = "kyutai/tts-1.6b-en_fr"
     kyutai_voice_repo: str = "kyutai/tts-voices"
     kyutai_voice: str = "expresso/ex03-ex01_happy_001_channel1_334s.wav"

--- a/src/installers/__init__.py
+++ b/src/installers/__init__.py
@@ -13,6 +13,7 @@ from .irodori import install as install_irodori
 from .irodori_lite import install as install_irodori_lite
 from .qwen3_tts import install as install_qwen3_tts
 from .kokoro import install as install_kokoro
+from .kokoro_onnx import install as install_kokoro_onnx
 from .kyutai_tts import install as install_kyutai_tts
 from .maskgct import install as install_maskgct
 from .melo import install as install_melo
@@ -53,6 +54,7 @@ INSTALLERS = {
     "Irodori-TTS": install_irodori,
     "Irodori-TTS-Lite": install_irodori_lite,
     "Kokoro": install_kokoro,
+    "Kokoro-ONNX": install_kokoro_onnx,
     "Kyutai-TTS": install_kyutai_tts,
     "MaskGCT": install_maskgct,
     "MeloTTS": install_melo,

--- a/src/installers/kokoro_onnx.py
+++ b/src/installers/kokoro_onnx.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import os
+
+from src.config import Settings
+from src.runtime import ensure_venv, popen, run, uv_pip_install, write_text
+
+
+def install(settings: Settings) -> dict:
+    engine_dir = settings.engines_dir / "kokoro-onnx-openai"
+    engine_dir.mkdir(parents=True, exist_ok=True)
+    python_bin = ensure_venv(engine_dir)
+    # espeak-ng backs misaki's G2P (English OOV fallback + es/fr/hi/it/pt).
+    run(["apt-get", "-qq", "-y", "install", "espeak-ng"])
+    uv_pip_install(
+        python_bin,
+        [
+            "fastapi",
+            "uvicorn",
+            "onnxruntime-gpu",
+            "huggingface_hub",
+            "soundfile",
+            "numpy",
+            "misaki[en]",
+            "misaki[ja]",
+            "misaki[zh]",
+            "unidic",
+        ],
+    )
+    # JAG2P (Japanese) needs the full UniDic dictionary, not just unidic-lite.
+    run([str(python_bin), "-m", "unidic", "download"], cwd=str(engine_dir))
+    write_text(engine_dir / "app.py", settings.read_repo_text("src/apps/kokoro_onnx_app.py"))
+    env = {
+        **os.environ,
+        "PYTHONUNBUFFERED": "1",
+        "OPENAI_MODEL_ID": settings.openai_model_id or "kokoro-82m-onnx",
+        "KOKORO_ONNX_HF_MODEL": settings.kokoro_onnx_hf_model,
+        "KOKORO_ONNX_DEFAULT_VOICE": settings.kokoro_onnx_default_voice,
+        "KOKORO_ONNX_DEFAULT_LANG_CODE": settings.kokoro_onnx_default_lang_code,
+        "KOKORO_ONNX_PROVIDER": settings.kokoro_onnx_provider,
+    }
+    proc = popen(
+        [
+            str(engine_dir / ".venv" / "bin" / "uvicorn"),
+            "app:app",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            str(settings.app_port),
+            "--log-level",
+            "info",
+        ],
+        cwd=str(engine_dir),
+        env=env,
+        log_path=settings.log_dir / "kokoro-onnx-uvicorn.log",
+    )
+    return {
+        "proc": proc,
+        "app_dir": engine_dir,
+        "log_path": settings.log_dir / "kokoro-onnx-uvicorn.log",
+    }

--- a/src/installers/kokoro_onnx.py
+++ b/src/installers/kokoro_onnx.py
@@ -27,6 +27,17 @@ def install(settings: Settings) -> dict:
             "unidic",
         ],
     )
+    # misaki's English G2P (en.G2P) requires the spaCy en_core_web_sm model for
+    # POS tagging. It is not pulled by misaki[en], and `spacy download` does not
+    # target a pip-less uv venv, so install the matching wheel explicitly
+    # (spaCy 3.8.x -> en_core_web_sm 3.8.0).
+    uv_pip_install(
+        python_bin,
+        [
+            "https://github.com/explosion/spacy-models/releases/download/"
+            "en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl"
+        ],
+    )
     # JAG2P (Japanese) needs the full UniDic dictionary, not just unidic-lite.
     run([str(python_bin), "-m", "unidic", "download"], cwd=str(engine_dir))
     write_text(engine_dir / "app.py", settings.read_repo_text("src/apps/kokoro_onnx_app.py"))

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -8,7 +8,13 @@ import subprocess
 import sys
 import time
 
-from src.config import KOKORO_VOICE_PRESETS, MELO_VOICE_PRESETS, NEUTTS_VOICE_PRESETS, Settings
+from src.config import (
+    KOKORO_ONNX_VOICE_PRESETS,
+    KOKORO_VOICE_PRESETS,
+    MELO_VOICE_PRESETS,
+    NEUTTS_VOICE_PRESETS,
+    Settings,
+)
 from src.installers import INSTALLERS
 from src.runtime import (
     ensure_cloudflared,
@@ -26,6 +32,8 @@ def resolve_selected_voice(settings: Settings) -> str:
         return settings.test_voice
     if settings.engine == "Kokoro":
         return settings.kokoro_default_voice
+    if settings.engine == "Kokoro-ONNX":
+        return settings.kokoro_onnx_default_voice
     if settings.engine == "MeloTTS":
         return settings.melo_default_voice
     if settings.engine == "NeuTTS":
@@ -96,6 +104,18 @@ def print_engine_voice_hints(settings: Settings):
     elif settings.engine == "Kokoro":
         print("Kokoro はフォームで音声を選択できます。")
         print("候補:", ", ".join(KOKORO_VOICE_PRESETS))
+    elif settings.engine == "Kokoro-ONNX":
+        print("Kokoro-ONNX は NVIDIA が最適化した Kokoro-82M の ONNX 版です（onnxruntime で実行、GPU/CPU 両対応）。")
+        print(f"モデル: {settings.kokoro_onnx_hf_model}")
+        print(f"provider: {settings.kokoro_onnx_provider}（auto/cuda は GPU 優先・CPU フォールバック、cpu は CPU 強制）")
+        print(f"デフォルト voice: {settings.kokoro_onnx_default_voice}")
+        print("候補(代表例):", ", ".join(KOKORO_ONNX_VOICE_PRESETS))
+        print("全 53 voice は起動後の /v1/voices を参照してください。")
+        print("言語は voice 名の接頭辞から自動判定します:")
+        print("  a/b=英語(米/英), e=西語, f=仏語, h=ヒンディー, i=伊語, j=日本語, p=ポルトガル語(ブラジル), z=中国語")
+        print("音素化は misaki（j=ja, z=zh, a/b=en+espeak fallback, e/f/h/i/p=espeak）で行います。")
+        print("注意: GPU 不要でも動作（82M と軽量）。Voice cloning は未対応（preset のみ）。")
+        print("ライセンス: コード / 重みとも Apache-2.0（商用 OK）。ベースは hexgrad/Kokoro-82M。")
     elif settings.engine == "MeloTTS":
         print("MeloTTS はフォームで代表的な voice を選択できます。")
         print("候補:", ", ".join(MELO_VOICE_PRESETS))


### PR DESCRIPTION
## Summary

Adds a new TTS engine **Kokoro-ONNX**, wrapping [`nvidia/kokoro-82M-onnx-opt`](https://huggingface.co/nvidia/kokoro-82M-onnx-opt) — NVIDIA's ONNX build of hexgrad/Kokoro-82M — as an OpenAI-compatible `/v1/audio/speech` endpoint. This is a separate engine from the existing PyTorch `Kokoro`, so both can be selected independently.

- Runs via `onnxruntime` (no PyTorch). The ONNX graph is driven directly (`tokens` / `style` / `speed` → `audio`).
- Exposes all **53 preset voices** from the model's `voices.bin`, across the **9 Kokoro languages** (American/British English, Spanish, French, Hindi, Italian, Japanese, Brazilian Portuguese, Mandarin Chinese). Language is inferred from the voice-name prefix.
- Phonemization uses **misaki** (the official Kokoro G2P): `ja` for Japanese, `zh` for Chinese, `en` + espeak-ng fallback for English, espeak-ng for es/fr/hi/it/pt. NVIDIA ships the model with a self-contained phonemizer aimed at a Windows/ONNXRuntime-EP runtime (no Linux/Python path), so this wrapper keeps the Colab path Linux-friendly by supplying phonemes via misaki instead.
- `KOKORO_ONNX_PROVIDER`: `auto`/`cuda` prefer the GPU and fall back to CPU; `cpu` forces CPU-only. The model is only 82M params, so it runs comfortably on CPU as well as GPU.
- Voice cloning is not supported (presets only); `clone` and unknown voices return 4xx, and only `wav` is supported.

## License

Both **code and weights are Apache-2.0** (NVIDIA's ONNX repackaging of hexgrad/Kokoro-82M, which is itself Apache-2.0) — commercial use OK. Verified against the NVIDIA model card and the base hexgrad model card.

## Colab verification

Verified end-to-end on Colab (Tesla T4) from a **clean bootstrap** of this branch (`REPO_REF=feat/kokoro-onnx`), exercising `/v1/audio/speech` against the **trycloudflare public URL** (ephemeral): `https://allowing-humanities-came-radical.trycloudflare.com`

- Japanese (`jf_alpha`), English (`af_heart` / `am_michael` long-text chunking / British `bf_emma`), and Chinese (`zf_xiaobei`) all return valid 24 kHz WAV.
- Error paths: `clone` → 400, unknown voice → 400, `mp3` → 400.
- `CUDAExecutionProvider` active in the engine venv; CPU fallback path also confirmed during probing.

### Fix found during verification

misaki's English G2P (`en.G2P`) requires the spaCy `en_core_web_sm` model and raised `OSError E050` in a fresh uv venv (the model is not pulled by `misaki[en]`, and `spacy download` does not target a pip-less uv venv). Japanese/Chinese were unaffected. The installer now installs the spaCy-3.8-compatible model wheel into the engine venv, and English was re-verified through the public URL after the fix.

## Changes

- `src/installers/kokoro_onnx.py`, `src/apps/kokoro_onnx_app.py`
- Register `Kokoro-ONNX` in `src/installers/__init__.py`; `Settings` fields + CLI flags (`colab/bootstrap.py`) + voice resolution/hints (`src/launcher.py`)
- `README.md` / `README.ja.md`: supported-engines table, engine notes, license table, references
- `multi_tts_openai_colab.py` params + synced embedded cells; regenerated `docs/engines.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
