### PR TITLE
Add ZONOS2 TTS engine (Zyphra, MoE + Mini-SGLang, 41 languages)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -28,7 +28,7 @@ Google Colab 上で選択したローカル TTS を一時的に OpenAI 互換 `/
 | F5-TTS | 動作OK (GPU必須) | 英語 / 中国語（日本語は別モデル） |
 | Chatterbox | 動作OK (GPU推奨) | 日本語 / 英語 / 中国語 他 23言語 |
 | Zonos | 動作OK (GPU必須・VRAM ~6GB) | 日本語 / 英語 / 中国語 / フランス語 / ドイツ語 |
-| ZONOS2 | 未検証 (L4必須・sm_80+) | 41言語 (tier-1: 日本語 / 英語 / 中国語) |
+| ZONOS2 | 動作OK (L4検証済・sm_80+必須) | 41言語 (tier-1: 日本語 / 英語 / 中国語) |
 | OuteTTS | 動作OK (CPU可) | 日本語 / 英語 / 中国語 他 多言語 |
 | Dia | 動作OK (GPU推奨) | 英語（マルチスピーカー対話） |
 | Kyutai-TTS | 動作OK (GPU推奨) | 英語 / フランス語 |

--- a/README.ja.md
+++ b/README.ja.md
@@ -28,6 +28,7 @@ Google Colab 上で選択したローカル TTS を一時的に OpenAI 互換 `/
 | F5-TTS | 動作OK (GPU必須) | 英語 / 中国語（日本語は別モデル） |
 | Chatterbox | 動作OK (GPU推奨) | 日本語 / 英語 / 中国語 他 23言語 |
 | Zonos | 動作OK (GPU必須・VRAM ~6GB) | 日本語 / 英語 / 中国語 / フランス語 / ドイツ語 |
+| ZONOS2 | 未検証 (L4必須・sm_80+) | 41言語 (tier-1: 日本語 / 英語 / 中国語) |
 | OuteTTS | 動作OK (CPU可) | 日本語 / 英語 / 中国語 他 多言語 |
 | Dia | 動作OK (GPU推奨) | 英語（マルチスピーカー対話） |
 | Kyutai-TTS | 動作OK (GPU推奨) | 英語 / フランス語 |
@@ -105,7 +106,7 @@ REPO_URL = "https://github.com/shinshin86/local-tts-on-google-colab.git"  #@para
 REPO_REF = "main"  #@param {type:"string"}
 WORKDIR = "/content/local-tts-on-google-colab"  #@param {type:"string"}
 
-ENGINE = "Kokoro"  #@param ["Bark", "ChatTTS", "Chatterbox", "CosyVoice2", "CSM-1B", "Dia", "dots.tts", "DramaBox", "F5-TTS", "Fish-Speech", "GPT-SoVITS", "Higgs-Audio-v2", "Higgs-Audio-v3", "Irodori-TTS", "Irodori-TTS-Lite", "Kokoro", "Kokoro-ONNX", "Kyutai-TTS", "LFM2.5-Audio-JP", "MaskGCT", "MeloTTS", "MisoTTS", "MOSS-TTS-Nano", "MOSS-TTS-v1.5", "NeuTTS", "OpenVoice-V2", "Orpheus-TTS", "OuteTTS", "Piper", "Piper-Plus", "Pocket-TTS", "Qwen3-TTS", "Sarashina-TTS", "Scenema", "Spark-TTS", "Style-Bert-VITS2", "StyleTTS2", "Supertonic", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos"]
+ENGINE = "Kokoro"  #@param ["Bark", "ChatTTS", "Chatterbox", "CosyVoice2", "CSM-1B", "Dia", "dots.tts", "DramaBox", "F5-TTS", "Fish-Speech", "GPT-SoVITS", "Higgs-Audio-v2", "Higgs-Audio-v3", "Irodori-TTS", "Irodori-TTS-Lite", "Kokoro", "Kokoro-ONNX", "Kyutai-TTS", "LFM2.5-Audio-JP", "MaskGCT", "MeloTTS", "MisoTTS", "MOSS-TTS-Nano", "MOSS-TTS-v1.5", "NeuTTS", "OpenVoice-V2", "Orpheus-TTS", "OuteTTS", "Piper", "Piper-Plus", "Pocket-TTS", "Qwen3-TTS", "Sarashina-TTS", "Scenema", "Spark-TTS", "Style-Bert-VITS2", "StyleTTS2", "Supertonic", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos", "ZONOS2"]
 EXPOSE_PUBLIC_URL = True  #@param {type:"boolean"}
 TEST_TEXT = "こんにちは。これは OpenAI 互換 TTS の動作確認です。"  #@param {type:"string"}
 TEST_SPEED = 1.0  #@param {type:"number"}
@@ -260,6 +261,20 @@ ZONOS_HF_MODEL = "Zyphra/Zonos-v0.1-transformer"  #@param {type:"string"}
 ZONOS_LANGUAGE = "ja"  #@param ["en", "ja", "zh", "fr", "de"]
 ZONOS_PROMPT_WAV = ""  #@param {type:"string"}
 ZONOS_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
+
+#@markdown ---
+#@markdown ZONOS2 (L4 required, 41 languages incl. Japanese, voice cloning)
+#@markdown - Zyphra's latest TTS: MoE backbone + DAC tokens + ECAPA-TDNN embedding, served by the bundled Mini-SGLang server. We launch `uv run python -m zonos2` as a backend and proxy its `/tts/generate` (44.1 kHz float32 PCM) as OpenAI-compatible.
+#@markdown - **GPU sm_80+ required** (L4 / A100): the backbone uses flashinfer / sgl_kernel / cutlass kernels, so T4 does not work. First launch is slow (`uv sync` fetches GPU kernels, then the weights download).
+#@markdown - `default` = a shipped reference voice (`default_voices/<ZONOS2_DEFAULT_REF>`); set `ZONOS2_PROMPT_WAV` and use `voice="clone"` for your own reference. `accurate_mode` on = closer voice match, off = more expressive.
+#@markdown - License: code is **MIT** (pyproject), weights are **Apache-2.0** ([HF model card](https://huggingface.co/Zyphra/ZONOS2)). Both allow commercial use.
+ZONOS2_HF_MODEL = "Zyphra/ZONOS2"  #@param {type:"string"}
+ZONOS2_LANGUAGE = "ja"  #@param ["en_us", "en_gb", "fr_fr", "de", "es", "it", "pt_br", "ja", "cmn", "ko"]
+ZONOS2_PROMPT_WAV = ""  #@param {type:"string"}
+ZONOS2_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
+ZONOS2_DEFAULT_REF = "AmericanFemale.mp3"  #@param {type:"string"}
+ZONOS2_ACCURATE_MODE = True  #@param {type:"boolean"}
+ZONOS2_SEED = -1  #@param {type:"integer"}
 
 #@markdown ---
 #@markdown OuteTTS (CPU OK, multilingual incl JP, voice cloning)
@@ -679,6 +694,18 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         ZONOS_PROMPT_WAV,
         "--zonos-default-voice",
         ZONOS_DEFAULT_VOICE,
+        "--zonos2-hf-model",
+        ZONOS2_HF_MODEL,
+        "--zonos2-language",
+        ZONOS2_LANGUAGE,
+        "--zonos2-prompt-wav",
+        ZONOS2_PROMPT_WAV,
+        "--zonos2-default-voice",
+        ZONOS2_DEFAULT_VOICE,
+        "--zonos2-default-ref",
+        ZONOS2_DEFAULT_REF,
+        "--zonos2-seed",
+        str(ZONOS2_SEED),
         "--outetts-model-size",
         OUTETTS_MODEL_SIZE,
         "--outetts-backend",
@@ -938,6 +965,8 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         cmd.append("--scenema-skip-vc")
     if SCENEMA_BACKGROUND_SFX:
         cmd.append("--scenema-background-sfx")
+    if not ZONOS2_ACCURATE_MODE:
+        cmd.append("--zonos2-no-accurate-mode")
     cmd.append("--expose-public-url" if EXPOSE_PUBLIC_URL else "--no-expose-public-url")
     return cmd
 
@@ -1140,6 +1169,23 @@ Resemble AI の [resemble-ai/chatterbox](https://github.com/resemble-ai/chatterb
 | `clone` | ゼロショット音声クローン。`--zonos-prompt-wav` を指定したときのみ有効 |
 
 音声クローンを使う場合は、必ず権利を持っている音声（本人の同意がある音声）でのみ行ってください。
+
+### ZONOS2
+
+Zyphra の最新 TTS、[Zyphra/ZONOS2](https://github.com/Zyphra/Zonos2) です。Mixture-of-Experts バックボーンが、NeMo で正規化した UTF-8 バイト列と ECAPA-TDNN 話者埋め込みから DAC トークンを生成します（600万時間以上の多言語音声で学習）。3 つの tier で計 41 言語に対応し（tier-1: 英語・中国語・日本語）、高忠実度のゼロショット音声クローンを備えています。デフォルトモデルは `Zyphra/ZONOS2`。
+
+インプロセスで動く Zonos v0.1 と異なり、ZONOS2 は [Mini-SGLang](https://github.com/sgl-project/mini-sglang) ベースの推論サーバのみを提供します。インストーラはリポジトリを clone し、`uv sync` でプロジェクト環境を構築したうえで `uv run python -m zonos2` を `--zonos2-backend-port`（既定 5003）でバックエンド起動します。薄い OpenAI 互換プロキシが `/v1/audio/speech` をバックエンドの `/tts/generate` に転送し、返ってくる 44.1kHz float32 PCM を WAV に変換します。
+
+**GPU は compute capability sm_80+（L4 / A100）が必須です。** バックボーンが `flashinfer` / `sgl_kernel` / `cutlass` カーネルに依存するため、T4（sm_75）では動作しません。初回起動は遅く、`uv sync` での GPU カーネル取得に加え、初回生成時に重みがダウンロードされます。
+
+`voice` パラメータには次の値を指定できます。
+
+| voice | 説明 |
+|---|---|
+| `default` | 同梱の参照音声（`default_voices/<--zonos2-default-ref>`、例: `AmericanFemale.mp3`）を使用。クロスリンガルにクローンするため、`--zonos2-language ja` で日本語も話せます |
+| `clone` | ゼロショット音声クローン。`--zonos2-prompt-wav` を指定したときのみ有効 |
+
+`--zonos2-accurate-mode`（既定 ON）は声質再現を重視し、`--zonos2-no-accurate-mode` で表現力重視になります。`--zonos2-seed` に 0 以上を指定すると出力が再現可能になります。音声クローンを使う場合は、必ず権利を持っている音声（本人の同意がある音声）でのみ行ってください。ライセンス: コードは MIT（pyproject）、重みは Apache 2.0（HF モデルカード）。いずれも商用利用可。
 
 ### OuteTTS
 
@@ -1567,6 +1613,7 @@ Scenema AI による zero-shot な表現力豊か / 演技指向 TTS です（[S
 | F5-TTS | MIT | CC-BY-NC | 不可（モデル） | モデル重みは Emilia データセットの制約により非商用 |
 | Chatterbox | MIT | MIT | OK | 多言語（23言語、日本語含む）。ゼロショット voice cloning |
 | Zonos | Apache 2.0 | Apache 2.0 | OK | 英 / 日 / 中 / 仏 / 独。ゼロショット voice cloning。`espeak-ng` 必須 |
+| ZONOS2 | MIT | Apache 2.0 | OK | 41言語（tier-1 英/中/日）。ゼロショット voice cloning。Mini-SGLang バックエンド。GPU sm_80+（L4/A100） |
 | OuteTTS (0.6B) | Apache 2.0 | Apache 2.0 | OK | 日本語含む多言語、CPU 動作可、voice cloning |
 | OuteTTS (1B)   | Apache 2.0 | CC-BY-NC-SA-4.0 + Llama 3.2 Community License | 不可 | Llama-3.2 ベース。重みは非商用 |
 | Dia | Apache 2.0 | Apache 2.0 | OK | 英語のみ。`[S1]`/`[S2]` でマルチスピーカー対話 TTS |
@@ -1654,6 +1701,8 @@ Scenema AI による zero-shot な表現力豊か / 演技指向 TTS です（[S
   https://github.com/resemble-ai/chatterbox
 - Zonos
   https://github.com/Zyphra/Zonos
+- ZONOS2
+  https://github.com/Zyphra/Zonos2
 - OuteTTS
   https://github.com/edwko/OuteTTS
 - Dia

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Supported engines:
 | F5-TTS | Works (GPU required) | English / Chinese (Japanese via separate model) |
 | Chatterbox | Works (GPU recommended) | Japanese / English / Chinese and 23 languages |
 | Zonos | Works (GPU required, ~6GB VRAM) | Japanese / English / Chinese / French / German |
-| ZONOS2 | Untested (L4 required, sm_80+) | 41 languages (tier-1: Japanese / English / Chinese) |
+| ZONOS2 | Works (L4 verified, sm_80+ required) | 41 languages (tier-1: Japanese / English / Chinese) |
 | OuteTTS | Works (CPU OK) | Japanese / English / Chinese and many languages |
 | Dia | Works (GPU recommended) | English (multi-speaker dialogue) |
 | Kyutai-TTS | Works (GPU recommended) | English / French |

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Supported engines:
 | F5-TTS | Works (GPU required) | English / Chinese (Japanese via separate model) |
 | Chatterbox | Works (GPU recommended) | Japanese / English / Chinese and 23 languages |
 | Zonos | Works (GPU required, ~6GB VRAM) | Japanese / English / Chinese / French / German |
+| ZONOS2 | Untested (L4 required, sm_80+) | 41 languages (tier-1: Japanese / English / Chinese) |
 | OuteTTS | Works (CPU OK) | Japanese / English / Chinese and many languages |
 | Dia | Works (GPU recommended) | English (multi-speaker dialogue) |
 | Kyutai-TTS | Works (GPU recommended) | English / French |
@@ -104,7 +105,7 @@ REPO_URL = "https://github.com/shinshin86/local-tts-on-google-colab.git"  #@para
 REPO_REF = "main"  #@param {type:"string"}
 WORKDIR = "/content/local-tts-on-google-colab"  #@param {type:"string"}
 
-ENGINE = "Kokoro"  #@param ["Bark", "ChatTTS", "Chatterbox", "CosyVoice2", "CSM-1B", "Dia", "dots.tts", "DramaBox", "F5-TTS", "Fish-Speech", "GPT-SoVITS", "Higgs-Audio-v2", "Higgs-Audio-v3", "Irodori-TTS", "Irodori-TTS-Lite", "Kokoro", "Kokoro-ONNX", "Kyutai-TTS", "LFM2.5-Audio-JP", "MaskGCT", "MeloTTS", "MisoTTS", "MOSS-TTS-Nano", "MOSS-TTS-v1.5", "NeuTTS", "OpenVoice-V2", "Orpheus-TTS", "OuteTTS", "Piper", "Piper-Plus", "Pocket-TTS", "Qwen3-TTS", "Sarashina-TTS", "Scenema", "Spark-TTS", "Style-Bert-VITS2", "StyleTTS2", "Supertonic", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos"]
+ENGINE = "Kokoro"  #@param ["Bark", "ChatTTS", "Chatterbox", "CosyVoice2", "CSM-1B", "Dia", "dots.tts", "DramaBox", "F5-TTS", "Fish-Speech", "GPT-SoVITS", "Higgs-Audio-v2", "Higgs-Audio-v3", "Irodori-TTS", "Irodori-TTS-Lite", "Kokoro", "Kokoro-ONNX", "Kyutai-TTS", "LFM2.5-Audio-JP", "MaskGCT", "MeloTTS", "MisoTTS", "MOSS-TTS-Nano", "MOSS-TTS-v1.5", "NeuTTS", "OpenVoice-V2", "Orpheus-TTS", "OuteTTS", "Piper", "Piper-Plus", "Pocket-TTS", "Qwen3-TTS", "Sarashina-TTS", "Scenema", "Spark-TTS", "Style-Bert-VITS2", "StyleTTS2", "Supertonic", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos", "ZONOS2"]
 EXPOSE_PUBLIC_URL = True  #@param {type:"boolean"}
 TEST_TEXT = "こんにちは。これは OpenAI 互換 TTS の動作確認です。"  #@param {type:"string"}
 TEST_SPEED = 1.0  #@param {type:"number"}
@@ -259,6 +260,20 @@ ZONOS_HF_MODEL = "Zyphra/Zonos-v0.1-transformer"  #@param {type:"string"}
 ZONOS_LANGUAGE = "ja"  #@param ["en", "ja", "zh", "fr", "de"]
 ZONOS_PROMPT_WAV = ""  #@param {type:"string"}
 ZONOS_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
+
+#@markdown ---
+#@markdown ZONOS2 (L4 required, 41 languages incl. Japanese, voice cloning)
+#@markdown - Zyphra's latest TTS: MoE backbone + DAC tokens + ECAPA-TDNN embedding, served by the bundled Mini-SGLang server. We launch `uv run python -m zonos2` as a backend and proxy its `/tts/generate` (44.1 kHz float32 PCM) as OpenAI-compatible.
+#@markdown - **GPU sm_80+ required** (L4 / A100): the backbone uses flashinfer / sgl_kernel / cutlass kernels, so T4 does not work. First launch is slow (`uv sync` fetches GPU kernels, then the weights download).
+#@markdown - `default` = a shipped reference voice (`default_voices/<ZONOS2_DEFAULT_REF>`); set `ZONOS2_PROMPT_WAV` and use `voice="clone"` for your own reference. `accurate_mode` on = closer voice match, off = more expressive.
+#@markdown - License: code is **MIT** (pyproject), weights are **Apache-2.0** ([HF model card](https://huggingface.co/Zyphra/ZONOS2)). Both allow commercial use.
+ZONOS2_HF_MODEL = "Zyphra/ZONOS2"  #@param {type:"string"}
+ZONOS2_LANGUAGE = "ja"  #@param ["en_us", "en_gb", "fr_fr", "de", "es", "it", "pt_br", "ja", "cmn", "ko"]
+ZONOS2_PROMPT_WAV = ""  #@param {type:"string"}
+ZONOS2_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
+ZONOS2_DEFAULT_REF = "AmericanFemale.mp3"  #@param {type:"string"}
+ZONOS2_ACCURATE_MODE = True  #@param {type:"boolean"}
+ZONOS2_SEED = -1  #@param {type:"integer"}
 
 #@markdown ---
 #@markdown OuteTTS (CPU OK, multilingual incl JP, voice cloning)
@@ -678,6 +693,18 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         ZONOS_PROMPT_WAV,
         "--zonos-default-voice",
         ZONOS_DEFAULT_VOICE,
+        "--zonos2-hf-model",
+        ZONOS2_HF_MODEL,
+        "--zonos2-language",
+        ZONOS2_LANGUAGE,
+        "--zonos2-prompt-wav",
+        ZONOS2_PROMPT_WAV,
+        "--zonos2-default-voice",
+        ZONOS2_DEFAULT_VOICE,
+        "--zonos2-default-ref",
+        ZONOS2_DEFAULT_REF,
+        "--zonos2-seed",
+        str(ZONOS2_SEED),
         "--outetts-model-size",
         OUTETTS_MODEL_SIZE,
         "--outetts-backend",
@@ -937,6 +964,8 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         cmd.append("--scenema-skip-vc")
     if SCENEMA_BACKGROUND_SFX:
         cmd.append("--scenema-background-sfx")
+    if not ZONOS2_ACCURATE_MODE:
+        cmd.append("--zonos2-no-accurate-mode")
     cmd.append("--expose-public-url" if EXPOSE_PUBLIC_URL else "--no-expose-public-url")
     return cmd
 
@@ -1139,6 +1168,23 @@ The `voice` parameter exposes:
 | `clone` | Zero-shot voice cloning. Only available when `--zonos-prompt-wav` is configured. |
 
 For voice cloning, only use reference audio you have rights to (consent of the speaker).
+
+### ZONOS2
+
+Zyphra's latest TTS, [Zyphra/ZONOS2](https://github.com/Zyphra/Zonos2). A Mixture-of-Experts backbone generates DAC tokens from NeMo-normalized UTF-8 bytes conditioned on an ECAPA-TDNN speaker embedding, trained on 6M+ hours of multilingual speech. It supports 41 languages across three tiers (tier-1: English, Mandarin Chinese, Japanese) with high-fidelity zero-shot voice cloning. Default model: `Zyphra/ZONOS2`.
+
+Unlike the in-process Zonos v0.1 engine, ZONOS2 only ships a high-performance inference server built on [Mini-SGLang](https://github.com/sgl-project/mini-sglang). The installer clones the repo, runs `uv sync` to build the project environment, and launches `uv run python -m zonos2` as a backend on `--zonos2-backend-port` (default 5003). A thin OpenAI-compatible proxy then forwards `/v1/audio/speech` to the backend's `/tts/generate` endpoint and wraps its raw 44.1 kHz float32 PCM stream into WAV.
+
+**A GPU with compute capability sm_80+ is required** (L4, A100). The backbone depends on `flashinfer` / `sgl_kernel` / `cutlass` kernels, so T4 (sm_75) does not work. The first launch is slow: `uv sync` fetches the GPU kernel wheels and the model weights download on first generation.
+
+The `voice` parameter exposes:
+
+| voice | description |
+|---|---|
+| `default` | Uses a bundled reference voice (`default_voices/<--zonos2-default-ref>`, e.g. `AmericanFemale.mp3`). The model clones it cross-lingually, so it can speak Japanese with `--zonos2-language ja`. |
+| `clone` | Zero-shot voice cloning. Only available when `--zonos2-prompt-wav` is configured. |
+
+`--zonos2-accurate-mode` (default on) favors a closer voice match; disable it (`--zonos2-no-accurate-mode`) for a more expressive read. Set `--zonos2-seed` to a non-negative value for reproducible output. For voice cloning, only use reference audio you have rights to (consent of the speaker). License: code is MIT (pyproject), weights are Apache 2.0 (HF model card) — both allow commercial use.
 
 ### OuteTTS
 
@@ -1569,6 +1615,7 @@ The license for each engine is as follows. When using them, always check each pr
 | F5-TTS | MIT | CC-BY-NC | Not allowed (model) | Model weights are non-commercial due to Emilia dataset constraints |
 | Chatterbox | MIT | MIT | OK | Multilingual (23 languages incl JP). Zero-shot voice cloning |
 | Zonos | Apache 2.0 | Apache 2.0 | OK | EN/JA/ZH/FR/DE. Zero-shot voice cloning. Requires `espeak-ng` |
+| ZONOS2 | MIT | Apache 2.0 | OK | 41 languages (tier-1 EN/ZH/JA). Zero-shot voice cloning. Mini-SGLang backend; GPU sm_80+ (L4/A100) |
 | OuteTTS (0.6B) | Apache 2.0 | Apache 2.0 | OK | Multilingual incl JP. CPU OK. Voice cloning |
 | OuteTTS (1B)   | Apache 2.0 | CC-BY-NC-SA-4.0 + Llama 3.2 Community License | Not allowed | Llama-3.2-based; non-commercial weights |
 | Dia | Apache 2.0 | Apache 2.0 | OK | EN only. Multi-speaker `[S1]`/`[S2]` dialogue TTS |
@@ -1653,6 +1700,8 @@ This repository itself is intended for short-term operational verification and t
   https://github.com/resemble-ai/chatterbox
 - Zonos
   https://github.com/Zyphra/Zonos
+- ZONOS2
+  https://github.com/Zyphra/Zonos2
 - OuteTTS
   https://github.com/edwko/OuteTTS
 - Dia

--- a/colab/bootstrap.py
+++ b/colab/bootstrap.py
@@ -101,6 +101,18 @@ def parse_args():
     parser.add_argument("--zonos-language", default="ja")
     parser.add_argument("--zonos-prompt-wav", default="")
     parser.add_argument("--zonos-default-voice", default="default")
+    parser.add_argument("--zonos2-hf-model", default="Zyphra/ZONOS2")
+    parser.add_argument(
+        "--zonos2-language",
+        default="ja",
+        choices=["en_us", "en_gb", "fr_fr", "de", "es", "it", "pt_br", "ja", "cmn", "ko"],
+    )
+    parser.add_argument("--zonos2-prompt-wav", default="")
+    parser.add_argument("--zonos2-default-voice", default="default")
+    parser.add_argument("--zonos2-default-ref", default="AmericanFemale.mp3")
+    parser.add_argument("--zonos2-no-accurate-mode", action="store_true")
+    parser.add_argument("--zonos2-seed", type=int, default=-1)
+    parser.add_argument("--zonos2-backend-port", type=int, default=5003)
     parser.add_argument("--outetts-model-size", default="0.6B")
     parser.add_argument("--outetts-backend", default="HF")
     parser.add_argument("--outetts-default-speaker", default="EN-FEMALE-1-NEUTRAL")
@@ -314,6 +326,14 @@ def main():
         zonos_language=args.zonos_language,
         zonos_prompt_wav=args.zonos_prompt_wav,
         zonos_default_voice=args.zonos_default_voice,
+        zonos2_hf_model=args.zonos2_hf_model,
+        zonos2_language=args.zonos2_language,
+        zonos2_prompt_wav=args.zonos2_prompt_wav,
+        zonos2_default_voice=args.zonos2_default_voice,
+        zonos2_default_ref=args.zonos2_default_ref,
+        zonos2_accurate_mode=not args.zonos2_no_accurate_mode,
+        zonos2_seed=args.zonos2_seed,
+        zonos2_backend_port=args.zonos2_backend_port,
         outetts_model_size=args.outetts_model_size,
         outetts_backend=args.outetts_backend,
         outetts_default_speaker=args.outetts_default_speaker,

--- a/docs/engines.json
+++ b/docs/engines.json
@@ -2368,7 +2368,7 @@
     {
       "id": "ZONOS2",
       "title": "ZONOS2 (L4 required, 41 languages incl. Japanese, voice cloning)",
-      "status": "Untested (L4 required, sm_80+)",
+      "status": "Works (L4 verified, sm_80+ required)",
       "languages": "41 languages (tier-1: Japanese / English / Chinese)",
       "description": "Zyphra's latest TTS, [Zyphra/ZONOS2](https://github.com/Zyphra/Zonos2). A Mixture-of-Experts backbone generates DAC tokens from NeMo-normalized UTF-8 bytes conditioned on an ECAPA-TDNN speaker embedding, trained on 6M+ hours of multilingual speech. It supports 41 languages across three tiers (tier-1: English, Mandarin Chinese, Japanese) with high-fidelity zero-shot voice cloning. Default model: `Zyphra/ZONOS2`.",
       "notes": [

--- a/docs/engines.json
+++ b/docs/engines.json
@@ -63,7 +63,8 @@
       "VibeVoice",
       "VoxCPM2",
       "Voxtral-TTS",
-      "Zonos"
+      "Zonos",
+      "ZONOS2"
     ]
   },
   "expose_setting": {
@@ -2361,6 +2362,80 @@
             "clone"
           ],
           "flag": "--zonos-default-voice"
+        }
+      ]
+    },
+    {
+      "id": "ZONOS2",
+      "title": "ZONOS2 (L4 required, 41 languages incl. Japanese, voice cloning)",
+      "status": "Untested (L4 required, sm_80+)",
+      "languages": "41 languages (tier-1: Japanese / English / Chinese)",
+      "description": "Zyphra's latest TTS, [Zyphra/ZONOS2](https://github.com/Zyphra/Zonos2). A Mixture-of-Experts backbone generates DAC tokens from NeMo-normalized UTF-8 bytes conditioned on an ECAPA-TDNN speaker embedding, trained on 6M+ hours of multilingual speech. It supports 41 languages across three tiers (tier-1: English, Mandarin Chinese, Japanese) with high-fidelity zero-shot voice cloning. Default model: `Zyphra/ZONOS2`.",
+      "notes": [
+        "- Zyphra's latest TTS: MoE backbone + DAC tokens + ECAPA-TDNN embedding, served by the bundled Mini-SGLang server. We launch `uv run python -m zonos2` as a backend and proxy its `/tts/generate` (44.1 kHz float32 PCM) as OpenAI-compatible.",
+        "- **GPU sm_80+ required** (L4 / A100): the backbone uses flashinfer / sgl_kernel / cutlass kernels, so T4 does not work. First launch is slow (`uv sync` fetches GPU kernels, then the weights download).",
+        "- `default` = a shipped reference voice (`default_voices/<ZONOS2_DEFAULT_REF>`); set `ZONOS2_PROMPT_WAV` and use `voice=\"clone\"` for your own reference. `accurate_mode` on = closer voice match, off = more expressive.",
+        "- License: code is **MIT** (pyproject), weights are **Apache-2.0** ([HF model card](https://huggingface.co/Zyphra/ZONOS2)). Both allow commercial use."
+      ],
+      "prefix": "ZONOS2",
+      "params": [
+        {
+          "name": "ZONOS2_HF_MODEL",
+          "default": "Zyphra/ZONOS2",
+          "type": "string",
+          "flag": "--zonos2-hf-model"
+        },
+        {
+          "name": "ZONOS2_LANGUAGE",
+          "default": "ja",
+          "type": "select",
+          "options": [
+            "en_us",
+            "en_gb",
+            "fr_fr",
+            "de",
+            "es",
+            "it",
+            "pt_br",
+            "ja",
+            "cmn",
+            "ko"
+          ],
+          "flag": "--zonos2-language"
+        },
+        {
+          "name": "ZONOS2_PROMPT_WAV",
+          "default": "",
+          "type": "string",
+          "flag": "--zonos2-prompt-wav"
+        },
+        {
+          "name": "ZONOS2_DEFAULT_VOICE",
+          "default": "default",
+          "type": "select",
+          "options": [
+            "default",
+            "clone"
+          ],
+          "flag": "--zonos2-default-voice"
+        },
+        {
+          "name": "ZONOS2_DEFAULT_REF",
+          "default": "AmericanFemale.mp3",
+          "type": "string",
+          "flag": "--zonos2-default-ref"
+        },
+        {
+          "name": "ZONOS2_ACCURATE_MODE",
+          "default": true,
+          "type": "boolean",
+          "flag": null
+        },
+        {
+          "name": "ZONOS2_SEED",
+          "default": -1,
+          "type": "integer",
+          "flag": "--zonos2-seed"
         }
       ]
     }

--- a/multi_tts_openai_colab.py
+++ b/multi_tts_openai_colab.py
@@ -11,7 +11,7 @@ REPO_URL = "https://github.com/shinshin86/local-tts-on-google-colab.git"  #@para
 REPO_REF = "main"  #@param {type:"string"}
 WORKDIR = "/content/local-tts-on-google-colab"  #@param {type:"string"}
 
-ENGINE = "Kokoro"  #@param ["Bark", "ChatTTS", "Chatterbox", "CosyVoice2", "CSM-1B", "Dia", "dots.tts", "DramaBox", "F5-TTS", "Fish-Speech", "GPT-SoVITS", "Higgs-Audio-v2", "Higgs-Audio-v3", "Irodori-TTS", "Irodori-TTS-Lite", "Kokoro", "Kokoro-ONNX", "Kyutai-TTS", "LFM2.5-Audio-JP", "MaskGCT", "MeloTTS", "MisoTTS", "MOSS-TTS-Nano", "MOSS-TTS-v1.5", "NeuTTS", "OpenVoice-V2", "Orpheus-TTS", "OuteTTS", "Piper", "Piper-Plus", "Pocket-TTS", "Qwen3-TTS", "Sarashina-TTS", "Scenema", "Spark-TTS", "Style-Bert-VITS2", "StyleTTS2", "Supertonic", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos"]
+ENGINE = "Kokoro"  #@param ["Bark", "ChatTTS", "Chatterbox", "CosyVoice2", "CSM-1B", "Dia", "dots.tts", "DramaBox", "F5-TTS", "Fish-Speech", "GPT-SoVITS", "Higgs-Audio-v2", "Higgs-Audio-v3", "Irodori-TTS", "Irodori-TTS-Lite", "Kokoro", "Kokoro-ONNX", "Kyutai-TTS", "LFM2.5-Audio-JP", "MaskGCT", "MeloTTS", "MisoTTS", "MOSS-TTS-Nano", "MOSS-TTS-v1.5", "NeuTTS", "OpenVoice-V2", "Orpheus-TTS", "OuteTTS", "Piper", "Piper-Plus", "Pocket-TTS", "Qwen3-TTS", "Sarashina-TTS", "Scenema", "Spark-TTS", "Style-Bert-VITS2", "StyleTTS2", "Supertonic", "TinyTTS", "VibeVoice", "VoxCPM2", "Voxtral-TTS", "Zonos", "ZONOS2"]
 EXPOSE_PUBLIC_URL = True  #@param {type:"boolean"}
 TEST_TEXT = "こんにちは。これは OpenAI 互換 TTS の動作確認です。"  #@param {type:"string"}
 TEST_SPEED = 1.0  #@param {type:"number"}
@@ -166,6 +166,20 @@ ZONOS_HF_MODEL = "Zyphra/Zonos-v0.1-transformer"  #@param {type:"string"}
 ZONOS_LANGUAGE = "ja"  #@param ["en", "ja", "zh", "fr", "de"]
 ZONOS_PROMPT_WAV = ""  #@param {type:"string"}
 ZONOS_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
+
+#@markdown ---
+#@markdown ZONOS2 (L4 required, 41 languages incl. Japanese, voice cloning)
+#@markdown - Zyphra's latest TTS: MoE backbone + DAC tokens + ECAPA-TDNN embedding, served by the bundled Mini-SGLang server. We launch `uv run python -m zonos2` as a backend and proxy its `/tts/generate` (44.1 kHz float32 PCM) as OpenAI-compatible.
+#@markdown - **GPU sm_80+ required** (L4 / A100): the backbone uses flashinfer / sgl_kernel / cutlass kernels, so T4 does not work. First launch is slow (`uv sync` fetches GPU kernels, then the weights download).
+#@markdown - `default` = a shipped reference voice (`default_voices/<ZONOS2_DEFAULT_REF>`); set `ZONOS2_PROMPT_WAV` and use `voice="clone"` for your own reference. `accurate_mode` on = closer voice match, off = more expressive.
+#@markdown - License: code is **MIT** (pyproject), weights are **Apache-2.0** ([HF model card](https://huggingface.co/Zyphra/ZONOS2)). Both allow commercial use.
+ZONOS2_HF_MODEL = "Zyphra/ZONOS2"  #@param {type:"string"}
+ZONOS2_LANGUAGE = "ja"  #@param ["en_us", "en_gb", "fr_fr", "de", "es", "it", "pt_br", "ja", "cmn", "ko"]
+ZONOS2_PROMPT_WAV = ""  #@param {type:"string"}
+ZONOS2_DEFAULT_VOICE = "default"  #@param ["default", "clone"]
+ZONOS2_DEFAULT_REF = "AmericanFemale.mp3"  #@param {type:"string"}
+ZONOS2_ACCURATE_MODE = True  #@param {type:"boolean"}
+ZONOS2_SEED = -1  #@param {type:"integer"}
 
 #@markdown ---
 #@markdown OuteTTS (CPU OK, multilingual incl JP, voice cloning)
@@ -585,6 +599,18 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         ZONOS_PROMPT_WAV,
         "--zonos-default-voice",
         ZONOS_DEFAULT_VOICE,
+        "--zonos2-hf-model",
+        ZONOS2_HF_MODEL,
+        "--zonos2-language",
+        ZONOS2_LANGUAGE,
+        "--zonos2-prompt-wav",
+        ZONOS2_PROMPT_WAV,
+        "--zonos2-default-voice",
+        ZONOS2_DEFAULT_VOICE,
+        "--zonos2-default-ref",
+        ZONOS2_DEFAULT_REF,
+        "--zonos2-seed",
+        str(ZONOS2_SEED),
         "--outetts-model-size",
         OUTETTS_MODEL_SIZE,
         "--outetts-backend",
@@ -844,6 +870,8 @@ def build_bootstrap_command(workdir: Path) -> list[str]:
         cmd.append("--scenema-skip-vc")
     if SCENEMA_BACKGROUND_SFX:
         cmd.append("--scenema-background-sfx")
+    if not ZONOS2_ACCURATE_MODE:
+        cmd.append("--zonos2-no-accurate-mode")
     cmd.append("--expose-public-url" if EXPOSE_PUBLIC_URL else "--no-expose-public-url")
     return cmd
 

--- a/src/apps/zonos2_app.py
+++ b/src/apps/zonos2_app.py
@@ -175,7 +175,9 @@ async def audio_speech(payload: AudioSpeechRequest):
         raise HTTPException(status_code=500, detail="No audio was generated.")
 
     buf = io.BytesIO()
-    sf.write(buf, pcm, BACKEND_SAMPLE_RATE, format="WAV", subtype="FLOAT")
+    # Write PCM_16 (not FLOAT) so the WAV is readable by the Python stdlib
+    # `wave` module and the broadest set of OpenAI-style clients.
+    sf.write(buf, pcm, BACKEND_SAMPLE_RATE, format="WAV", subtype="PCM_16")
     audio_bytes = buf.getvalue()
 
     return Response(

--- a/src/apps/zonos2_app.py
+++ b/src/apps/zonos2_app.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import base64
+import io
+import logging
+import os
+from pathlib import Path
+
+import numpy as np
+import requests
+import soundfile as sf
+from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+logger = logging.getLogger("uvicorn.error")
+
+OPENAI_MODEL_ID = os.environ.get("OPENAI_MODEL_ID", "zonos2")
+BACKEND_URL = os.environ.get("ZONOS2_BACKEND_URL", "http://127.0.0.1:5003")
+ZONOS2_LANGUAGE = os.environ.get("ZONOS2_LANGUAGE", "ja")
+ZONOS2_DEFAULT_REF = os.environ.get("ZONOS2_DEFAULT_REF", "")
+ZONOS2_PROMPT_WAV = os.environ.get("ZONOS2_PROMPT_WAV", "")
+ZONOS2_DEFAULT_VOICE = os.environ.get("ZONOS2_DEFAULT_VOICE", "default")
+ZONOS2_ACCURATE_MODE = os.environ.get("ZONOS2_ACCURATE_MODE", "1") not in {"0", "false", "False", ""}
+_seed_raw = os.environ.get("ZONOS2_SEED", "")
+ZONOS2_SEED: int | None = int(_seed_raw) if _seed_raw.strip() else None
+
+# Mini-SGLang `/tts/generate` always streams raw little-endian float32 PCM,
+# mono, at 44.1 kHz (see the X-Audio-* response headers upstream sends).
+BACKEND_SAMPLE_RATE = 44100
+
+# Convenience aliases → the text-normalization language codes the backend
+# `/tts/generate` endpoint understands (en_us, en_gb, fr_fr, de, es, it,
+# pt_br, ja, cmn, ko). Pass any of those codes through verbatim.
+LANGUAGE_ALIASES = {
+    "en": "en_us",
+    "en-us": "en_us",
+    "en-gb": "en_gb",
+    "zh": "cmn",
+    "zh-cn": "cmn",
+    "fr": "fr_fr",
+    "pt": "pt_br",
+    "jp": "ja",
+}
+
+
+def _resolve_language(language: str) -> str:
+    key = language.strip().lower()
+    return LANGUAGE_ALIASES.get(key, key or "ja")
+
+
+app = FastAPI(title="ZONOS2 OpenAI Compatible TTS")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[],
+    allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
+    allow_credentials=False,
+    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_headers=["*"],
+    expose_headers=["x-openai-model", "x-openai-voice"],
+)
+
+
+class AudioSpeechRequest(BaseModel):
+    model: str = OPENAI_MODEL_ID
+    input: str
+    voice: str | None = None
+    response_format: str = "wav"
+    speed: float = 1.0
+
+
+def _reference_path(voice: str) -> str:
+    if voice == "clone":
+        return ZONOS2_PROMPT_WAV
+    return ZONOS2_DEFAULT_REF
+
+
+def _encode_reference(wav_path: str) -> tuple[str, str]:
+    path = Path(wav_path)
+    if not wav_path or not path.exists():
+        raise HTTPException(
+            status_code=500,
+            detail=f"Reference audio not found: {wav_path}",
+        )
+    audio_b64 = base64.b64encode(path.read_bytes()).decode("ascii")
+    return audio_b64, path.name
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, exc: Exception):
+    logger.exception("Unhandled exception while serving request")
+    return JSONResponse(
+        status_code=500,
+        content={"error": type(exc).__name__, "detail": str(exc)},
+    )
+
+
+@app.get("/")
+def root():
+    return {
+        "ok": True,
+        "engine": "ZONOS2",
+        "model": OPENAI_MODEL_ID,
+        "backend": BACKEND_URL,
+        "language": ZONOS2_LANGUAGE,
+        "default_voice": ZONOS2_DEFAULT_VOICE,
+    }
+
+
+@app.get("/v1/models")
+def list_models():
+    return {
+        "object": "list",
+        "data": [{"id": OPENAI_MODEL_ID, "object": "model", "owned_by": "zyphra"}],
+    }
+
+
+@app.get("/v1/voices")
+def list_voices():
+    voices = [{"id": "default", "object": "voice", "language": ZONOS2_LANGUAGE}]
+    if ZONOS2_PROMPT_WAV:
+        voices.append({"id": "clone", "object": "voice", "language": ZONOS2_LANGUAGE})
+    return {"object": "list", "data": voices}
+
+
+@app.post("/v1/audio/speech")
+async def audio_speech(payload: AudioSpeechRequest):
+    if payload.response_format.lower() != "wav":
+        raise HTTPException(status_code=400, detail="This wrapper currently supports only wav.")
+
+    voice = payload.voice or ZONOS2_DEFAULT_VOICE
+    if voice not in {"default", "clone"}:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown voice '{voice}'. Use 'default' or 'clone'.",
+        )
+    if voice == "clone" and not ZONOS2_PROMPT_WAV:
+        raise HTTPException(
+            status_code=400,
+            detail="voice='clone' requires --zonos2-prompt-wav at startup.",
+        )
+
+    speaker_b64, speaker_name = _encode_reference(_reference_path(voice))
+
+    backend_payload = {
+        "text": payload.input,
+        "language": _resolve_language(ZONOS2_LANGUAGE),
+        "accurate_mode": ZONOS2_ACCURATE_MODE,
+        "stream": False,
+        "speaker_audio_base64": speaker_b64,
+        "speaker_audio_name": speaker_name,
+    }
+    if ZONOS2_SEED is not None:
+        backend_payload["seed"] = ZONOS2_SEED
+
+    try:
+        # First call blocks while the Mini-SGLang workers finish loading the
+        # model, so keep the timeout generous.
+        response = requests.post(
+            f"{BACKEND_URL}/tts/generate",
+            json=backend_payload,
+            timeout=900,
+        )
+        response.raise_for_status()
+    except requests.HTTPError as exc:
+        detail = exc.response.text if exc.response is not None else str(exc)
+        raise HTTPException(status_code=502, detail=f"Backend error: {detail}")
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=f"Failed to synthesize audio: {exc}")
+
+    pcm = np.frombuffer(response.content, dtype="<f4")
+    if pcm.size == 0:
+        raise HTTPException(status_code=500, detail="No audio was generated.")
+
+    buf = io.BytesIO()
+    sf.write(buf, pcm, BACKEND_SAMPLE_RATE, format="WAV", subtype="FLOAT")
+    audio_bytes = buf.getvalue()
+
+    return Response(
+        content=audio_bytes,
+        media_type="audio/wav",
+        headers={
+            "Content-Length": str(len(audio_bytes)),
+            "x-openai-model": payload.model,
+            "x-openai-voice": voice,
+        },
+    )

--- a/src/config.py
+++ b/src/config.py
@@ -139,6 +139,22 @@ class Settings:
     zonos_language: str = "ja"
     zonos_prompt_wav: str = ""
     zonos_default_voice: str = "default"
+    # ZONOS2 (Zyphra): MoE backbone + DAC tokens + ECAPA-TDNN embedding served
+    # by the bundled Mini-SGLang server (GPU sm_80+ required: flashinfer /
+    # sgl_kernel / cutlass kernels). Multilingual (tier-1: en/zh/ja). We launch
+    # `uv run python -m zonos2` as a backend and proxy its /tts/generate
+    # (44.1 kHz float32 PCM). default = a shipped reference voice; clone =
+    # --zonos2-prompt-wav. Code MIT (pyproject), weights Apache-2.0 (HF card).
+    zonos2_hf_model: str = "Zyphra/ZONOS2"
+    zonos2_language: str = "ja"
+    zonos2_prompt_wav: str = ""
+    zonos2_default_voice: str = "default"
+    # Bare filename → looked up inside the cloned repo's default_voices/.
+    zonos2_default_ref: str = "AmericanFemale.mp3"
+    zonos2_accurate_mode: bool = True
+    # >= 0 forces a fixed seed for reproducible output; -1 leaves it random.
+    zonos2_seed: int = -1
+    zonos2_backend_port: int = 5003
     outetts_model_size: str = "0.6B"
     outetts_backend: str = "HF"
     outetts_default_speaker: str = "EN-FEMALE-1-NEUTRAL"

--- a/src/installers/__init__.py
+++ b/src/installers/__init__.py
@@ -41,6 +41,7 @@ from .voxcpm import install as install_voxcpm
 from .tiny_tts import install as install_tiny_tts
 from .voxtral import install as install_voxtral
 from .zonos import install as install_zonos
+from .zonos2 import install as install_zonos2
 
 
 INSTALLERS = {
@@ -87,4 +88,5 @@ INSTALLERS = {
     "VoxCPM2": install_voxcpm,
     "Voxtral-TTS": install_voxtral,
     "Zonos": install_zonos,
+    "ZONOS2": install_zonos2,
 }

--- a/src/installers/zonos2.py
+++ b/src/installers/zonos2.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import os
+
+from src.config import Settings
+from src.runtime import (
+    ensure_git_clone,
+    ensure_venv,
+    popen,
+    run,
+    tail_log,
+    uv_pip_install,
+    wait_http,
+    write_text,
+)
+
+
+ZONOS2_REPO_URL = "https://github.com/Zyphra/Zonos2.git"
+
+
+def install(settings: Settings) -> dict:
+    engine_dir = settings.engines_dir / "zonos2"
+    engine_dir.mkdir(parents=True, exist_ok=True)
+
+    repo_dir = engine_dir / "Zonos2"
+    ensure_git_clone(ZONOS2_REPO_URL, repo_dir)
+
+    # ZONOS2 ships a uv project (pyproject + uv.lock) whose backbone relies on
+    # flashinfer / sgl_kernel / cutlass GPU kernels (sm_80+). `uv sync` builds
+    # the project's own .venv from the lockfile; we launch the bundled
+    # Mini-SGLang server from it via `uv run`.
+    run(["uv", "sync"], cwd=str(repo_dir))
+
+    default_voices_dir = repo_dir / "default_voices"
+    backend_port = settings.zonos2_backend_port
+    backend_env = {
+        **os.environ,
+        "PYTHONUNBUFFERED": "1",
+    }
+    backend_proc = popen(
+        [
+            "uv",
+            "run",
+            "python",
+            "-m",
+            "zonos2",
+            "--model-path",
+            settings.zonos2_hf_model,
+            "--tts-default-voices-dir",
+            str(default_voices_dir),
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(backend_port),
+        ],
+        cwd=str(repo_dir),
+        env=backend_env,
+        log_path=settings.log_dir / "zonos2-backend.log",
+    )
+    # The frontend binds the HTTP port shortly after launch; the Mini-SGLang
+    # worker processes keep loading the model (and downloading weights on the
+    # first run) in the background, so the first /tts/generate call blocks
+    # until they are ready. We only wait for the port to come up here.
+    if not wait_http(f"http://127.0.0.1:{backend_port}/v1", timeout=600):
+        tail_log(settings.log_dir / "zonos2-backend.log")
+        raise RuntimeError("ZONOS2 Mini-SGLang backend did not become ready.")
+
+    # Resolve the default reference voice to an absolute path. A bare filename
+    # is looked up inside the cloned repo's default_voices/ directory.
+    default_ref = settings.zonos2_default_ref
+    if default_ref and not os.path.isabs(default_ref):
+        default_ref = str(default_voices_dir / default_ref)
+
+    # The OpenAI-compatible proxy runs in its own lightweight venv so the
+    # uv-synced project environment stays untouched.
+    python_bin = ensure_venv(engine_dir)
+    uv_pip_install(python_bin, ["fastapi", "uvicorn", "requests", "soundfile", "numpy"])
+    write_text(engine_dir / "app.py", settings.read_repo_text("src/apps/zonos2_app.py"))
+
+    env = {
+        **os.environ,
+        "PYTHONUNBUFFERED": "1",
+        "OPENAI_MODEL_ID": settings.openai_model_id or "zonos2",
+        "ZONOS2_BACKEND_URL": f"http://127.0.0.1:{backend_port}",
+        "ZONOS2_LANGUAGE": settings.zonos2_language,
+        "ZONOS2_DEFAULT_REF": default_ref,
+        "ZONOS2_PROMPT_WAV": settings.zonos2_prompt_wav,
+        "ZONOS2_DEFAULT_VOICE": settings.zonos2_default_voice,
+        "ZONOS2_ACCURATE_MODE": "1" if settings.zonos2_accurate_mode else "0",
+        "ZONOS2_SEED": str(settings.zonos2_seed) if settings.zonos2_seed >= 0 else "",
+    }
+    proc = popen(
+        [
+            str(engine_dir / ".venv" / "bin" / "uvicorn"),
+            "app:app",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            str(settings.app_port),
+            "--log-level",
+            "info",
+        ],
+        cwd=str(engine_dir),
+        env=env,
+        log_path=settings.log_dir / "zonos2-uvicorn.log",
+    )
+    return {
+        "proc": proc,
+        "backend_proc": backend_proc,
+        "app_dir": engine_dir,
+        "log_path": settings.log_dir / "zonos2-uvicorn.log",
+        "backend_log_path": settings.log_dir / "zonos2-backend.log",
+    }

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -44,6 +44,8 @@ def resolve_selected_voice(settings: Settings) -> str:
         return settings.chatterbox_default_voice
     if settings.engine == "Zonos":
         return settings.zonos_default_voice
+    if settings.engine == "ZONOS2":
+        return settings.zonos2_default_voice
     if settings.engine == "OuteTTS":
         return settings.outetts_default_voice
     if settings.engine == "Dia":
@@ -227,6 +229,24 @@ def print_engine_voice_hints(settings: Settings):
             print("             clone は --zonos-prompt-wav を指定すると有効になります")
         print("対応言語: en, ja, zh, fr, de（espeak-ng で音素化）")
         print("注意: GPU 推奨（VRAM 6GB+）。ライセンス: Apache-2.0（コードと重み）")
+    elif settings.engine == "ZONOS2":
+        print("ZONOS2 は Zyphra の最新多言語 TTS です（MoE バックボーン + DAC、41言語、ゼロショット voice cloning）。")
+        print(f"モデル: {settings.zonos2_hf_model}")
+        print(f"language: {settings.zonos2_language}（tier-1: en_us/en_gb, cmn, ja）")
+        print(f"デフォルト voice: {settings.zonos2_default_voice} / 参照音声: {settings.zonos2_default_ref}")
+        print(f"accurate_mode: {settings.zonos2_accurate_mode}（True=声質再現重視 / False=表現力重視）")
+        print(f"seed: {'random' if settings.zonos2_seed < 0 else settings.zonos2_seed}")
+        print("voice 候補: default（同梱の default_voices/<ZONOS2_DEFAULT_REF> を参照音声として使用）")
+        if settings.zonos2_prompt_wav:
+            print(f"             clone（参照音声: {settings.zonos2_prompt_wav}）")
+        else:
+            print("             clone は --zonos2-prompt-wav を指定すると有効になります")
+        print("対応言語コード: en_us, en_gb, fr_fr, de, es, it, pt_br, ja, cmn, ko（tier 1-3 で計41言語）")
+        print("構成: 同梱の Mini-SGLang サーバ（uv run python -m zonos2）をバックエンドに起動し、")
+        print("      その /tts/generate（44.1kHz float32 PCM）を OpenAI 互換にプロキシします。")
+        print("注意: GPU は sm_80+ 必須（L4 / A100。flashinfer / sgl_kernel / cutlass カーネルのため T4 不可）。")
+        print("      初回は `uv sync`（GPU カーネルの取得）と重みダウンロードで起動に時間がかかります。")
+        print("ライセンス: コードは MIT（pyproject）、重みは Apache-2.0（HF モデルカード）。いずれも商用 OK。")
     elif settings.engine == "OuteTTS":
         print("OuteTTS は OuteAI の軽量多言語 TTS です（日本語含む多言語対応、voice cloning 対応）。")
         print(f"モデルサイズ: {settings.outetts_model_size} / backend: {settings.outetts_backend}")


### PR DESCRIPTION
## Summary

Adds **ZONOS2**, Zyphra's latest TTS, as a new engine. ZONOS2 uses a Mixture-of-Experts backbone that generates DAC tokens from NeMo-normalized UTF-8 bytes conditioned on an ECAPA-TDNN speaker embedding, trained on 6M+ hours of multilingual speech. It supports 41 languages across three tiers (tier-1: English, Mandarin Chinese, Japanese) with high-fidelity zero-shot voice cloning.

Unlike the in-process Zonos v0.1 engine already in this repo, ZONOS2 only ships a high-performance inference server built on [Mini-SGLang](https://github.com/sgl-project/mini-sglang). The integration therefore follows the dual-process proxy pattern (like Piper):

- The installer clones [Zyphra/Zonos2](https://github.com/Zyphra/Zonos2), runs `uv sync`, and launches `uv run python -m zonos2` as a backend on `--zonos2-backend-port` (default 5003).
- A thin OpenAI-compatible proxy forwards `/v1/audio/speech` to the backend's `/tts/generate` endpoint and wraps its raw 44.1 kHz float32 PCM stream into a PCM_16 WAV.

`voice` presets: `default` (a bundled reference voice — `default_voices/<--zonos2-default-ref>` — cloned cross-lingually so it can speak the configured language) and `clone` (`--zonos2-prompt-wav`). `--zonos2-accurate-mode` (default on) favors a closer voice match; off is more expressive.

## License

- **Code: MIT** (upstream `pyproject.toml`)
- **Weights: Apache-2.0** ([HF model card](https://huggingface.co/Zyphra/ZONOS2))

Both allow commercial use. (Code and weights licenses differ, so both are recorded in the README license table.)

## GPU requirement

Compute capability **sm_80+ required** (L4 / A100). The backbone depends on `flashinfer` / `sgl_kernel` / `cutlass` kernels, so T4 (sm_75) does not work.

## Colab verification

Verified on **Google Colab (NVIDIA L4, sm_89, 23 GB)**:

- `uv sync` builds the project env (torch 2.9.1, sgl-kernel 0.3.20, nvidia-cutlass-dsl 4.3.1, flashinfer, pynini 2.1.6, `zonos2==0.1.0`).
- Mini-SGLang backend loads ZONOS2 (bf16), auto-selects the **flashinfer** attention backend, allocates a 5.31 GiB KV cache, and captures CUDA graphs (~20.5 GB VRAM resident).
- Proxy serves `/`, `/v1/models`, `/v1/voices`, `/v1/audio/speech` (all 200 OK).
- **End-to-end over the trycloudflare public URL** (Japanese, `voice=default`): returns a valid 44.1 kHz mono PCM_16 WAV with ~4 s of real speech; backend reports `E2E≈17.3 s (incl. first-call JA normalizer compile), audio=4.67 s, RTF≈0.27x`.

Public URL exercised during verification: `https://postcard-too-dryer-occupational.trycloudflare.com/v1/audio/speech` (ephemeral trycloudflare tunnel).

## Changes

- `src/installers/zonos2.py`, `src/apps/zonos2_app.py`, registered in `src/installers/__init__.py`
- `src/config.py` (`zonos2_*` tunables + `zonos2_backend_port`), `colab/bootstrap.py` (CLI flags + passthrough), `src/launcher.py` (voice resolution + hints)
- `multi_tts_openai_colab.py` (form params + cmd args), synced embedded cells in `README.md` / `README.ja.md`
- README engine table / notes / license table / references (EN + JA)
- Regenerated `docs/engines.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)